### PR TITLE
feat(markers): generate post-setter marker classes for cross-receiver narrowing

### DIFF
--- a/lib/rbs_infer.rb
+++ b/lib/rbs_infer.rb
@@ -25,5 +25,6 @@ module RbsInfer
 end
 
 require_relative "rbs_infer/analyzer"
+require_relative "rbs_infer/setter_marker_synthesizer"
 require_relative "rbs_infer/dependency_sorter"
 require_relative "rbs_infer/railtie" if defined?(Rails::Railtie)

--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -132,9 +132,60 @@ module RbsInfer
     # Identificar parâmetros opcionais do initialize
     optional_params = extract_optional_init_params
 
+    # Marker classes para cross-receiver narrowing (felixefelip/rbs_infer#11).
+    # Cada setter que escreve um ivar com tipo estritamente mais
+    # específico que o declarado vira uma marker nested class — Steep
+    # intersecta o receiver com ela após a chamada via
+    # `unconditional.self` no sidecar.
+    markers = synthesize_setter_markers(target_members, attr_types, ivar_types)
+
     namespace_classes = resolve_namespace_classes
     rbs_builder = RbsBuilder.new(target_class: @target_class, superclass_name: @superclass_name, namespace_classes: namespace_classes, is_module: @is_module)
-    rbs_builder.build(target_members, init_arg_types, attr_types, optional_params, method_param_types, ivar_types: ivar_types)
+    rbs_builder.build(target_members, init_arg_types, attr_types, optional_params, method_param_types, ivar_types: ivar_types, markers: markers)
+  end
+
+  # Builds the marker class list to inject into the generated RBS.
+  # The "declared" type for each ivar is the type the GENERATED RBS
+  # will actually expose to callers via `attr_reader`/`attr_accessor`
+  # — not Steep's internal wide view of all writes. If a setter's
+  # narrowed type already equals what callers see by default, the
+  # marker would be a no-op; only refinements add value.
+  #
+  # Mirrors `RbsBuilder`'s emit rule: if the member's signature
+  # carries an annotation (any non-`untyped` type), use it; otherwise
+  # fall back to `attr_types[name]` from the inference pipeline.
+  def synthesize_setter_markers(target_members, attr_types, _ivar_types)
+    return [] unless @parsed_target && @parsed_target.source
+
+    per_method = steep_bridge.ivar_write_types_per_method(@parsed_target.source)
+    return [] if per_method.empty?
+
+    declared_ivar_types = collect_declared_attr_types(target_members, attr_types)
+    SetterMarkerSynthesizer.synthesize(
+      members: target_members,
+      ivar_write_types_per_method: per_method,
+      declared_ivar_types: declared_ivar_types
+    )
+  end
+
+  def collect_declared_attr_types(target_members, attr_types)
+    result = {}
+    target_members.each do |m|
+      next unless [:attr_reader, :attr_accessor].include?(m.kind)
+      result[m.name] = emitted_attr_type_for(m, attr_types)
+    end
+    result
+  end
+
+  # Extracts the type the builder will actually emit for an attr
+  # member, mirroring `RbsBuilder#build`'s logic.
+  def emitted_attr_type_for(member, attr_types)
+    sig = member.signature
+    if sig.end_with?(": untyped") && attr_types[member.name]
+      attr_types[member.name]
+    else
+      sig.split(": ", 2)[1].to_s
+    end
   end
 
   def self.extract_constant_path(node)

--- a/lib/rbs_infer/rbs_builder.rb
+++ b/lib/rbs_infer/rbs_builder.rb
@@ -7,7 +7,7 @@ module RbsInfer
       @is_module = is_module
     end
 
-    def build(members, init_arg_types, attr_types, optional_params = Set.new, method_param_types = {}, ivar_types: {})
+    def build(members, init_arg_types, attr_types, optional_params = Set.new, method_param_types = {}, ivar_types: {}, markers: [])
       parts = @target_class.split("::")
       class_name = parts.pop
       modules = parts
@@ -98,6 +98,15 @@ module RbsInfer
         end
       end
 
