### PR TITLE
feat(markers): generate marker classes for predicate (when_true) narrowings

### DIFF
--- a/lib/rbs_infer.rb
+++ b/lib/rbs_infer.rb
@@ -26,5 +26,6 @@ end
 
 require_relative "rbs_infer/analyzer"
 require_relative "rbs_infer/setter_marker_synthesizer"
+require_relative "rbs_infer/predicate_marker_synthesizer"
 require_relative "rbs_infer/dependency_sorter"
 require_relative "rbs_infer/railtie" if defined?(Rails::Railtie)

--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -137,7 +137,7 @@ module RbsInfer
     # específico que o declarado vira uma marker nested class — Steep
     # intersecta o receiver com ela após a chamada via
     # `unconditional.self` no sidecar.
-    markers = synthesize_setter_markers(target_members, attr_types, ivar_types)
+    markers = synthesize_markers(target_members, attr_types, ivar_types)
 
     namespace_classes = resolve_namespace_classes
     rbs_builder = RbsBuilder.new(target_class: @target_class, superclass_name: @superclass_name, namespace_classes: namespace_classes, is_module: @is_module)
@@ -154,9 +154,16 @@ module RbsInfer
   # Mirrors `RbsBuilder`'s emit rule: if the member's signature
   # carries an annotation (any non-`untyped` type), use it; otherwise
   # fall back to `attr_types[name]` from the inference pipeline.
-  def synthesize_setter_markers(target_members, attr_types, _ivar_types)
+  def synthesize_markers(target_members, attr_types, _ivar_types)
     return [] unless @parsed_target && @parsed_target.source
 
+    setter_markers = synthesize_setter_markers(target_members, attr_types)
+    predicate_markers = synthesize_predicate_markers(target_members)
+
+    merge_markers(setter_markers + predicate_markers)
+  end
+
+  def synthesize_setter_markers(target_members, attr_types)
     per_method = steep_bridge.ivar_write_types_per_method(@parsed_target.source)
     return [] if per_method.empty?
 
@@ -166,6 +173,39 @@ module RbsInfer
       ivar_write_types_per_method: per_method,
       declared_ivar_types: declared_ivar_types
     )
+  end
+
+  # Reads Steep's `Postconditions::Inferrer` output directly — the
+  # source-of-truth for "this predicate narrows these ivars". Keeps
+  # rbs_infer's predicate-marker generation in lockstep with Steep's
+  # `LogicTypeInterpreter`-driven detection.
+  def synthesize_predicate_markers(target_members)
+    entries = steep_bridge.postcondition_inferred_entries(@parsed_target.source)
+    return [] if entries.empty?
+
+    PredicateMarkerSynthesizer.synthesize(
+      inferred_entries: entries,
+      target_class: @target_class,
+      members: target_members
+    )
+  end
+
+  # Merge markers from multiple synthesizers, deduplicating by
+  # marker_name. If two synthesizers produce the same marker name
+  # (a method that's both a setter and a predicate — pathological
+  # but possible with `name=` / `name?` collisions stripping to the
+  # same pascal), unions the overrides preserving the first emitter.
+  def merge_markers(markers)
+    by_name = {}
+    markers.each do |marker|
+      existing = by_name[marker.marker_name]
+      if existing
+        existing.overrides.merge!(marker.overrides) { |_key, old, _new| old }
+      else
+        by_name[marker.marker_name] = marker
+      end
+    end
+    by_name.values.sort_by(&:marker_name)
   end
 
   def collect_declared_attr_types(target_members, attr_types)

