### PR TITLE
fix(new_call_collector): infer `self` argument in .new call-sites

### DIFF
--- a/lib/rbs_infer/caller_file_analyzer.rb
+++ b/lib/rbs_infer/caller_file_analyzer.rb
@@ -50,6 +50,18 @@ module RbsInfer
       short_name = @target_class.split("::").last
       match_bare = source.match?(/\binclude\b.*\b#{Regexp.escape(short_name)}\b/)
 
+      # After-validation callback narrowing: inside e.g. an `after_create`
+      # handler, `self` is the validated record, so `Foo.new(self)` should
+      # infer the arg as `Caller & Caller::Validated`. Pull the refined
+      # `self` types from the callback sidecar (felixefelip/steep#27) — the
+      # narrowing isn't readable from Steep's per-node typing.
+      self_types_by_method =
+        if @steep_bridge && caller_visitor.class_name
+          @steep_bridge.callback_self_types(caller_visitor.class_name)
+        else
+          {}
+        end
+
       visitor = NewCallCollector.new(
         target_class: @target_class,
         method_return_types: method_return_types,
@@ -58,7 +70,8 @@ module RbsInfer
         caller_class_name: caller_visitor.class_name,
         init_positional_params: @init_positional_params,
         target_methods: @target_methods,
-        match_bare_calls: match_bare
+        match_bare_calls: match_bare,
+        self_types_by_method: self_types_by_method
       )
       result.value.accept(visitor)
 

--- a/lib/rbs_infer/new_call_collector.rb
+++ b/lib/rbs_infer/new_call_collector.rb
@@ -2,7 +2,7 @@ module RbsInfer
   class NewCallCollector < Prism::Visitor
     attr_reader :usages, :method_call_usages
 
-    def initialize(target_class:, method_return_types:, local_var_types:, method_type_resolver: nil, caller_class_name: nil, init_positional_params: [], target_methods: {}, match_bare_calls: false)
+    def initialize(target_class:, method_return_types:, local_var_types:, method_type_resolver: nil, caller_class_name: nil, init_positional_params: [], target_methods: {}, match_bare_calls: false, self_types_by_method: {})
       @target_class = target_class
       @method_return_types = method_return_types
       @local_var_types = local_var_types
@@ -11,6 +11,11 @@ module RbsInfer
       @init_positional_params = init_positional_params
       @target_methods = target_methods
       @match_bare_calls = match_bare_calls
+      # `{ "method_name" => "Self & Self::Validated" }` — refined `self`
+      # types per method, from after-validation callback sidecars (see
+      # SteepBridge#callback_self_types). Preferred over the lexical class
+      # name when resolving `self` inside such a method.
+      @self_types_by_method = self_types_by_method
       @usages = []
       @method_call_usages = Hash.new { |h, k| h[k] = [] }
       # Lexically-enclosing class names (fully qualified) and whether the
@@ -18,6 +23,7 @@ module RbsInfer
       # `self` argument/receiver to its type.
       @class_name_stack = []
       @in_singleton_method = false
+      @current_method = nil
     end
 
     def visit_class_node(node)
@@ -38,10 +44,13 @@ module RbsInfer
     def visit_def_node(node)
       old_vars = @local_var_types.dup
       old_singleton = @in_singleton_method
+      old_method = @current_method
       # `def self.foo` carries a receiver; plain `def foo` does not.
       @in_singleton_method = !node.receiver.nil?
+      @current_method = node.name.to_s
       collect_local_assignments(node)
       super
+      @current_method = old_method
       @in_singleton_method = old_singleton
       @local_var_types = old_vars
     end
@@ -296,6 +305,16 @@ module RbsInfer
     # `Caderneta#criar_caderneta_de_vacinacao`, where the positional
     # `initialize(caderneta)` param should infer as `Caderneta`.
     def current_self_type
+      # Inside an instance method covered by an after-validation callback,
+      # `self` is the validated record — prefer the refined type from the
+      # callback sidecar (e.g. `Caderneta & Caderneta::Validated`) over the
+      # bare lexical class. Singleton methods aren't callback handlers, so
+      # they keep the lexical resolution.
+      unless @in_singleton_method
+        refined = @current_method && @self_types_by_method[@current_method]
+        return refined if refined && !refined.empty?
+      end
+
       base = @class_name_stack.last || @caller_class_name
       return "untyped" unless base
 

--- a/lib/rbs_infer/new_call_collector.rb
+++ b/lib/rbs_infer/new_call_collector.rb
@@ -13,19 +13,36 @@ module RbsInfer
       @match_bare_calls = match_bare_calls
       @usages = []
       @method_call_usages = Hash.new { |h, k| h[k] = [] }
+      # Lexically-enclosing class names (fully qualified) and whether the
+      # current method is a singleton (`def self.x`) — used to resolve a
+      # `self` argument/receiver to its type.
+      @class_name_stack = []
+      @in_singleton_method = false
     end
 
     def visit_class_node(node)
       # Pré-coletar tipos de ivars de todos os métodos da classe
       # para que @post definido em set_post esteja disponível em publish
       collect_class_ivar_types(node)
+
+      segment = RbsInfer::Analyzer.extract_constant_path(node.constant_path)
+      full_name =
+        if segment
+          @class_name_stack.empty? ? segment : "#{@class_name_stack.last}::#{segment}"
+        end
+      @class_name_stack.push(full_name) if full_name
       super
+      @class_name_stack.pop if full_name
     end
 
     def visit_def_node(node)
       old_vars = @local_var_types.dup
+      old_singleton = @in_singleton_method
+      # `def self.foo` carries a receiver; plain `def foo` does not.
+      @in_singleton_method = !node.receiver.nil?
       collect_local_assignments(node)
       super
+      @in_singleton_method = old_singleton
       @local_var_types = old_vars
     end
 
@@ -258,11 +275,31 @@ module RbsInfer
       when Prism::HashNode then RbsInfer::NodeTypeInferrer.infer_hash_type(node)
       when Prism::ConstantReadNode, Prism::ConstantPathNode
         RbsInfer::Analyzer.extract_constant_path(node) || "untyped"
+      when Prism::SelfNode
+        current_self_type
       when Prism::ImplicitNode
         resolve_value_type(node.value)
       else
         "untyped"
       end
+    end
+
+    # Resolve `self` (passed as an argument or used as a receiver) to the
+    # lexically-enclosing class. Inside an instance method `self` is an
+    # instance of that class (`Caderneta`); inside a singleton method
+    # (`def self.x`) it's the class object itself (`singleton(Caderneta)`),
+    # so we never infer a bogus instance type for it. Falls back to the
+    # caller class (derived from the file path) when no class node is on
+    # the stack, and to `"untyped"` when even that is unknown.
+    #
+    # Drives call-site inference like `Cadastrar.new(self)` inside
+    # `Caderneta#criar_caderneta_de_vacinacao`, where the positional
+    # `initialize(caderneta)` param should infer as `Caderneta`.
+    def current_self_type
+      base = @class_name_stack.last || @caller_class_name
+      return "untyped" unless base
+
+      @in_singleton_method ? "singleton(#{base})" : base
     end
 
     # Resolver receiver.method() → tipo do retorno do method no receiver
@@ -292,7 +329,10 @@ module RbsInfer
           resolve_method_chain(node)
         end
       when Prism::SelfNode
-        nil # self → seria a própria classe, não resolvemos por enquanto
+        # self → tipo da classe léxica (instância ou singleton); nil quando
+        # desconhecido, mantendo a convenção nil-returning deste método.
+        resolved = current_self_type
+        resolved == "untyped" ? nil : resolved
       end
     end
 

--- a/lib/rbs_infer/steep_bridge.rb
+++ b/lib/rbs_infer/steep_bridge.rb
@@ -395,6 +395,40 @@ module RbsInfer
       result
     end
 
+    # Returns `{ "method_name" => "Self & Self::Validated" }` for `class_name`,
+    # derived from the `applies_self` callback sidecar entries
+    # (`.steep_callbacks.yml`, felixefelip/steep#27) loaded into the
+    # callbacks store. rbs_rails' `ModelCallbacksGenerator` emits these for
+    # after-validation lifecycle callbacks (`after_create`, `after_save`, …)
+    # and their transitive self-call closure — so inside such a handler the
+    # record is known validated and `self` refines to `Model & Model::Validated`.
+    #
+    # rbs_infer needs this because Steep keeps a `self` node as the abstract
+    # `self` token in its typing output (the refinement only affects dispatch,
+    # never the recorded node type), so the narrowed self type can't be read
+    # back from `each_typing`. Reading the sidecar — the same source of truth
+    # Steep consumes — lets call-site inference resolve `Klass.new(self)`
+    # inside a callback to the validated type instead of the bare class.
+    def callback_self_types(class_name)
+      return {} unless class_name
+
+      store = callbacks_store
+      return {} if store.nil? || store.empty?
+
+      key = class_name.to_s.sub(/\A::/, "")
+      entries = store.entries_by_class[key]
+      return {} unless entries
+
+      result = {}
+      entries.each do |entry|
+        next unless entry.applies_self
+        entry.runs_before.each do |method_sym|
+          result[method_sym.to_s] ||= entry.applies_self
+        end
+      end
+      result
+    end
+
     private
 
     # Walks `node` accumulating ivar writes attributed to the enclosing

--- a/spec/lib/rbs_infer/new_call_collector_spec.rb
+++ b/spec/lib/rbs_infer/new_call_collector_spec.rb
@@ -125,14 +125,15 @@ RSpec.describe RbsInfer::NewCallCollector do
     # should infer the positional `initialize(caderneta)` param as
     # `Caderneta` — `self` resolves to the lexically-enclosing class.
     # Previously `self` fell through to `untyped`.
-    def collect_with_self(source, target_class:, caller_class_name:, init_positional_params:)
+    def collect_with_self(source, target_class:, caller_class_name:, init_positional_params:, self_types_by_method: {})
       result = Prism.parse(source)
       visitor = described_class.new(
         target_class: target_class,
         method_return_types: {},
         local_var_types: {},
         caller_class_name: caller_class_name,
-        init_positional_params: init_positional_params
+        init_positional_params: init_positional_params,
+        self_types_by_method: self_types_by_method
       )
       result.value.accept(visitor)
       visitor.usages
@@ -192,6 +193,49 @@ RSpec.describe RbsInfer::NewCallCollector do
         init_positional_params: ["owner"]
       )
       expect(usages.first["owner"]).to eq("Outer::Inner")
