### PR TITLE
fix(steep_bridge): collapse internal Logic types to bool in format_type

### DIFF
--- a/lib/rbs_infer/steep_bridge.rb
+++ b/lib/rbs_infer/steep_bridge.rb
@@ -582,6 +582,17 @@ module RbsInfer
     end
 
     def format_type(steep_type)
+      # `Steep::AST::Types::Logic::*` are internal types Steep uses for
+      # predicate-narrowing flow analysis (e.g., the body of
+      # `def x?; !@y.nil?; end` types as `Logic::Not`). They have no
+      # valid RBS surface form — `to_s` emits `<% Steep::AST::Types::Logic::Not %>`,
+      # which then leaks into generated RBS. Collapse all of them to
+      # `bool` since that's the user-visible meaning of any predicate
+      # return.
+      if defined?(Steep::AST::Types::Logic::Base) && steep_type.is_a?(Steep::AST::Types::Logic::Base)
+        return "bool"
+      end
+
       str = steep_type.to_s
 
       # Remove leading :: from all type names

--- a/lib/rbs_infer/steep_bridge.rb
+++ b/lib/rbs_infer/steep_bridge.rb
@@ -589,9 +589,7 @@ module RbsInfer
       # which then leaks into generated RBS. Collapse all of them to
       # `bool` since that's the user-visible meaning of any predicate
       # return.
-      if defined?(Steep::AST::Types::Logic::Base) && steep_type.is_a?(Steep::AST::Types::Logic::Base)
-        return "bool"
-      end
+      return "bool" if steep_type.is_a?(Steep::AST::Types::Logic::Base)
 
       str = steep_type.to_s
 

--- a/spec/lib/rbs_infer/steep_bridge_spec.rb
+++ b/spec/lib/rbs_infer/steep_bridge_spec.rb
@@ -176,6 +176,19 @@ RSpec.describe RbsInfer::SteepBridge, :dummy_app do
       expect(result["bar"]).to eq("bool")
     end
 
+    it "collapses Steep Logic types to bool (regression for Logic::Not leaking into RBS)" do
+      # `!@x.nil?` and similar predicate bodies type as
+      # `Steep::AST::Types::Logic::*` internally — unprintable types
+      # Steep uses for predicate flow narrowing. Without explicit
+      # handling, `to_s` emits `<% Steep::AST::Types::Logic::Not %>`
+      # which leaks into the generated RBS as a literal `Logic::Not`
+      # string. Verify the helper collapses each Logic type to `bool`.
+      expect(bridge.send(:format_type, Steep::AST::Types::Logic::Not.instance)).to eq("bool")
+      expect(bridge.send(:format_type, Steep::AST::Types::Logic::ReceiverIsNil.instance)).to eq("bool")
+      expect(bridge.send(:format_type, Steep::AST::Types::Logic::ReceiverIsArg.instance)).to eq("bool")
+      expect(bridge.send(:format_type, Steep::AST::Types::Logic::ArgIsReceiver.instance)).to eq("bool")
+    end
+
     it "resolves chained method return types" do
       code = <<~RUBY
         class Foo


### PR DESCRIPTION
## Bug

Predicate-style methods like `def confirmed?; !@name.nil?; end` were being inferred with a return type of `<% Steep::AST::Types::Logic::Not %>` — a debug-style string from Steep's internal Logic-type printer that leaks into the generated RBS.

Reproduced against `Concerts::Venue#confirmed?` in `order_factory`:

```rbs
# Before
def confirmed?: () -> <% Steep::AST::Types::Logic::Not %>
```

## Cause

`Steep::AST::Types::Logic::*` are internal types Steep uses for predicate-narrowing flow analysis. They show up as the body type of `!`, `.nil?`, `.is_a?`, `==`, etc. when used in a context where flow narrowing matters. `format_type` doesn't recognize them and falls through to `to_s`, which emits the unprintable `<% ... %>` form.

## Fix

Detect any `Steep::AST::Types::Logic::Base` subclass instance at the start of `format_type` and collapse to `\"bool\"`. That matches the user-visible semantic of every Logic-typed expression — they all yield true or false at runtime; the Logic shapes only matter inside Steep's flow-sensitive checker.

```rbs
# After
def confirmed?: () -> bool
```

## Test plan

- [x] Direct unit test in `steep_bridge_spec` asserting `Logic::Not`, `Logic::ReceiverIsNil`, `Logic::ReceiverIsArg`, `Logic::ArgIsReceiver` all collapse to `\"bool\"`.
- [x] Reproduced against real `order_factory` model — `Concerts::Venue#confirmed?` now generates correctly.
- [x] Full suite: 371 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)