--- a/lib/rbs_infer/predicate_marker_synthesizer.rb
+++ b/lib/rbs_infer/predicate_marker_synthesizer.rb
@@ -1,0 +1,106 @@
+module RbsInfer
+  # Generates marker class declarations for predicate-narrowing
+  # methods (`def confirmed?; !@name.nil?; end`) by reading Steep's
+  # `Postconditions::Inferrer` output directly. The inferrer is
+  # authoritative for "what does this method narrow?" — using its
+  # `InferredEntry` records keeps marker emission aligned with
+  # whatever shapes Steep's `LogicTypeInterpreter` recognizes today
+  # or in the future.
+  #
+  # Symmetric to `SetterMarkerSynthesizer` (which handles
+  # `unconditional.ivars` narrowings — setters that assign literals
+  # to ivars). This one handles `when_true.ivars` — predicates whose
+  # truthy branch narrows ivars to a non-nil residual. Both produce
+  # `MarkerClass` structs with the same shape, and the analyzer
+  # merges their outputs into a single set of nested classes.
+  class PredicateMarkerSynthesizer
+    # Reuses `SetterMarkerSynthesizer::MarkerClass` so the analyzer
+    # and `RbsBuilder` consume one shape regardless of origin.
+    MarkerClass = SetterMarkerSynthesizer::MarkerClass
+
+    # @param inferred_entries [Array<Steep::Postconditions::InferredEntry>]
+    #   The entries `Steep::Postconditions::Inferrer.infer(...)` returned
+    #   for the source under analysis.
+    # @param target_class [String] only entries matching this class
+    #   contribute markers — the analyzer scopes synthesis per file.
+    # @param members [Array<RbsInfer::Member>] used to confirm a
+    #   reader exists for each narrowed ivar (an
+    #   `attr_reader`/`attr_accessor`); without one the marker would
+    #   be unobservable.
+    # @return [Array<MarkerClass>]
+    def self.synthesize(inferred_entries:, target_class:, members:)
+      new(inferred_entries: inferred_entries, target_class: target_class, members: members).synthesize
+    end
+
+    def initialize(inferred_entries:, target_class:, members:)
+      @inferred_entries = inferred_entries
+      @target_class = normalize_class_name(target_class)
+      @members = members
+    end
+
+    def synthesize
+      reader_ivars = collect_reader_ivars
+
+      markers = []
+      @inferred_entries.each do |entry|
+        next unless normalize_class_name(entry.class_name) == @target_class
+        next if entry.singleton
+        next if entry.when_true_ivars.nil? || entry.when_true_ivars.empty?
+
+        overrides = filter_observable_overrides(entry.when_true_ivars, reader_ivars)
+        next if overrides.empty?
+
+        marker_name = marker_short_name_for(entry.method_name)
+        next unless marker_name
+
+        markers << MarkerClass.new(
+          method_name: entry.method_name.to_s,
+          marker_name: marker_name,
+          overrides: overrides
+        )
+      end
+      markers.sort_by(&:marker_name)
+    end
+
+    private
+
+    def collect_reader_ivars
+      @members
+        .select { |m| [:attr_reader, :attr_accessor].include?(m.kind) }
+        .map(&:name)
+        .to_set
+    end
+
+    # Keep only ivar refinements whose name matches a public reader
+    # on the class. A predicate that narrows `@internal_state` to
+    # non-nil is correct, but without `attr_reader :internal_state`
+    # there's no exposed path for callers to observe the refinement
+    # — the marker would be sidecar/RBS noise.
+    def filter_observable_overrides(when_true_ivars, reader_ivars)
+      overrides = {}
+      when_true_ivars.each do |ivar_sym, refined_type|
+        ivar_name = ivar_sym.to_s.sub(/\A@/, "")
+        next unless reader_ivars.include?(ivar_name)
+        overrides[ivar_name] = format_type(refined_type)
+      end
+      overrides
+    end
+
+    # The `InferredEntry` carries `Steep::AST::Types::t` instances; we
+    # need RBS-printable strings for the `attr_reader x: Type` line.
+    # `Steep::AST::Types::*#to_s` already produces RBS-compatible
+    # output (with leading `::`); use it directly.
+    def format_type(type)
+      type.to_s
+    end
+
+    def marker_short_name_for(method_name)
+      return nil unless Steep::Postconditions::MarkerNaming.valid_method_name?(method_name)
+      "After#{Steep::Postconditions::MarkerNaming.pascal_case(method_name)}"
+    end
+
+    def normalize_class_name(name)
+      name.to_s.sub(/\A::/, "")
+    end
+  end
+end

--- a/lib/rbs_infer/steep_bridge.rb
+++ b/lib/rbs_infer/steep_bridge.rb
@@ -279,6 +279,28 @@ module RbsInfer
       result
     end
 
+    # Runs Steep's `Postconditions::Inferrer` against the source and
+    # returns the resulting `InferredEntry` array. These describe what
+    # ivars each method narrows (unconditional for setters, when_true
+    # for predicates) and which marker class names the inferrer would
+    # reference in the sidecar — exactly the info rbs_infer needs to
+    # generate the matching marker class declarations in RBS.
+    #
+    # Using Steep's inferrer (instead of re-implementing detection on
+    # the rbs_infer side) keeps the two emitters semantically aligned
+    # for free: whenever Steep learns a new predicate shape, rbs_infer
+    # picks it up without code change.
+    def postcondition_inferred_entries(source_code)
+      typing = type_check(source_code)
+      return [] unless typing
+      return [] unless @subtyping
+
+      Steep::Postconditions::Inferrer.infer(typing.source, typing, @subtyping)
+    rescue StandardError => e
+      Steep.logger.warn { "[rbs_infer] postcondition inferrer failed: #{e.message}" } if defined?(Steep.logger)
+      []
+    end
+
     # Returns Set[String] of ivar names (without leading `@`) that are
     # assigned inside `def initialize` of any class in the source, or at
     # class-body scope. Used by the definite-initialization rule to