+    end
+
+    # After-validation callback narrowing: inside an `after_create` handler
+    # the record is validated, so `self` (and thus `Cadastrar.new(self)`)
+    # should be `Caderneta & Caderneta::Validated`. The refined self type
+    # comes from the callback sidecar (SteepBridge#callback_self_types) since
+    # Steep keeps `self` abstract in its typing output.
+    it "prefers the callback-refined self type over the lexical class" do
+      source = <<~RUBY
+        class Caderneta
+          def criar_caderneta_de_vacinacao
+            Cadastrar.new(self).call
+          end
+        end
+      RUBY
+
+      usages = collect_with_self(
+        source,
+        target_class: "Caderneta::Cadastrar",
+        caller_class_name: "Caderneta",
+        init_positional_params: ["caderneta"],
+        self_types_by_method: { "criar_caderneta_de_vacinacao" => "Caderneta & Caderneta::Validated" }
+      )
+      expect(usages.first["caderneta"]).to eq("Caderneta & Caderneta::Validated")
+    end
+
+    it "uses the lexical class for methods not covered by a callback entry" do
+      source = <<~RUBY
+        class Caderneta
+          def some_other_method
+            Cadastrar.new(self)
+          end
+        end
+      RUBY
+
+      usages = collect_with_self(
+        source,
+        target_class: "Caderneta::Cadastrar",
+        caller_class_name: "Caderneta",
+        init_positional_params: ["caderneta"],
+        self_types_by_method: { "criar_caderneta_de_vacinacao" => "Caderneta & Caderneta::Validated" }
+      )
+      expect(usages.first["caderneta"]).to eq("Caderneta")
     end
 
     it "falls back to untyped when self has no resolvable class context" do