+      # Marker classes para cross-receiver narrowing
+      # (felixefelip/rbs_infer#11). Cada um vira uma nested class
+      # `class AfterXxx ... end` com attr_reader overrides — Steep
+      # intersecta o receiver com ela após a chamada via
+      # `unconditional.self` no sidecar.
+      markers.each do |marker|
+        emit_marker(lines, marker, member_indent)
+      end
+
       lines << "#{base_indent}end"
       modules.each_with_index do |_, i|
         lines << "#{"  " * (modules.size - 1 - i)}end"
@@ -107,6 +116,16 @@ module RbsInfer
     end
 
     private
+
+    def emit_marker(lines, marker, member_indent)
+      override_indent = member_indent + "  "
+      lines << ""
+      lines << "#{member_indent}class #{marker.marker_name}"
+      marker.overrides.sort_by { |name, _| name }.each do |ivar_name, type_str|
+        lines << "#{override_indent}attr_reader #{ivar_name}: #{type_str}"
+      end
+      lines << "#{member_indent}end"
+    end
 
     # Qualifica nomes de tipo que seriam ambíguos no contexto do namespace gerado.
     # Ex: dentro de "class Account { module Storage { ... } }", um include "Storage::Totaled"

--- a/lib/rbs_infer/setter_marker_synthesizer.rb
+++ b/lib/rbs_infer/setter_marker_synthesizer.rb
@@ -1,0 +1,136 @@
+require "steep/postconditions/marker_naming"
+
+module RbsInfer
+  # Produces "marker" class declarations to attach to a generated RBS
+  # so that Steep's `unconditional.self` postcondition refinements have
+  # a real type to intersect with. See felixefelip/rbs_infer#11 and the
+  # companion `Steep::Postconditions::Inferrer` change which emits the
+  # matching `unconditional.self: "::Foo & ::Foo::AfterX"` sidecar.
+  #
+  # Without these markers, the sidecar references a class that doesn't
+  # exist in RBS and `apply_unconditional_postconditions` silently no-ops
+  # — the type checker sees no narrowing.
+  #
+  # Generation rule (V1, matching the issue spec):
+  #
+  #   For each method M of class C:
+  #     - Find ivars M assigns whose narrowed write type differs from
+  #       the declared (class-level) type — that's a refinement.
+  #     - For each such ivar, check that C has a reader for it
+  #       (`attr_reader` / `attr_accessor`). Without a reader the
+  #       marker would be unobservable; skip.
+  #     - Emit `class C::After<M_pascal> { attr_reader <ivar>: <narrowed> }`.
+  #
+  # Singletons are already filtered by `SteepBridge#ivar_write_types_per_method`
+  # (it skips `:defs` nodes), so the singleton case doesn't need
+  # explicit handling here.
+  class SetterMarkerSynthesizer
+    # Output: list of marker class declarations, sorted by marker name
+    # so the RBS output is deterministic across runs.
+    #
+    #   method_name  : "set_default_name"        (no `self.` prefix; singletons already filtered)
+    #   marker_name  : "AfterSetDefaultName"     (short form — used as a nested class inside parent)
+    #   overrides    : { "name" => "String" }    (ivar name without leading `@` → narrowed type str)
+    MarkerClass = Struct.new(:method_name, :marker_name, :overrides, keyword_init: true)
+
+    # @param members [Array<RbsInfer::Member>] members of the target class
+    # @param ivar_write_types_per_method [Hash{String=>Hash{String=>String}}]
+    #   from `SteepBridge#ivar_write_types_per_method` — method name →
+    #   ivar name (no `@`) → narrowed type string
+    # @param declared_ivar_types [Hash{String=>String}] declared (wide
+    #   union) ivar types, keyed by ivar name without `@`. Built by the
+    #   analyzer from `infer_ivar_types` + `attr_types`.
+    # @return [Array<MarkerClass>]
+    def self.synthesize(members:, ivar_write_types_per_method:, declared_ivar_types:)
+      new(
+        members: members,
+        ivar_write_types_per_method: ivar_write_types_per_method,
+        declared_ivar_types: declared_ivar_types
+      ).synthesize
+    end
+
+    def initialize(members:, ivar_write_types_per_method:, declared_ivar_types:)
+      @members = members
+      @ivar_write_types_per_method = ivar_write_types_per_method
+      @declared_ivar_types = declared_ivar_types
+    end
+
+    def synthesize
+      reader_ivars = collect_reader_ivars
+
+      markers = []
+      @ivar_write_types_per_method.each do |method_name, ivar_types|
+        overrides = filter_overrides(ivar_types, reader_ivars)
+        next if overrides.empty?
+
+        marker_name = marker_short_name_for(method_name)
+        next unless marker_name
+
+        markers << MarkerClass.new(
+          method_name: method_name,
+          marker_name: marker_name,
+          overrides: overrides
+        )
+      end
+      markers.sort_by(&:marker_name)
+    end
+
+    private
+
+    # Ivars that have an `attr_reader` or `attr_accessor` declared on
+    # the class. Manual `def name; @name; end` getters are out of scope
+    # for V1 — the test would have to distinguish "method that just
+    # reads the ivar" from "method that does other stuff", which is a
+    # larger commitment than the marker output warrants.
+    def collect_reader_ivars
+      @members
+        .select { |m| [:attr_reader, :attr_accessor].include?(m.kind) }
+        .map(&:name)
+        .to_set
+    end
+
+    def filter_overrides(ivar_types, reader_ivars)
+      overrides = {}
+      ivar_types.each do |ivar_name, narrowed_type|
+        next unless reader_ivars.include?(ivar_name)
+        declared = @declared_ivar_types[ivar_name]
+        next if declared.nil?
+        next if same_type?(declared, narrowed_type)
+        overrides[ivar_name] = narrowed_type
+      end
+      overrides
+    end
+
+    # Trivial string-equality after stripping outer parens. The
+    # narrowed-vs-declared comparison can't easily be "strict subtype"
+    # without re-parsing through RBS, but the inferrer upstream
+    # (`ivar_write_types_per_method`) only returns the writer's actual
+    # contribution — so "different from declared" is a safe proxy for
+    # "narrowing happened." Equal types mean no refinement; emitting a
+    # marker would be a no-op.
+    def same_type?(a, b)
+      normalize(a) == normalize(b)
+    end
+
+    # Whitespace-insensitive, parens-insensitive, and `T?`-as-`T|nil`
+    # normalization. The goal isn't a full type-equality check (that
+    # would require running through RBS::Parser); it's enough to keep
+    # cosmetic differences (`(String | nil)` vs `String?` vs
+    # `String | nil`) from masquerading as real narrowings.
+    def normalize(type_string)
+      s = type_string.to_s.gsub(/\s+/, "")
+      s = s.sub(/\A\((.*)\)\z/, '\1')
+      s = s.sub(/\?\z/, "|nil")
+      s
+    end
+
+    # Delegates to the shared convention. `pascal_case` is the
+    # snake_case → PascalCase part; we prepend "After" here to keep the
+    # full prefix-and-segment rule visible in one place. Returns nil
+    # for method names that strip to empty (e.g. `:"="`).
+    def marker_short_name_for(method_name)
+      return nil unless Steep::Postconditions::MarkerNaming.valid_method_name?(method_name)
+      "After#{Steep::Postconditions::MarkerNaming.pascal_case(method_name)}"
+    end
+  end
+end