--- a/spec/lib/rbs_infer/predicate_marker_synthesizer_spec.rb
+++ b/spec/lib/rbs_infer/predicate_marker_synthesizer_spec.rb
@@ -1,0 +1,172 @@
+require "spec_helper"
+require "rbs_infer"
+require "steep"
+
+# Unit specs for the predicate-marker synthesizer. The input here is
+# `Steep::Postconditions::InferredEntry` instances (hand-built, no
+# live type-checker) so the rules are tested in isolation from
+# Steep's source-walking machinery — that machinery is covered by
+# Steep's own `PostconditionsInferrerTest`.
+RSpec.describe RbsInfer::PredicateMarkerSynthesizer do
+  Member = RbsInfer::Member
+  InferredEntry = Steep::Postconditions::InferredEntry
+
+  def member(kind:, name:)
+    Member.new(kind: kind, name: name, signature: "#{name}: untyped", visibility: :public)
+  end
+
+  def entry(class_name:, method_name:, when_true_ivars: {}, when_true_self_type_string: nil, ivars: {}, self_type_string: nil, singleton: false)
+    InferredEntry.new(
+      class_name: class_name,
+      method_name: method_name,
+      singleton: singleton,
+      ivars: ivars,
+      self_type_string: self_type_string,
+      when_true_ivars: when_true_ivars,
+      when_true_self_type_string: when_true_self_type_string
+    )
+  end
+
+  def string_type
+    Steep::AST::Types::Name::Instance.new(name: RBS::TypeName.parse("::String"), args: [])
+  end
+
+  it "emits a marker for a predicate whose when_true narrows an attr_reader ivar" do
+    markers = described_class.synthesize(
+      inferred_entries: [
+        entry(
+          class_name: "Venue",
+          method_name: :confirmed?,
+          when_true_ivars: { :"@name" => string_type },
+          when_true_self_type_string: "::Venue & ::Venue::AfterConfirmed"
+        )
+      ],
+      target_class: "Venue",
+      members: [member(kind: :attr_accessor, name: "name")]
+    )
+
+    expect(markers.size).to eq(1)
+    expect(markers.first.marker_name).to eq("AfterConfirmed")
+    expect(markers.first.overrides).to eq({ "name" => "::String" })
+  end
+
+  it "skips ivars without a corresponding attr_reader/attr_accessor" do
+    # `@internal_state` narrowed but no reader — the marker would be
+    # unobservable from any caller, so skip.
+    markers = described_class.synthesize(
+      inferred_entries: [
+        entry(
+          class_name: "Venue",
+          method_name: :ready?,
+          when_true_ivars: { :"@internal_state" => string_type }
+        )
+      ],
+      target_class: "Venue",
+      members: []
+    )
+
+    expect(markers).to be_empty
+  end
+
+  it "ignores entries for other classes" do
+    # The analyzer scopes per-file; we shouldn't accidentally emit a
+    # marker for class B inside class A's RBS file.
+    markers = described_class.synthesize(
+      inferred_entries: [
+        entry(
+          class_name: "OtherClass",
+          method_name: :confirmed?,
+          when_true_ivars: { :"@name" => string_type }
+        )
+      ],
+      target_class: "Venue",
+      members: [member(kind: :attr_accessor, name: "name")]
+    )
+
+    expect(markers).to be_empty
+  end
+
+  it "ignores entries that only have unconditional narrowing" do
+    # Setter-style entries are handled by `SetterMarkerSynthesizer`.
+    # This synthesizer focuses on `when_true` narrowings; mixing
+    # would double-emit markers for the same method.
+    markers = described_class.synthesize(
+      inferred_entries: [
+        entry(
+          class_name: "Venue",
+          method_name: :set_default_name,
+          ivars: { :"@name" => string_type },
+          self_type_string: "::Venue & ::Venue::AfterSetDefaultName"
+        )
+      ],
+      target_class: "Venue",
+      members: [member(kind: :attr_accessor, name: "name")]
+    )
+
+    expect(markers).to be_empty
+  end
+
+  it "skips singleton entries" do
+    markers = described_class.synthesize(
+      inferred_entries: [
+        entry(
+          class_name: "Venue",
+          method_name: :self_check?,
+          singleton: true,
+          when_true_ivars: { :"@name" => string_type }
+        )
+      ],
+      target_class: "Venue",
+      members: [member(kind: :attr_accessor, name: "name")]
+    )
+
+    expect(markers).to be_empty
+  end
+
+  it "produces markers sorted by marker_name for deterministic output" do
+    markers = described_class.synthesize(
+      inferred_entries: [
+        entry(
+          class_name: "Venue",
+          method_name: :zebra?,
+          when_true_ivars: { :"@name" => string_type }
+        ),
+        entry(
+          class_name: "Venue",
+          method_name: :alpha?,
+          when_true_ivars: { :"@name" => string_type }
+        )
+      ],
+      target_class: "Venue",
+      members: [member(kind: :attr_accessor, name: "name")]
+    )
+
+    expect(markers.map(&:marker_name)).to eq(["AfterAlpha", "AfterZebra"])
+  end
+
+  it "agrees with Steep::Postconditions::MarkerNaming naming convention" do
+    # The marker class generated here must match exactly what
+    # `Steep::Postconditions::Inferrer` writes into the sidecar's
+    # `when_true.self` slot. Drift would mean the sidecar references
+    # a marker that doesn't exist in RBS, which triggers the
+    # defensive guard on the consumer side and silently no-ops the
+    # refinement.
+    expected = Steep::Postconditions::MarkerNaming.marker_name_for("Venue", :confirmed?)
+    expect(expected).to eq("::Venue::AfterConfirmed")
+
+    markers = described_class.synthesize(
+      inferred_entries: [
+        entry(
+          class_name: "Venue",
+          method_name: :confirmed?,
+          when_true_ivars: { :"@name" => string_type },
+          when_true_self_type_string: expected
+        )
+      ],
+      target_class: "Venue",
+      members: [member(kind: :attr_accessor, name: "name")]
+    )
+
+    expect(markers.first.marker_name).to eq("AfterConfirmed")
+  end
+end