--- a/spec/lib/rbs_infer/new_call_collector_spec.rb
+++ b/spec/lib/rbs_infer/new_call_collector_spec.rb
@@ -120,6 +120,95 @@ RSpec.describe RbsInfer::NewCallCollector do
     expect(usages.first["nome"]).to eq("String")
   end
 
+  describe "self as a .new argument (regression)" do
+    # `Cadastrar.new(self)` inside `Caderneta#criar_caderneta_de_vacinacao`
+    # should infer the positional `initialize(caderneta)` param as
+    # `Caderneta` — `self` resolves to the lexically-enclosing class.
+    # Previously `self` fell through to `untyped`.
+    def collect_with_self(source, target_class:, caller_class_name:, init_positional_params:)
+      result = Prism.parse(source)
+      visitor = described_class.new(
+        target_class: target_class,
+        method_return_types: {},
+        local_var_types: {},
+        caller_class_name: caller_class_name,
+        init_positional_params: init_positional_params
+      )
+      result.value.accept(visitor)
+      visitor.usages
+    end
+
+    it "infers self in an instance method as the enclosing class instance" do
+      source = <<~RUBY
+        class Caderneta
+          def criar_caderneta_de_vacinacao
+            Cadastrar.new(self).call
+          end
+        end
+      RUBY
+
+      usages = collect_with_self(
+        source,
+        target_class: "Caderneta::Cadastrar",
+        caller_class_name: "Caderneta",
+        init_positional_params: ["caderneta"]
+      )
+      expect(usages.first["caderneta"]).to eq("Caderneta")
+    end
+
+    it "infers self in a singleton method as singleton(EnclosingClass)" do
+      source = <<~RUBY
+        class Caderneta
+          def self.build
+            Cadastrar.new(self)
+          end
+        end
+      RUBY
+
+      usages = collect_with_self(
+        source,
+        target_class: "Caderneta::Cadastrar",
+        caller_class_name: "Caderneta",
+        init_positional_params: ["caderneta"]
+      )
+      expect(usages.first["caderneta"]).to eq("singleton(Caderneta)")
+    end
+
+    it "resolves self to the innermost lexically-enclosing class when nested" do
+      source = <<~RUBY
+        class Outer
+          class Inner
+            def make
+              Target.new(self)
+            end
+          end
+        end
+      RUBY
+
+      usages = collect_with_self(
+        source,
+        target_class: "Outer::Inner::Target",
+        caller_class_name: "Outer",
+        init_positional_params: ["owner"]
+      )
+      expect(usages.first["owner"]).to eq("Outer::Inner")
+    end
+
+    it "falls back to untyped when self has no resolvable class context" do
+      # No enclosing class node and no caller_class_name.
+      source = "Target.new(self)"
+      result = Prism.parse(source)
+      visitor = described_class.new(
+        target_class: "Target",
+        method_return_types: {},
+        local_var_types: {},
+        init_positional_params: ["owner"]
+      )
+      result.value.accept(visitor)
+      expect(visitor.usages.first["owner"]).to eq("untyped")
+    end
+  end
+
   describe "ivar/local name collision (regression)" do
     # The ERB caller resolver passes ivar types keyed by `@name`
     # (with prefix) and locals keyed by `name`. The collector's