--- a/lib/rbs_infer/steep_bridge.rb
+++ b/lib/rbs_infer/steep_bridge.rb
@@ -346,14 +346,23 @@ module RbsInfer
         # Singleton `def self.X` — class-instance variable scope, not
         # relevant for the per-action narrowing this method serves.
       when :ivasgn
-        if current_method
+        rhs = node.children[1]
+        if current_method && rhs
           var_name = node.children[0].to_s.sub(/\A@/, "")
-          ivasgn_type = typing.type_of(node: node) rescue nil
-          if ivasgn_type
-            result[current_method][var_name].add(format_type(ivasgn_type))
+          # Read the RHS type, not the `:ivasgn` node's type. When the
+          # ivar is already declared in RBS (e.g., `@name: String?`),
+          # Steep widens the assignment's typing to the declared type,
+          # which silently swallows narrowings the writer actually
+          # introduces (`@name = "TBA Venue"` would show up as
+          # `String?` instead of `String`). Steep's own
+          # `Postconditions::Inferrer` reads the RHS for the same
+          # reason; mirroring keeps the two narrow-detection paths
+          # consistent and unblocks marker synthesis in steady state.
+          rhs_type = typing.type_of(node: rhs) rescue nil
+          if rhs_type
+            result[current_method][var_name].add(format_type(rhs_type))
           end
         end
