### PR TITLE
fix(initialize): propagate nilability when keyword param defaults to nil

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -94,6 +94,17 @@ module RbsInfer
       end
     end
 
+    # Params com default literal `nil` aceitam nil mesmo se todos os
+    # callers atuais passam não-nil — o signature precisa refletir
+    # isso. Aplicado APÓS o enriquecimento pra não duplicar `?` em
+    # tipos que já vieram nilable do attr_types.
+    nil_default_param_names = extract_nil_default_param_names
+    nil_default_param_names.each do |param_name|
+      current = init_arg_types[param_name]
+      next if current.nil? || current == "untyped"
+      init_arg_types[param_name] = "#{current}?" unless current.end_with?("?")
+    end
+
     # Resolver return types de métodos que retornam attrs conhecidos
     type_merger.resolve_method_return_types_from_attrs(target_members, attr_types, method_type_resolver: method_type_resolver, parsed_target: @parsed_target)
 
@@ -264,6 +275,7 @@ module RbsInfer
 
     # Mapear defaults dos keyword params: param_name -> tipo do default
     default_types = visitor.keyword_defaults
+    nil_default_params = visitor.nil_default_params
 
     # Mapear self.attr = expr encontrados no initialize
     visitor.self_assignments.each do |attr_name, expr_info|
@@ -273,7 +285,15 @@ module RbsInfer
                param_name = expr_info[:name]
                call_site_type = init_arg_types[param_name]
                call_site_type = nil if call_site_type == "untyped"
-               call_site_type || default_types[param_name]
+               type = call_site_type || default_types[param_name]
+               # Se o param tem default literal `nil` (e.g.,
+               # `def initialize(name: nil); @name = name; end`), a
+               # ivar pode receber nil mesmo quando todos os callers
+               # passam não-nil. Refletir isso na declaração.
+               if type && nil_default_params.include?(param_name) && !type.end_with?("?")
+                 type = "#{type}?"
+               end
+               type
              when :param_method
                # self.x = param.method → resolver tipo do param, depois método
                param_name = expr_info[:param_name]
@@ -422,6 +442,18 @@ module RbsInfer
     params.requireds.each { |p| names << p.name.to_s if p.respond_to?(:name) } if params.respond_to?(:requireds)
     params.optionals.each { |p| names << p.name.to_s if p.respond_to?(:name) } if params.respond_to?(:optionals)
     names
+  end
+
+  # Returns the names of `initialize` keyword params whose default
+  # value is literal `nil` — used to widen the inferred type to its
+  # nilable form (`String` → `String?`) since the param can in fact
+  # receive nil even if every observed call site passes non-nil.
+  def extract_nil_default_param_names
+    return Set.new unless @parsed_target
+
+    visitor = InitializeBodyAnalyzer.new
+    @parsed_target.tree.accept(visitor)
+    visitor.nil_default_params
   end
 
   def method_type_resolver

--- a/lib/rbs_infer/initialize_body_analyzer.rb
+++ b/lib/rbs_infer/initialize_body_analyzer.rb
@@ -2,11 +2,17 @@ module RbsInfer
   class InitializeBodyAnalyzer < Prism::Visitor
     include NodeTypeInferrer
 
-    attr_reader :self_assignments, :keyword_defaults
+    attr_reader :self_assignments, :keyword_defaults, :nil_default_params
 
     def initialize
       @self_assignments = {}
       @keyword_defaults = {}
+      # Params com default literal `nil` (`def x(name: nil)`). Separados
+      # do `keyword_defaults` porque o tipo `nil` em si não é
+      # informativo pra inferência — mas a *presença* de um default nil
+      # significa que o tipo final do param/attr é nilable (`String?`
+      # em vez de `String`).
+      @nil_default_params = Set.new
       @param_names = []
       @in_initialize = false
     end
@@ -60,8 +66,13 @@ module RbsInfer
       params.keywords.each do |kw|
         next unless kw.is_a?(Prism::OptionalKeywordParameterNode)
         param_name = kw.name.to_s
-        default_type = infer_type_from_node(kw.value)
-        @keyword_defaults[param_name] = default_type if default_type
+
+        if kw.value.is_a?(Prism::NilNode)
+          @nil_default_params << param_name
+        else
+          default_type = infer_type_from_node(kw.value)
+          @keyword_defaults[param_name] = default_type if default_type
+        end
       end
     end
 

--- a/spec/lib/rbs_infer/initialize_body_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/initialize_body_analyzer_spec.rb
@@ -81,6 +81,40 @@ RSpec.describe RbsInfer::InitializeBodyAnalyzer do
     expect(visitor.keyword_defaults).not_to have_key("senha")
   end
 
+  it "registra params com default nil em nil_default_params (pra propagar nilabilidade)" do
+    # Param com default literal nil aceita nil em runtime mesmo se
+    # callers só passam não-nil. O attr/ivar correspondente precisa
+    # virar `T?` em vez de `T`. Trackear separadamente do
+    # `keyword_defaults` (que é só pra tipo do default).
+    source = <<~RUBY
+      class Foo
+        def initialize(nome: nil, idade: 0)
+          @nome = nome
+          @idade = idade
+        end
+      end
+    RUBY
+
+    visitor = analyze(source)
+    expect(visitor.nil_default_params).to include("nome")
+    expect(visitor.nil_default_params).not_to include("idade")  # default literal, não nil
+    expect(visitor.keyword_defaults["idade"]).to eq("Integer")
+    expect(visitor.keyword_defaults).not_to have_key("nome")
+  end
+
+  it "nil_default_params vazio quando initialize não tem keyword params" do
+    source = <<~RUBY
+      class Foo
+        def initialize(nome)
+          @nome = nome
+        end
+      end
+    RUBY
+
+    visitor = analyze(source)
+    expect(visitor.nil_default_params).to be_empty
+  end
+
   it "detecta self.attr = param.method como :param_method" do
     source = <<~RUBY
       class Matricular


### PR DESCRIPTION
## Bug

`def initialize(name: nil); @name = name; end` accepts `nil` at runtime via the default, but rbs_infer was emitting:

```rbs
attr_reader name: String
def initialize: (?name: String) -> void
```

Both lines miss the nil case. A caller doing `Foo.new` (no args) produces `@name = nil`, but Steep would believe `@name: String` — accepting `@name.upcase` and flagging `@name.nil?` checks as dead code.

Reproduced against `Concerts::Venue#name` in `order_factory`.

## Root cause

`InitializeBodyAnalyzer#infer_type_from_node` discarded `NilNode` entirely:

```ruby
return nil if node.is_a?(Prism::NilNode)
```

The intent was \"don't infer `nil` as the *type* of the default\" — but the side effect was also losing the signal that the param has a nil default, which downstream code needed to widen the type.

## Fix

Track params with literal-nil defaults in a separate `nil_default_params` Set on `InitializeBodyAnalyzer`. Two consumers use it:

1. **`infer_attr_types_from_initialize` (`:param` kind)**: if the attr's param is in the nil-default set, append `?` to the resolved type.
2. **`Analyzer#generate_rbs`** (init signature): after enriching `init_arg_types` from `attr_types`, widen each entry whose param has a nil default.

After fix:

```rbs
attr_reader name: String?
def initialize: (?name: String?) -> void
```

## Test plan

- [x] Two new cases in `initialize_body_analyzer_spec.rb` confirming `nil_default_params` is populated for literal-nil defaults only (not for `idade: 0`).
- [x] Manual verification against `Concerts::Venue#name` in order_factory.
- [x] Full suite: 373 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)