--- a/spec/lib/rbs_infer/steep_bridge_spec.rb
+++ b/spec/lib/rbs_infer/steep_bridge_spec.rb
@@ -376,6 +376,30 @@ RSpec.describe RbsInfer::SteepBridge, :dummy_app do
     end
   end
 
+  describe "#callback_self_types" do
+    # Reads the `applies_self` callback sidecar (.steep_callbacks.yml,
+    # felixefelip/steep#27) so call-site inference can resolve `self`
+    # inside an after-validation callback to the validated record type.
+    # The dummy's sidecar declares `Comment#notify_post_author` →
+    # `Comment & Comment::Validated`.
+    it "maps callback handler methods to their refined self type" do
+      result = bridge.callback_self_types("Comment")
+      expect(result["notify_post_author"]).to eq("Comment & Comment::Validated")
+    end
+
+    it "normalizes a leading :: in the class name" do
+      expect(bridge.callback_self_types("::Comment")).to eq(bridge.callback_self_types("Comment"))
+    end
+
+    it "returns an empty hash for a class with no callback entries" do
+      expect(bridge.callback_self_types("Foo")).to eq({})
+    end
+
+    it "returns an empty hash for nil" do
+      expect(bridge.callback_self_types(nil)).to eq({})
+    end
+  end
+
   describe "#ivar_write_types" do
     # Cobertura da regra introduzida em felixefelip/rbs_infer#4:
     # coleta todas as escritas, deduplica, e adiciona `| nil` quando a


