### PR TITLE
fix(steep_bridge): use literal's intrinsic type for ivar narrowing detection

### DIFF
--- a/lib/rbs_infer/steep_bridge.rb
+++ b/lib/rbs_infer/steep_bridge.rb
@@ -198,8 +198,12 @@ module RbsInfer
       typing.each_typing do |node, type|
         case node.type
         when :ivasgn
+          rhs = node.children[1]
+          next unless rhs
+          rhs_type = intrinsic_type_of(rhs, typing)
+          next unless rhs_type
           var_name = node.children[0].to_s.sub(/\A@/, "")
-          type_sets[var_name].add(format_type(type))
+          type_sets[var_name].add(format_type(rhs_type))
         when :send
           receiver, method_name, *args = node.children
           next unless attr_writer_to_ivar.key?(method_name)
@@ -207,7 +211,7 @@ module RbsInfer
           next if args.empty?
 
           arg = args[0]
-          arg_type = typing.type_of(node: arg) rescue nil
+          arg_type = intrinsic_type_of(arg, typing)
           next unless arg_type
 
           ivar = attr_writer_to_ivar.fetch(method_name)
@@ -349,16 +353,17 @@ module RbsInfer
         rhs = node.children[1]
         if current_method && rhs
           var_name = node.children[0].to_s.sub(/\A@/, "")
-          # Read the RHS type, not the `:ivasgn` node's type. When the
-          # ivar is already declared in RBS (e.g., `@name: String?`),
-          # Steep widens the assignment's typing to the declared type,
-          # which silently swallows narrowings the writer actually
-          # introduces (`@name = "TBA Venue"` would show up as
-          # `String?` instead of `String`). Steep's own
-          # `Postconditions::Inferrer` reads the RHS for the same
-          # reason; mirroring keeps the two narrow-detection paths
-          # consistent and unblocks marker synthesis in steady state.
-          rhs_type = typing.type_of(node: rhs) rescue nil
+          # Use the RHS's INTRINSIC type, not what `typing` recorded.
+          # When the ivar is already declared in RBS (e.g.,
+          # `@name: String?`), Steep's `:ivasgn` synthesize widens
+          # the literal's typing via hint propagation — `@name = "TBA"`
+          # shows up as `String?` instead of `String`, silently
+          # swallowing the narrowing the writer actually introduces.
+          # `intrinsic_type_of` re-computes the type from the literal
+          # node shape, matching `synthesize(node, hint: nil)`.
+          # Mirrors the same fix in Steep's
+          # `Postconditions::Inferrer` (felixefelip/steep#35).
+          rhs_type = intrinsic_type_of(rhs, typing)
           if rhs_type
             result[current_method][var_name].add(format_type(rhs_type))
           end
@@ -373,7 +378,7 @@ module RbsInfer
            (receiver.nil? || (receiver.respond_to?(:type) && receiver.type == :self)) &&
            !args.empty?
           arg = args[0]
-          arg_type = typing.type_of(node: arg) rescue nil
+          arg_type = intrinsic_type_of(arg, typing)
           if arg_type
             ivar = attr_writer_to_ivar.fetch(method_name)
             result[current_method][ivar].add(format_type(arg_type))
@@ -588,6 +593,47 @@ module RbsInfer
       interface_builder = Steep::Interface::Builder.new(factory, implicitly_returns_nil: false)
       @subtyping = Steep::Subtyping::Check.new(builder: interface_builder)
       @constant_resolver = RBS::Resolver::ConstantResolver.new(builder: definition_builder)
+    end
+
+    # Returns the intrinsic (hint-free) type of a node. For literal AST
+    # nodes Steep's `:ivasgn` synthesize widens the recorded type to
+    # match the LHS declared type via hint propagation — so a
+    # `@name = "TBA"` against `@name: String?` ends up with the str
+    # node typed as `String?` in `typing`. The widening is intentional
+    # for collections (`@x: Array[Numeric] = [1, 2, 3]` needs hint to
+    # type-check), but for narrowing-detection it silently swallows
+    # the writer's actual contribution.
+    #
+    # For literal nodes we compute the type directly from the node
+    # shape, mirroring `synthesize(node, hint: nil)`. Non-literal RHS
+    # nodes (sends, lvars, dstrs without interpolation, arrays, hashes)
+    # fall back to `typing.type_of` — those rarely suffer the widening
+    # since the hint mostly affects literal value-class lookups.
+    #
+    # Same pattern as `Steep::Postconditions::Inferrer#intrinsic_type_of`
+    # (felixefelip/steep#35). Both call sites need to bypass the same
+    # widening for the cross-receiver narrowing pipeline to fire.
+    def intrinsic_type_of(node, typing)
+      case node.type
+      when :nil
+        Steep::AST::Builtin.nil_type
+      when :str, :dstr
+        Steep::AST::Builtin::String.instance_type
+      when :int
+        Steep::AST::Builtin::Integer.instance_type
+      when :float
+        Steep::AST::Builtin::Float.instance_type
+      when :sym, :dsym
+        Steep::AST::Builtin::Symbol.instance_type
+      when :true
+        Steep::AST::Types::Literal.new(value: true)
+      when :false
+        Steep::AST::Types::Literal.new(value: false)
+      when :regexp
+        Steep::AST::Builtin::Regexp.instance_type
+      else
+        typing.type_of(node: node) rescue nil
+      end
     end
 
     def format_type(steep_type)