### PR DESCRIPTION
Closes the rbs_infer side of the predicate-narrowing pipeline. When Steep's `Postconditions::Inferrer` (felixefelip/steep#37) emits a `when_true.self` referencing `Klass::AfterPredicate`, rbs_infer now generates the matching nested marker class with the narrowed `attr_reader` overrides — so the sidecar's reference resolves to a real RBS type and the defensive missing-marker guard on the consumer side doesn't silently skip the refinement.

## Pipeline composition

This is the final piece of the chain-narrowing scenario from felixefelip/steep#32 (issue's motivating example):

\`\`\`ruby
if ticket.event.venue.confirmed?
  ticket.event.venue.name.upcase   # direct narrowing (steep#37)
  ticket.event.venue_name.upcase   # 1-hop chain (steep#36)
  ticket.venue_name.upcase         # multi-hop chain (steep#36)
end
\`\`\`

Closes end-to-end in order_factory's `Concerts::MountTicketEvent#call` once both Steep and rbs_infer are up to date. Verified locally:

\`\`\`
$ bundle exec steep check app/models/concerts/mount_ticket_event.rb
No type error detected. 🫖
\`\`\`

## What changed

- **`SteepBridge#postcondition_inferred_entries(source)`** — runs Steep's `Postconditions::Inferrer.infer` against the source and returns the `InferredEntry` array. The inferrer is the source-of-truth for "what does this method narrow?"; consuming its output keeps rbs_infer's marker-generation aligned with whatever shapes Steep's `LogicTypeInterpreter` recognizes today or in the future.

- **`PredicateMarkerSynthesizer`** — consumes the entries and produces `SetterMarkerSynthesizer::MarkerClass` instances for entries with non-empty `when_true_ivars`. Same struct as the setter side, so `RbsBuilder` consumes one shape regardless of origin.
  - Filters by `target_class` (analyzer scopes per file).
  - Skips singletons.
  - Requires a matching `attr_reader`/`attr_accessor` for each narrowed ivar — without one the marker would be unobservable.
  - Marker name via `Steep::Postconditions::MarkerNaming.pascal_case` (shared with setter side, identical convention).

- **`Analyzer#synthesize_markers`** — splits into `synthesize_setter_markers` and `synthesize_predicate_markers`, merging via `merge_markers` (dedupes by name, unions overrides). Public API unchanged.

## Why use Steep's Inferrer instead of re-implementing detection

Predicate shape detection is non-trivial — `!@x.nil?` is the common case but Steep also handles `is_a?`, `kind_of?`, conjunctions, ternaries via the `LogicTypeInterpreter`. Re-implementing on the rbs_infer side would duplicate work AND drift over time. Reading the inferrer's emitted entries is the "good engineering" choice: one source of truth, automatic coverage of new patterns Steep learns.

## Test coverage

- [x] 7 new unit specs for `PredicateMarkerSynthesizer` (basic predicate → marker, attr_reader gate, cross-class skip, unconditional-only skip, singleton skip, deterministic sort, MarkerNaming convention agreement).
- [x] Existing setter integration tests still pass.
- [x] Full suite: 395 examples / 0 failures (was 388 / 0).
- [x] order_factory end-to-end: `mount_ticket_event.rb` typechecks clean with all 3 narrowing lines (direct + 1-hop chain + multi-hop chain).

## Related

- felixefelip/steep#37 — `Postconditions::Inferrer` emits `when_true` for nil-check predicates. **Merged**.
- felixefelip/steep#36 — chain narrowing via delegation inlining. **Merged**.
- felixefelip/steep#32 — original issue. Closeable after this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)