-        rhs = node.children[1]
         collect_ivar_writes_per_method(rhs, typing: typing,
                                        attr_writer_to_ivar: attr_writer_to_ivar,
                                        current_method: current_method,

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -2,7 +2,51 @@
 version: 1
 postconditions:
 - class: PostsController
+  method: create
+  unconditional:
+    ivars:
+      "@post": "::Post"
+    self: "::PostsController & ::PostsController::AfterCreate"
+- class: PostsController
+  method: index
+  unconditional:
+    ivars:
+      "@posts": "::Post::ActiveRecord_Relation"
+    self: "::PostsController & ::PostsController::AfterIndex"
+- class: PostsController
+  method: new
+  unconditional:
+    ivars:
+      "@post": "::Post"
+    self: "::PostsController & ::PostsController::AfterNew"
+- class: PostsController
   method: set_post
   unconditional:
     ivars:
       "@post": "(::Post & ::Post::Validated)"
+    self: "::PostsController & ::PostsController::AfterSetPost"
+- class: PostsController
+  method: show
+  unconditional:
+    ivars:
+      "@comments": "::Comment::ActiveRecord_Relation"
+    self: "::PostsController & ::PostsController::AfterShow"
+- class: Users::AvatarsController
+  method: set_user
+  unconditional:
+    ivars:
+      "@user": "(::User & ::User::Validated)"
+    self: "::Users::AvatarsController & ::Users::AvatarsController::AfterSetUser"
+- class: UsersController
+  method: index
+  unconditional:
+    ivars:
+      "@users": "::User::ActiveRecord_Relation"
+    self: "::UsersController & ::UsersController::AfterIndex"
+- class: UsersController
+  method: show
+  unconditional:
+    ivars:
+      "@posts": "::Post::ActiveRecord_Associations_CollectionProxy"
+      "@user": "(::User & ::User::Validated)"
+    self: "::UsersController & ::UsersController::AfterShow"

--- a/spec/lib/rbs_infer/analyzer_spec.rb
+++ b/spec/lib/rbs_infer/analyzer_spec.rb
@@ -885,6 +885,73 @@ RSpec.describe RbsInfer::Analyzer do
         expect { RBS::Parser.parse_signature(rbs) }.not_to raise_error
       end
     end
+
+    # ─── Setter marker classes (felixefelip/rbs_infer#11) ──────────
+
+    context "setter marker classes" do
+      it "gera marker nested class para setter que narrow attr_accessor" do
+        # `attr_accessor :name #: String?` declara explicitamente o
+        # tipo wide do ivar. set_default_name escreve "TBA Venue"
+        # (String, strict subtype de String?) → marker
+        # AfterSetDefaultName. clear_name escreve nil (também strict
+        # subtype) → marker AfterClearName com override pra nil.
+        files = {
+          "venue.rb" => <<~RUBY
+            class Venue
+              attr_accessor :name #: String?
+
+              def initialize(name: nil)
+                @name = name
+              end
+
+              def set_default_name
+                @name = "TBA Venue"
+              end
+
+              def clear_name
+                @name = nil
+              end
+            end
+          RUBY
+        }
+
+        with_temp_files(files) do |_dir, paths|
+          analyzer = described_class.new(target_file: paths.first, source_files: paths)
+          rbs = analyzer.generate_rbs
+
+          aggregate_failures do
+            expect(rbs).to include("class AfterSetDefaultName")
+            expect(rbs).to include("attr_reader name: String")
+            expect(rbs).to include("class AfterClearName")
+            expect(rbs).to include("attr_reader name: nil")
+            expect { RBS::Parser.parse_signature(rbs) }.not_to raise_error
+          end
+        end
+      end
+
+      it "não gera marker para classe sem attr_reader observável" do
+        files = {
+          "isolated.rb" => <<~RUBY
+            class Isolated
+              def initialize(name: nil)
+                @name = name
+              end
+
+              def set_default_name
+                @name = "TBA"
+              end
+            end
+          RUBY
+        }
+
+        with_temp_files(files) do |_dir, paths|
+          analyzer = described_class.new(target_file: paths.first, source_files: paths)
+          rbs = analyzer.generate_rbs
+
+          expect(rbs).not_to include("class After")
+        end
+      end
+    end
   end
 
   # ─── Integração com arquivos reais do projeto ───────────────────

--- a/spec/lib/rbs_infer/setter_marker_synthesizer_spec.rb
+++ b/spec/lib/rbs_infer/setter_marker_synthesizer_spec.rb
@@ -1,0 +1,166 @@
+require "spec_helper"
+require "rbs_infer"
+
+# Unit specs for the `SetterMarkerSynthesizer`. Pinned in isolation so
+# the marker-generation rules (matches attr_reader, skips no-narrow
+# methods, etc.) are independent of the Steep bridge's per-method
+# write detection — that piece is covered by `steep_bridge_spec`.
+RSpec.describe RbsInfer::SetterMarkerSynthesizer do
+  Member = RbsInfer::Member
+
+  def member(kind:, name:)
+    Member.new(kind: kind, name: name, signature: "#{name}: untyped", visibility: :public)
+  end
+
+  def synthesize(members:, per_method:, declared:)
+    described_class.synthesize(
+      members: members,
+      ivar_write_types_per_method: per_method,
+      declared_ivar_types: declared
+    )
+  end
+
+  it "emits a marker for a setter that narrows an attr_reader ivar" do
+    markers = synthesize(
+      members: [member(kind: :attr_reader, name: "name")],
+      per_method: { "set_default_name" => { "name" => "String" } },
+      declared: { "name" => "String?" }
+    )
+
+    expect(markers.size).to eq(1)
+    expect(markers.first.marker_name).to eq("AfterSetDefaultName")
+    expect(markers.first.method_name).to eq("set_default_name")
+    expect(markers.first.overrides).to eq({ "name" => "String" })
+  end
+
+  it "emits a marker for a setter that narrows to nil (clear-style method)" do
+    markers = synthesize(
+      members: [member(kind: :attr_accessor, name: "name")],
+      per_method: { "clear_name" => { "name" => "nil" } },
+      declared: { "name" => "String?" }
+    )
+
+    expect(markers.size).to eq(1)
+    expect(markers.first.marker_name).to eq("AfterClearName")
+    expect(markers.first.overrides).to eq({ "name" => "nil" })
+  end
+
+  it "emits multi-ivar overrides when a setter writes more than one ivar" do
+    markers = synthesize(
+      members: [
+        member(kind: :attr_reader, name: "x"),
+        member(kind: :attr_reader, name: "y")
+      ],
+      per_method: { "setup" => { "x" => "Integer", "y" => "String" } },
+      declared: { "x" => "Integer?", "y" => "String?" }
+    )
+
+    expect(markers.size).to eq(1)
+    expect(markers.first.marker_name).to eq("AfterSetup")
+    expect(markers.first.overrides).to eq({ "x" => "Integer", "y" => "String" })
+  end
+
+  it "skips ivars without a corresponding attr_reader/attr_accessor" do
+    # The class has no reader for `internal_state`, so even though it's
+    # narrowed, the marker would be unobservable — refining a type
+    # that no public API exposes is just noise.
+    markers = synthesize(
+      members: [],
+      per_method: { "compute" => { "internal_state" => "Integer" } },
+      declared: { "internal_state" => "Integer?" }
+    )
+
+    expect(markers).to be_empty
+  end
+
+  it "accepts attr_writer-only ivars as readable (marker still observable via the writer in callers? no — skip)" do
+    # `attr_writer :name` does NOT generate a reader. Marker's
+    # `attr_reader name: T` override has nothing to refine. Skip.
+    markers = synthesize(
+      members: [member(kind: :attr_writer, name: "name")],
+      per_method: { "set_default_name" => { "name" => "String" } },
+      declared: { "name" => "String?" }
+    )
+
+    expect(markers).to be_empty
+  end
+
+  it "skips ivars whose narrowed type equals the declared type" do
+    # Setter writes the same type that was already declared — emitting
+    # `attr_reader name: String` would be a no-op (the original
+    # `attr_reader name: String` is identical). Avoid clutter.
+    markers = synthesize(
+      members: [member(kind: :attr_reader, name: "name")],
+      per_method: { "set_name" => { "name" => "String" } },
+      declared: { "name" => "String" }
+    )
+
+    expect(markers).to be_empty
+  end
+
+  it "treats parenthesized declared types as equal to the narrowed form" do
+    # `(String | Integer)` vs `String | Integer` mean the same thing.
+    # The synthesizer's `same_type?` strips outer parens before
+    # comparing so a redundant intersection doesn't sneak in.
+    markers = synthesize(
+      members: [member(kind: :attr_reader, name: "value")],
+      per_method: { "set_value" => { "value" => "String | Integer" } },
+      declared: { "value" => "(String | Integer)" }
+    )
+
+    expect(markers).to be_empty
+  end
+
+  it "skips an ivar that's not declared at all (defensive)" do
+    # Synthesizer shouldn't crash if Steep observes a write to an ivar
+    # the class never declares. Just skip it.
+    markers = synthesize(
+      members: [member(kind: :attr_reader, name: "name")],
+      per_method: { "set_x" => { "x" => "String" } },
+      declared: {}
+    )
+
+    expect(markers).to be_empty
+  end
+
+  it "sorts markers by marker_name for deterministic RBS output" do
+    markers = synthesize(
+      members: [member(kind: :attr_reader, name: "name")],
+      per_method: {
+        "z_finalize"    => { "name" => "String" },
+        "a_initialize"  => { "name" => "Integer" }
+      },
+      declared: { "name" => "untyped" }
+    )
+
+    expect(markers.map(&:marker_name)).to eq(["AfterAInitialize", "AfterZFinalize"])
+  end
+
+  it "skips methods whose marker name would strip to empty" do
+    # `:"="` reduces to "" under pascal_case — no usable marker.
+    markers = synthesize(
+      members: [member(kind: :attr_reader, name: "x")],
+      per_method: { "=" => { "x" => "Integer" } },
+      declared: { "x" => "untyped" }
+    )
+
+    expect(markers).to be_empty
+  end
+
+  it "agrees with Steep::Postconditions::MarkerNaming.pascal_case verbatim" do
+    # The whole point of MarkerNaming is single-source-of-truth: if
+    # rbs_infer drifts from Steep, the postcondition's `unconditional.self`
+    # references a class that doesn't exist in RBS. This spec pins
+    # the contract.
+    require "steep/postconditions/marker_naming"
+
+    markers = synthesize(
+      members: [member(kind: :attr_reader, name: "name")],
+      per_method: { "mark_as_complete" => { "name" => "String" } },
+      declared: { "name" => "String?" }
+    )
+
+    short = "After#{Steep::Postconditions::MarkerNaming.pascal_case("mark_as_complete")}"
+    expect(markers.first.marker_name).to eq(short)
+  end
+end

--- a/spec/lib/rbs_infer/steep_bridge_spec.rb
+++ b/spec/lib/rbs_infer/steep_bridge_spec.rb
@@ -641,6 +641,36 @@ RSpec.describe RbsInfer::SteepBridge, :dummy_app do
       # narrowing we serve.
       expect(result).to eq({})
     end
+
+    it "reads RHS type rather than the :ivasgn type so LHS-widening doesn't mask narrowings" do
+      # When the ivar is declared via attr_accessor with a nilable
+      # type, Steep widens the :ivasgn node's type to the declared
+      # type. Reading the RHS directly preserves the writer's actual
+      # contribution — matching what Steep's own
+      # `Postconditions::Inferrer` does and unblocking marker
+      # synthesis in steady state.
+      code = <<~RUBY
+        class Foo
+          attr_accessor :name #: String?
+
+          def initialize(name: nil)
+            @name = name
+          end
+
+          def clear_name
+            @name = nil
+          end
+        end
+      RUBY
+
+      result = bridge.ivar_write_types_per_method(code)
+
+      # `nil` literal isn't context-widened (it's already the bottom
+      # of the union), so this test catches LHS-widening regressions
+      # specifically: if the code reverts to reading `:ivasgn` type,
+      # the result here would be `String?` instead of `nil`.
+      expect(result["clear_name"]["name"]).to eq("nil")
+    end
   end
 
   describe "#all_expression_types" do


### PR DESCRIPTION
Closes #11.

Producer side of the cross-receiver narrowing pipeline. Setters that narrow an ivar's type (e.g. `set_default_name` writing `@name = "TBA"` over a declared `String?`) now emit a nested marker class with `attr_reader` overrides — `class AfterSetDefaultName ... attr_reader name: String; end`. Steep's `unconditional.self` postcondition (felixefelip/steep#33) references this marker via the intersection `Venue & Venue::AfterSetDefaultName`, narrowing callers' view of `venue.name` from `String?` to `String` after the call.

With both sides in place the order_factory `TicketMounter#mount_ticket_event(venue)` typechecks end-to-end without manual annotations.

## What changed

- **`SetterMarkerSynthesizer`** — takes the per-method ivar writes surfaced by `SteepBridge#ivar_write_types_per_method`, intersects with the class's `attr_reader`/`attr_accessor` set, and emits one marker per (method, narrowing) pair. Skips ivars without a reader (unobservable), narrowings that match the declared type, and method names that strip to empty under `pascal_case` (e.g. `:"="`).
- **`Analyzer#synthesize_setter_markers`** — pipeline step after `infer_ivar_types`. Builds the declared-type lookup by mirroring `RbsBuilder`'s emit rule (signature override vs. `attr_types` fallback) so markers compare against the type callers actually see.
- **`RbsBuilder`** — accepts `markers:` keyword and emits each as a nested class with sorted overrides.
- **Naming convention** reuses `Steep::Postconditions::MarkerNaming.pascal_case` verbatim — single source of truth for the snake_case → PascalCase rule keeps rbs_infer's output in sync with whatever Steep emits in the sidecar's `unconditional.self` slot.

## Generated example

\`\`\`rbs
class Venue
  attr_accessor name: String?
  def initialize: (?name: String?) -> void
  def set_default_name: () -> String
  def clear_name: () -> nil

  class AfterSetDefaultName
    attr_reader name: String
  end

  class AfterClearName
    attr_reader name: nil
  end
end
\`\`\`

## Test plan

- [x] 11 unit specs pinning every synthesizer rule (attr_reader gate, declared-equality skip, paren/`?` normalization, deterministic sort, MarkerNaming agreement).
- [x] 2 integration specs through the full Analyzer pipeline (Venue-style narrowing + no-reader negative case).
- [x] Dummy app fixture (`spec/dummy/sig/generated/.steep_postconditions.yml`) regenerated to reflect the matching `self:` slot emission from Steep's `Postconditions::Inferrer`.
- [x] Full suite: 386 examples, 0 failures (was 385 / 1 before; the regression was paren/`?` normalization and is fixed).

## Out of scope

- Marker generation for inter-procedural setters (method calls another method that mutates) — requires call-graph analysis.
- Marker generation for manual getter methods (`def name; @name; end`) — V1 only handles `attr_reader`/`attr_accessor`.
- Marker generation for singleton methods (`def self.x`) — already filtered by `SteepBridge#ivar_write_types_per_method`.

## Related

- felixefelip/steep#33 — Steep `unconditional.self` consumer + `MarkerNaming` module. **Open**.
- felixefelip/steep#31 (closed by #33) — cross-receiver narrowing semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)