--- a/spec/lib/rbs_infer/steep_bridge_spec.rb
+++ b/spec/lib/rbs_infer/steep_bridge_spec.rb
@@ -671,6 +671,37 @@ RSpec.describe RbsInfer::SteepBridge, :dummy_app do
       # the result here would be `String?` instead of `nil`.
       expect(result["clear_name"]["name"]).to eq("nil")
     end
+
+    it "uses literal's intrinsic type when ivar is declared nilable in RBS" do
+      # Even reading the RHS still gives the WIDENED type because
+      # Steep's `:ivasgn` synthesize passes the LHS declared type as
+      # `hint:` to RHS synthesize, and `test_literal_type` returns the
+      # hint when the literal is compatible. `intrinsic_type_of`
+      # bypasses hint propagation for literal nodes (mirrors the same
+      # fix in Steep's `Postconditions::Inferrer`,
+      # felixefelip/steep#35).
+      #
+      # Without the fix, `@name = "TBA"` against declared `String?`
+      # types as `String?` — narrowing detection misses it and the
+      # SetterMarkerSynthesizer never emits `AfterSetDefaultName`.
+      code = <<~RUBY
+        class Foo
+          attr_accessor :name #: String?
+
+          def initialize(name: nil)
+            @name = name
+          end
+
+          def set_default_name
+            @name = "TBA"
+          end
+        end
+      RUBY
+
+      result = bridge.ivar_write_types_per_method(code)
+
+      expect(result["set_default_name"]["name"]).to eq("String")
+    end
   end
 
   describe "#all_expression_types" do


### PR DESCRIPTION
Same widening that broke Steep's `Postconditions::Inferrer` (felixefelip/steep#34, fixed in felixefelip/steep#35) also broke rbs_infer's `SetterMarkerSynthesizer`: when the target class has prior RBS with a nilable ivar declaration, Steep's `:ivasgn` synthesize widens the RHS literal's recorded type via hint propagation.

\`\`\`ruby
attr_accessor :name #: String?

def set_default_name
  @name = "TBA"           # str node types as String?, not String
end
\`\`\`

The synthesizer compares declared vs narrowed; both come out `String?`, no narrowing detected, no `AfterSetDefaultName` marker emitted, and the sidecar's `unconditional.self` for the same method references a class that doesn't exist in RBS.

## What changed

`intrinsic_type_of(node, typing)` mirrors the Steep-side fix: for literal AST nodes (`:str`, `:int`, `:sym`, `:nil`, `:true`/`:false`, `:float`, `:regexp`, `:dstr`, `:dsym`) compute the type directly from the node shape (`AST::Builtin::String.instance_type` for `:str`, etc.) — matching what `synthesize(node, hint: nil)` would return. Non-literal RHS falls back to `typing.type_of`.

Applied to both `ivar_write_types` and `ivar_write_types_per_method`, covering both the direct `:ivasgn` case (`@x = "TBA"`) and the attr_writer-style call (`self.x = "TBA"`).

## Why two repos need the same fix

Steep's `Postconditions::Inferrer` and rbs_infer's `SteepBridge` are independent narrowing-detection paths:

- **Steep Inferrer** writes the sidecar's `unconditional.ivars` / `unconditional.self` entries.
- **rbs_infer SteepBridge** feeds `SetterMarkerSynthesizer` which emits the marker class definitions in RBS.

Both need to bypass the same hint-widening or the cross-receiver narrowing pipeline closes only for `nil` literal cases (the one literal type that isn't context-widened).

## Test plan

- [x] New spec `uses literal's intrinsic type when ivar is declared nilable in RBS` — pins the actual bug.
- [x] Existing `reads RHS type rather than the :ivasgn type` spec — still passes (still relevant for non-literal RHS).
- [x] Full rbs_infer suite: 388 examples, 0 failures.
- [x] End-to-end verified in order_factory: `Concerts::Venue.rbs` now emits both `class AfterClearName { attr_reader name: nil }` AND `class AfterSetDefaultName { attr_reader name: String }`.

## Related

- felixefelip/steep#35 — matching fix on the Steep side. **Open**.
- felixefelip/rbs_infer#11 — original marker synthesis work that this unblocks for the literal-narrowing case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)