### PR DESCRIPTION
Resolve `self` at `.new` call-sites instead of leaving it `untyped`. Two commits:

### 1. Lexical `self` (ae165d3)

A `self` argument fell through `resolve_value_type` to `untyped`. Now resolves to the lexically-enclosing class — an instance of it in an instance method (`Caderneta`), or `singleton(Caderneta)` in a singleton method (`def self.x`), so we never emit a bogus instance type. A class-name stack handles nesting; falls back to the caller class, then `untyped`.

### 2. Callback-aware `self` (5e06d9b)

`criar_caderneta_de_vacinacao` is an `after_create` callback, so it runs **after** validation/persistence — `self` is the validated record, and the precise type is `Caderneta & Caderneta::Validated`, not the bare class.

Steep can't supply this: a `:self` node always types as the abstract `self` token in its output (the refinement only affects dispatch, never the recorded node type), so the narrowed type isn't readable from `each_typing`. Instead we read the **same source of truth Steep consumes** — the `applies_self` entries of `.steep_callbacks.yml`, emitted by rbs_rails' `ModelCallbacksGenerator` for after-validation callbacks and their transitive self-call closure:

- `SteepBridge#callback_self_types(class_name)` → `{ method => "Self & Self::Validated" }` from the loaded callbacks store.
- `CallerFileAnalyzer` passes it to `NewCallCollector`.
- `NewCallCollector` tracks the current method and prefers the callback-refined self type over the lexical class (instance methods only).

## Antes / depois (converged `--output`)

`sig/generated/app/models/caderneta/cadastrar.rbs`:

```diff
-    def initialize: (untyped caderneta) -> void
+    def initialize: (Caderneta & Caderneta::Validated caderneta) -> void
-    attr_accessor caderneta: untyped
+    attr_accessor caderneta: Caderneta & Caderneta::Validated
```

(A transient first-pass `AfterInitialize` marker, seen before the on-disk RBS settles on `& Validated`, converges away across rbs_infer's iterative passes.)

## Testes

- `new_call_collector_spec`: lexical (instance/singleton/nested/fallback) + callback-aware (refined-self-wins / lexical-for-uncovered-method).
- `steep_bridge_spec`: `#callback_self_types` reads the dummy's sidecar (`Comment#notify_post_author → Comment & Comment::Validated`).
- Full suite: **411 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)