### PR TITLE
fix(steep_bridge): pass delegation_registry to TypeCheckService.type_check

### DIFF
--- a/lib/rbs_infer/steep_bridge.rb
+++ b/lib/rbs_infer/steep_bridge.rb
@@ -540,10 +540,20 @@ module RbsInfer
         cursor: nil,
         contracts: contracts_store,
         postconditions: postconditions_store,
-        callbacks: callbacks_store
+        callbacks: callbacks_store,
+        delegation_registry: delegation_registry_store
       )
     rescue Parser::SyntaxError
       nil
+    end
+
+    # rbs_infer runs Steep's inferrers in isolation per-source, with
+    # no surrounding project context — there's no delegation graph
+    # to feed in. An empty registry satisfies the required kwarg
+    # (felixefelip/steep#38) without enabling chain inlining that
+    # we wouldn't be able to populate here anyway.
+    def delegation_registry_store
+      @delegation_registry_store ||= Steep::Project::DelegationRegistry.new
     end
 
     # Loads Steep's auto-inferred precondition contracts from the project's


### PR DESCRIPTION
Required by felixefelip/steep#38 — `delegation_registry:` is now a required kwarg on `TypeCheckService.type_check`. Without this fix every call from rbs_infer (via `SteepBridge#type_check`) raises:

\`\`\`
ArgumentError: missing keyword: :delegation_registry
\`\`\`

rbs_infer runs Steep's inferrers in isolation per-source, with no surrounding project context — there's no delegation graph to feed in. An empty `Steep::Project::DelegationRegistry.new` satisfies the required kwarg without enabling chain inlining that we wouldn't be able to populate here anyway.

## Test plan

- [x] Full suite: 395 examples, 0 failures.
- [x] Verified end-to-end in order_factory: running rbs_infer on `app/models/concerts/event.rb` no longer crashes with `ArgumentError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)