### PR TITLE
fix(steep_bridge): load RBS collection (incl. stdlib) via lockfile

### DIFF
--- a/lib/rbs_infer/steep_bridge.rb
+++ b/lib/rbs_infer/steep_bridge.rb
@@ -39,16 +39,68 @@ module RbsInfer
 
       def build_definition_builder
         require "rbs"
+        require "yaml"
 
         loader = RBS::EnvironmentLoader.new
 
+        # Load the project's RBS collection (gems + stdlib) from its
+        # lockfile, mirroring what `steep check` does (see Steep's
+        # `Drivers::Utils::DriverHelper`). This is what pulls in the
+        # *stdlib* RBS — `date`, `time`, etc. — which gem RBS depends on
+        # but `EnvironmentLoader.new` does not load by itself.
+        #
+        # It matters because gems like activesupport reopen core stdlib
+        # classes with overload-extending signatures, e.g. on `::Date`:
+        #
+        #     def +: (ActiveSupport::Duration other) -> self
+        #          | ...   # extends the stdlib Date#+ overloads
+        #
+        # The trailing `| ...` requires the stdlib `date` base method to
+        # already exist. Without `date` loaded, building `::Date`'s method
+        # table raises `RBS::InvalidOverloadMethodError`; Steep wraps it as
+        # an `UnexpectedError` and types every `Date`-receiver expression
+        # as `untyped`. That silently poisons whole return-type chains
+        # (e.g. `((Date.current - born) / 365).to_f.truncate(2)` inferred
+        # as `untyped` instead of `Float`). Loading the lockfile keeps the
+        # bridge's environment in parity with `steep check`.
+        add_collection_from_lockfile(loader)
+
         Dir["sig/*/"].each { |d| loader.add(path: Pathname(d)) }
-        Dir[".gem_rbs_collection/*/*/"].each { |ver_dir| loader.add(path: Pathname(ver_dir)) }
 
         env = RBS::Environment.from_loader(loader).resolve_type_names
         RBS::DefinitionBuilder.new(env: env)
       rescue LoadError, StandardError => _e
         nil
+      end
+
+      # Adds the project's RBS collection (gems + stdlib) to `loader` from
+      # its `rbs_collection.lock.yaml`. Falls back to the legacy
+      # `.gem_rbs_collection/*/*/` glob when there's no readable/usable
+      # lockfile — note that fallback does NOT bring in stdlib RBS, so
+      # `Date`/`Time` chains there still degrade to `untyped`.
+      def add_collection_from_lockfile(loader)
+        config_path = RBS::Collection::Config.find_config_path
+        lock_path = config_path && RBS::Collection::Config.to_lockfile_path(config_path)
+
+        unless lock_path&.exist?
+          return add_gem_rbs_collection_glob(loader)
+        end
+
+        lockfile = RBS::Collection::Config::Lockfile.from_lockfile(
+          lockfile_path: lock_path,
+          data: YAML.load(lock_path.read)
+        )
+        # Raises CollectionNotAvailable if the lockfile references gems
+        # that aren't installed under the collection dir. Check before
+        # mutating `loader` so we can fall back cleanly to the glob.
+        lockfile.check_rbs_availability!
+        loader.add_collection(lockfile)
+      rescue StandardError
+        add_gem_rbs_collection_glob(loader)
+      end
+
+      def add_gem_rbs_collection_glob(loader)
+        Dir[".gem_rbs_collection/*/*/"].each { |ver_dir| loader.add(path: Pathname(ver_dir)) }
       end
     end
 

--- a/spec/lib/rbs_infer/steep_bridge_spec.rb
+++ b/spec/lib/rbs_infer/steep_bridge_spec.rb
@@ -231,6 +231,56 @@ RSpec.describe RbsInfer::SteepBridge, :dummy_app do
       expect(ret).not_to include("void")
     end
 
+    # Regression for the `User::Idade#idade` => `() -> untyped` bug.
+    #
+    # Gem RBS (e.g. activesupport) reopens core stdlib classes with
+    # overload-extending signatures, e.g. on `::Date`:
+    #
+    #     def +: (ActiveSupport::Duration other) -> self
+    #          | ...   # extends the stdlib Date#+ overloads
+    #
+    # The trailing `| ...` needs the stdlib `date` base method to exist.
+    # The bridge used to load only `.gem_rbs_collection/*/*/` (gem RBS,
+    # no stdlib), so building `::Date`'s method table raised
+    # `RBS::InvalidOverloadMethodError`, Steep wrapped it as an
+    # `UnexpectedError`, and every `Date`-receiver expression collapsed
+    # to `untyped` — poisoning the whole arithmetic chain. Loading the
+    # collection lockfile (which lists `date`/`time` as `type: stdlib`)
+    # brings in the base definitions and keeps the bridge in parity with
+    # `steep check`.
+    context "Date/stdlib-backed chains (collection lockfile loading)" do
+      it "types a Date arithmetic chain ending in #to_f as Float, not untyped" do
+        code = <<~RUBY
+          class Comment
+            def age_in_years
+              ((Date.today - Date.today) / 365).to_f
+            end
+          end
+        RUBY
+
+        result = bridge.method_return_types(code)
+        expect(result["age_in_years"]).to eq("Float")
+      end
+
+      it "types the reported User::Idade#idade chain (.to_f.truncate(2))" do
+        code = <<~RUBY
+          class Comment
+            def idade
+              ((Date.today - Date.today) / 365).to_f.truncate(2)
+            end
+          end
+        RUBY
+
+        result = bridge.method_return_types(code)
+        # The essential guarantee is that it is no longer `untyped`
+        # (absent from the result). `Float#truncate(ndigits)` is declared
+        # to return `(Integer | Float)` because the type system can't see
+        # that `2 > 0`.
+        expect(result).to have_key("idade")
+        expect(result["idade"]).to eq("(Integer | Float)")
+      end
+    end
+
     it "returns empty hash for unparseable code" do
       result = bridge.method_return_types("!!!invalid ruby")
       expect(result).to eq({})


### PR DESCRIPTION
The bridge built its RBS environment from `EnvironmentLoader.new` plus a `.gem_rbs_collection/*/*/` glob, which loads gem RBS but no stdlib RBS. Gems like activesupport reopen core stdlib classes with overload-extending signatures, e.g. on `::Date`:

    def +: (ActiveSupport::Duration other) -> self
         | ...   # extends the stdlib Date#+ overloads

The trailing `| ...` requires the stdlib `date` base method to exist. Without `date` loaded, building `::Date`'s method table raised `RBS::InvalidOverloadMethodError`; Steep wrapped it as `UnexpectedError` and typed every `Date`-receiver expression as `untyped`. That silently poisoned whole return-type chains — e.g. `User::Idade#idade` (`((Date.current - data_nascimento) / 365).to_f.truncate(2)`) was inferred as `() -> untyped` even though `steep check` types it concretely.

Load the project's collection via its `rbs_collection.lock.yaml` (`RBS::Collection::Config` -> `loader.add_collection`), mirroring Steep's `Drivers::Utils::DriverHelper`. This pulls in the stdlib RBS (`date`, `time`, ...) declared as deps by gem manifests and keeps the bridge's environment in parity with `steep check`. Falls back to the legacy glob when there's no usable lockfile (collection missing/uninstalled), so the bridge degrades gracefully instead of being disabled.

Add regression coverage in steep_bridge_spec for Date/stdlib-backed chains (fails pre-fix with the Date#+ overload error -> untyped).