### PR TITLE
fix(core): nested-module support + decouple CurrentAttributes from core (#22)

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -61,7 +61,6 @@ module RbsInfer
 
     # Parsear o arquivo-alvo uma única vez e reutilizar em todo o pipeline
     source = File.read(@target_file)
-    @original_source = source
 
     # Desugar macros into plain-Ruby pseudo-code BEFORE the parse, so the
     # whole pipeline sees the expanded view (felixefelip/rbs_infer#19).
@@ -166,53 +165,7 @@ module RbsInfer
 
     namespace_classes = resolve_namespace_classes
     rbs_builder = RbsBuilder.new(target_class: @target_class, superclass_name: @superclass_name, namespace_classes: namespace_classes, is_module: @is_module)
-    module_info = generated_accessor_module(ivar_types)
-    rbs_builder.build(target_members, init_arg_types, attr_types, optional_params, method_param_types, ivar_types: ivar_types, markers: markers, nested_modules: module_info[:modules], skip_instance_methods: module_info[:skip_instance_methods])
-  end
-
-  # CurrentAttributes instance accessors live in an included
-  # `generated_attribute_methods` module at runtime (Rails:
-  # `Module.new.tap { |mod| include mod }`) — precisely so overrides can
-  # call `super`. The generated RBS mirrors that: ALL instance accessors
-  # go into a `GeneratedAttributeMethods` module (include-only, like the
-  # runtime), so cross-file resolution and `super` both flow through the
-  # ancestor chain uniformly — not just for overridden accessors
-  # (felixefelip/rbs_infer#19). Singleton accessors stay flat: at runtime
-  # they're delegated onto the singleton class, not in the module, and
-  # keeping them flat preserves their call-site-inferred types.
-  #
-  # Returns { modules: [...], skip_instance_methods: Set } — the latter
-  # are the generated instance accessors the builder must NOT emit flat
-  # (they're in the module); overrides are excluded so they stay flat.
-  def generated_accessor_module(ivar_types)
-    empty = { modules: [], skip_instance_methods: Set.new }
-    return empty unless @expanded_source
-
-    attrs = Extensions::Rails::CurrentAttributesExpander.attribute_names(@original_source.to_s)
-    return empty if attrs.empty?
-
-    methods = attrs.flat_map do |attr|
-      type = RbsParserUtil.parenthesize_compound(ivar_types[attr] || "untyped")
-      [
-        { signature: "#{attr}: () -> #{type}" },
-        { signature: "#{attr}=: (#{type} value) -> #{type}" },
-      ]
-    end
-
-    # Generated instance accessor names, minus the ones the class body
-    # overrides (those stay flat — they're the user's real methods, and
-    # their `super` targets the module version above).
-    override_names = Extensions::Rails::CurrentAttributesExpander
-                     .overridden_accessors(@original_source.to_s)
-                     .reject { |ov| ov[:singleton] }
-                     .map { |ov| ov[:method] }
-                     .to_set
-    generated_names = attrs.flat_map { |attr| [attr, "#{attr}="] }.to_set
-
-    {
-      modules: [{ name: "GeneratedAttributeMethods", methods: methods }],
-      skip_instance_methods: generated_names - override_names,
-    }
+    rbs_builder.build(target_members, init_arg_types, attr_types, optional_params, method_param_types, ivar_types: ivar_types, markers: markers)
   end
 
   # Builds the marker class list to inject into the generated RBS.
@@ -418,7 +371,7 @@ module RbsInfer
   # ─── Parsear classe-alvo: métodos, attrs, visibilidade ─────────────
 
   def parse_target_class
-    visitor = ClassMemberCollector.new(comments: @parsed_target.comments, lines: @parsed_target.lines)
+    visitor = ClassMemberCollector.new(comments: @parsed_target.comments, lines: @parsed_target.lines, target_class: @target_class)
     @parsed_target.tree.accept(visitor)
     @superclass_name = visitor.superclass_name
     @is_module = visitor.is_module if @is_module.nil?
@@ -749,6 +702,7 @@ require_relative "class_name_extractor"
 require_relative "class_body_attr_analyzer"
 require_relative "intra_class_call_analyzer"
 require_relative "initialize_body_analyzer"
+require_relative "lexical_scope"
 require_relative "class_member_collector"
 require_relative "def_collector"
 require_relative "new_call_collector"

--- a/lib/rbs_infer/class_member_collector.rb
+++ b/lib/rbs_infer/class_member_collector.rb
@@ -11,12 +11,13 @@ module RbsInfer
   class ClassMemberCollector < Prism::Visitor
     include NodeTypeInferrer
     include RbsAnnotationParser
+    include LexicalScope
 
     attr_reader :members, :delegates, :superclass_name, :is_module
 
     CONTROLLER_BASES = %w[ApplicationController ActionController::Base ActionController::API].freeze
 
-    def initialize(comments:, lines:)
+    def initialize(comments:, lines:, target_class: nil)
       @comments = comments
       @lines = lines
       @members = []
@@ -25,10 +26,7 @@ module RbsInfer
       @is_controller = false
       @superclass_name = nil
       @is_module = false
-      # Lexical scope stack of { kind:, name:, primary: } frames — used to
-      # attribute members to a nested module inside the target class
-      # (felixefelip/rbs_infer#22).
-      @scope_stack = []
+      self.scope_target = target_class
     end
 
     def visit_module_node(node)
@@ -39,8 +37,7 @@ module RbsInfer
 
     def visit_class_node(node)
       @is_module = false
-      primary = !@primary_class_seen
-      if primary
+      unless @primary_class_seen
         @primary_class_seen = true
         if node.superclass
           @superclass_name = RbsInfer::Analyzer.extract_constant_path(node.superclass)
@@ -48,7 +45,7 @@ module RbsInfer
         end
       end
       segment = RbsInfer::Analyzer.extract_constant_path(node.constant_path)
-      with_scope(:class, segment, primary: primary) { super }
+      with_scope(:class, segment) { super }
     end
 
     def visit_def_node(node)
@@ -113,26 +110,14 @@ module RbsInfer
     # Pushes a lexical scope frame, resetting visibility (a `private` in a
     # nested module must not leak out, and vice-versa), and restores both
     # on exit.
-    def with_scope(kind, name, primary: false)
-      @scope_stack.push({ kind: kind, name: name, primary: primary })
+    def with_scope(kind, name)
+      push_scope(kind, name)
       saved_visibility = @current_visibility
       @current_visibility = :public
       yield
     ensure
       @current_visibility = saved_visibility
-      @scope_stack.pop
-    end
-
-    # The nested-module path that owns members at the current position, or
-    # nil when they're direct members of the target class. Only modules
-    # lexically inside the primary class are owners — namespace modules
-    # wrapping the class (visited before it) are not.
-    def current_owner
-      primary_idx = @scope_stack.index { |f| f[:primary] }
-      return nil unless primary_idx
-
-      mods = @scope_stack[(primary_idx + 1)..].select { |f| f[:kind] == :module && f[:name] }
-      mods.empty? ? nil : mods.map { |f| f[:name] }.join("::")
+      pop_scope
     end
 
     def extract_includes(node)

--- a/lib/rbs_infer/class_member_collector.rb
+++ b/lib/rbs_infer/class_member_collector.rb
@@ -1,6 +1,9 @@
 module RbsInfer
-  # Estrutura que representa um membro da classe
-  Member = Struct.new(:kind, :name, :signature, :visibility, keyword_init: true)
+  # Estrutura que representa um membro da classe.
+  # `owner` = caminho do módulo aninhado que define o membro (ex.
+  # "Formatting"), ou nil quando é membro direto da classe-alvo
+  # (felixefelip/rbs_infer#22). Default nil preserva o comportamento atual.
+  Member = Struct.new(:kind, :name, :signature, :visibility, :owner, keyword_init: true)
 
   # Metadata extraída de uma chamada `delegate` — tipos são resolvidos depois no Analyzer
   DelegateInfo = Struct.new(:methods, :target, :prefix, :allow_nil, keyword_init: true)
@@ -22,23 +25,30 @@ module RbsInfer
       @is_controller = false
       @superclass_name = nil
       @is_module = false
+      # Lexical scope stack of { kind:, name:, primary: } frames — used to
+      # attribute members to a nested module inside the target class
+      # (felixefelip/rbs_infer#22).
+      @scope_stack = []
     end
 
     def visit_module_node(node)
       @is_module = true unless @superclass_name
-      super
+      segment = RbsInfer::Analyzer.extract_constant_path(node.constant_path)
+      with_scope(:module, segment) { super }
     end
 
     def visit_class_node(node)
       @is_module = false
-      unless @primary_class_seen
+      primary = !@primary_class_seen
+      if primary
         @primary_class_seen = true
         if node.superclass
           @superclass_name = RbsInfer::Analyzer.extract_constant_path(node.superclass)
           @is_controller = CONTROLLER_BASES.include?(@superclass_name)
         end
       end
-      super
+      segment = RbsInfer::Analyzer.extract_constant_path(node.constant_path)
+      with_scope(:class, segment, primary: primary) { super }
     end
 
     def visit_def_node(node)
@@ -64,7 +74,8 @@ module RbsInfer
         kind: is_class_method ? :class_method : :method,
         name: name,
         signature: signature,
-        visibility: @current_visibility
+        visibility: @current_visibility,
+        owner: current_owner
       )
       super
     end
@@ -99,6 +110,31 @@ module RbsInfer
 
     private
 
+    # Pushes a lexical scope frame, resetting visibility (a `private` in a
+    # nested module must not leak out, and vice-versa), and restores both
+    # on exit.
+    def with_scope(kind, name, primary: false)
+      @scope_stack.push({ kind: kind, name: name, primary: primary })
+      saved_visibility = @current_visibility
+      @current_visibility = :public
+      yield
+    ensure
+      @current_visibility = saved_visibility
+      @scope_stack.pop
+    end
+
+    # The nested-module path that owns members at the current position, or
+    # nil when they're direct members of the target class. Only modules
+    # lexically inside the primary class are owners — namespace modules
+    # wrapping the class (visited before it) are not.
+    def current_owner
+      primary_idx = @scope_stack.index { |f| f[:primary] }
+      return nil unless primary_idx
+
+      mods = @scope_stack[(primary_idx + 1)..].select { |f| f[:kind] == :module && f[:name] }
+      mods.empty? ? nil : mods.map { |f| f[:name] }.join("::")
+    end
+
     def extract_includes(node)
       return unless node.arguments
 
@@ -110,7 +146,8 @@ module RbsInfer
           kind: :include,
           name: name,
           signature: name,
-          visibility: :public
+          visibility: :public,
+          owner: current_owner
         )
       end
     end
@@ -126,7 +163,8 @@ module RbsInfer
           kind: :extend,
           name: name,
           signature: name,
-          visibility: :public
+          visibility: :public,
+          owner: current_owner
         )
       end
     end
@@ -187,7 +225,8 @@ module RbsInfer
           kind: node.name,
           name: attr_name,
           signature: "#{attr_name}: #{type}",
-          visibility: @current_visibility
+          visibility: @current_visibility,
+          owner: current_owner
         )
       end
     end

--- a/lib/rbs_infer/def_collector.rb
+++ b/lib/rbs_infer/def_collector.rb
@@ -1,14 +1,43 @@
 module RbsInfer
   class DefCollector < Prism::Visitor
-    attr_reader :defs
+    include LexicalScope
 
-    def initialize
+    attr_reader :defs, :owners
+
+    # `target_class` anchors owner computation; nil = no ownership (flat).
+    def initialize(target_class: nil)
       @defs = []
+      # def node => nested-module owner path (nil = direct class member),
+      # so consumers correlating a def to a member can disambiguate names
+      # that collide across a module and the class (e.g. an expanded
+      # CurrentAttributes accessor and its override) — felixefelip#22.
+      @owners = {}
+      self.scope_target = target_class
+    end
+
+    def visit_class_node(node)
+      push_scope(:class, RbsInfer::Analyzer.extract_constant_path(node.constant_path))
+      super
+    ensure
+      pop_scope
+    end
+
+    def visit_module_node(node)
+      push_scope(:module, RbsInfer::Analyzer.extract_constant_path(node.constant_path))
+      super
+    ensure
+      pop_scope
     end
 
     def visit_def_node(node)
       @defs << node
+      @owners[node] = current_owner
       super
+    end
+
+    # Owner of a previously-collected def node (nil = direct class member).
+    def owner_of(node)
+      @owners[node]
     end
   end
 end

--- a/lib/rbs_infer/extensions/rails/current_attributes_expander.rb
+++ b/lib/rbs_infer/extensions/rails/current_attributes_expander.rb
@@ -152,27 +152,48 @@ module RbsInfer
           all_names = []
           defaults = {}
 
-          parsed = calls.map do |call|
+          calls.each do |call|
             names, call_defaults = parse_attribute_call(source, call)
             all_names.concat(names)
             defaults.merge!(call_defaults)
-            [call, names]
           end
 
-          parsed.map.with_index do |(call, names), idx|
-            blocks = names.flat_map { |name| accessor_defs(name, overrides) }
-            if idx == parsed.length - 1
-              blocks.concat(initialize_def(defaults))
-              blocks.concat(set_with_defs(all_names))
-            end
-
+          # Instance accessors live in an included `GeneratedAttributeMethods`
+          # module (mirroring Rails' runtime `generated_attribute_methods`),
+          # so cross-file resolution and overrides' `super` flow through the
+          # ancestor chain. They are generated for EVERY attribute —
+          # including overridden ones — because the module is precisely the
+          # `super` target. Singleton accessors stay flat (delegated onto
+          # the singleton class at runtime) and skip overridden singletons.
+          # — felixefelip/rbs_infer#19, #22.
+          calls.each_with_index.map do |call, idx|
             indent = " " * call.location.start_column
-            {
-              start: call.location.start_offset,
-              end: call.location.end_offset,
-              text: join_blocks(blocks, indent),
-            }
+
+            # Only the last `attribute` call materializes the expansion;
+            # earlier calls are removed so the module is emitted once.
+            next { start: call.location.start_offset, end: call.location.end_offset, text: "" } unless idx == calls.length - 1
+
+            blocks = [module_block(all_names, indent)]
+            all_names.each { |name| blocks.concat(singleton_accessor_defs(name, overrides)) }
+            blocks.concat(initialize_def(defaults))
+            blocks.concat(set_with_defs(all_names))
+
+            { start: call.location.start_offset, end: call.location.end_offset, text: join_blocks(blocks, indent) }
           end
+        end
+
+        # The `module GeneratedAttributeMethods ... include` block (one
+        # multi-line block) wrapping every attribute's instance accessors.
+        # Inner defs are adjacent (no blank separators — those would pick
+        # up the block indent and leave trailing whitespace).
+        def module_block(names, indent)
+          inner = names.flat_map { |name| instance_accessor_defs(name) }
+          [
+            "module GeneratedAttributeMethods",
+            *inner.flat_map { |defn| defn.map { |line| "  #{line}" } },
+            "end",
+            "include GeneratedAttributeMethods",
+          ]
         end
 
         # Attribute accessor defs the class body declares itself (overrides
@@ -296,10 +317,19 @@ module RbsInfer
           node.is_a?(Prism::StatementsNode) && node.body.length > 1
         end
 
-        def accessor_defs(name, overrides = {})
+        # Instance accessors are always generated — the module is the
+        # `super` target for any override, so we never skip them here.
+        def instance_accessor_defs(name)
+          [
+            ["def #{name}", "  @#{name}", "end"],
+            ["def #{name}=(value)", "  @#{name} = value", "end"],
+          ]
+        end
+
+        # Singleton accessors stay flat in the class body; skip the ones
+        # the class overrides itself.
+        def singleton_accessor_defs(name, overrides)
           defs = []
-          defs << ["def #{name}", "  @#{name}", "end"] unless overrides.key?([false, name])
-          defs << ["def #{name}=(value)", "  @#{name} = value", "end"] unless overrides.key?([false, "#{name}="])
           defs << ["def self.#{name}", "  @#{name}", "end"] unless overrides.key?([true, name])
           defs << ["def self.#{name}=(value)", "  @#{name} = value", "end"] unless overrides.key?([true, "#{name}="])
           defs

--- a/lib/rbs_infer/lexical_scope.rb
+++ b/lib/rbs_infer/lexical_scope.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module RbsInfer
+  # Tracks the lexical class/module nesting of a Prism visitor so members
+  # and defs can be attributed to the nested module that owns them
+  # (felixefelip/rbs_infer#22). Shared by ClassMemberCollector and
+  # DefCollector to keep their owner computation identical.
+  #
+  # Owner is computed relative to the TARGET scope (`scope_target`, the
+  # fully-qualified name being generated) — NOT the outermost class. This
+  # matters when the target is itself nested: for `class User; module
+  # Idade; ...` with target `User::Idade`, the `User` wrapper is a
+  # namespace (not the primary), so `Idade`'s methods are direct members
+  # (owner nil), not owned by a nested module. When `scope_target` is nil
+  # or absent from the tree, nothing is owned (flat — safe default for
+  # caller files and any consumer that doesn't need ownership).
+  module LexicalScope
+    attr_accessor :scope_target
+
+    def scope_stack
+      @scope_stack ||= []
+    end
+
+    def push_scope(kind, name)
+      parent_path = scope_stack.last && scope_stack.last[:path]
+      path = name ? [parent_path, name].compact.join("::") : parent_path
+      scope_stack.push({ kind: kind, name: name, path: path })
+    end
+
+    def pop_scope
+      scope_stack.pop
+    end
+
+    # The nested-module path owning members at the current position
+    # (relative to the target scope), or nil for direct members of the
+    # target / positions outside it.
+    def current_owner
+      target = scope_target&.sub(/\A::/, "")
+      return nil unless target
+
+      target_idx = scope_stack.index { |f| f[:path] == target }
+      return nil unless target_idx
+
+      mods = scope_stack[(target_idx + 1)..].select { |f| f[:kind] == :module && f[:name] }
+      mods.empty? ? nil : mods.map { |f| f[:name] }.join("::")
+    end
+  end
+end

--- a/lib/rbs_infer/rbs_builder.rb
+++ b/lib/rbs_infer/rbs_builder.rb
@@ -45,14 +45,20 @@ module RbsInfer
         lines << "#{member_indent}include #{mod[:name]}"
       end
 
+      # Módulos aninhados definidos no corpo da classe-alvo
+      # (felixefelip/rbs_infer#22). Membros coletados com `owner` vêm de
+      # um `module X ... end` dentro da classe; reconstruímos o container
+      # aqui em vez de achatá-los (o que deixaria o `include X` pendurado).
+      emit_parsed_nested_modules(lines, members, member_indent, attr_types, method_param_types)
+
       # Emitir extend para módulos estendidos (e.g. ActiveSupport::Concern)
-      extends = members.select { |m| m.kind == :extend }
+      extends = members.select { |m| m.kind == :extend && m.owner.nil? }
       extends.each do |ext|
         lines << "#{member_indent}extend #{qualify(ext.name)}"
       end
 
       # Emitir include/extend para módulos incluídos (concerns)
-      includes = members.select { |m| m.kind == :include }
+      includes = members.select { |m| m.kind == :include && m.owner.nil? }
       includes.each do |inc|
         qualified = qualify(inc.name)
         lines << "#{member_indent}include #{qualified}"
@@ -66,7 +72,7 @@ module RbsInfer
       has_protected = members.any? { |m| m.visibility == :protected }
 
       # Emitir métodos de classe (def self.foo)
-      class_methods = members.select { |m| m.kind == :class_method }
+      class_methods = members.select { |m| m.kind == :class_method && m.owner.nil? }
       class_methods.each do |member|
         sig = member.signature
         # Param types inferred from call-sites also apply to singletons
@@ -81,7 +87,7 @@ module RbsInfer
       # Agrupar por visibilidade: public -> protected -> private
       # RBS não suporta `protected`, então tratamos como public
       [:public, :protected, :private].each do |vis|
-        vis_members = members.select { |m| m.visibility == vis && ![:include, :extend, :class_method].include?(m.kind) }
+        vis_members = members.select { |m| m.visibility == vis && m.owner.nil? && ![:include, :extend, :class_method].include?(m.kind) }
         next if vis_members.empty?
 
         if vis == :private
@@ -91,30 +97,13 @@ module RbsInfer
         end
 
         vis_members.each do |member|
-          case member.kind
-          when :method
-            # Generated instance accessors live in the nested module, not
-            # flat (felixefelip/rbs_infer#19). Overrides are excluded from
-            # the skip set, so they stay flat and `super` reaches the
-            # module version.
-            next if skip_instance_methods.include?(member.name)
-            sig = member.signature
-            # Substituir initialize com tipos inferidos dos call-sites
-            if member.name == "initialize" && !init_arg_types.empty?
-              sig = apply_inferred_init_types(sig, init_arg_types, optional_params)
-            elsif method_param_types[member.name]
-              sig = apply_inferred_param_types(sig, method_param_types[member.name])
-            end
-            lines << "#{member_indent}def #{sig}"
-          when :attr_accessor, :attr_reader, :attr_writer
-            sig = member.signature
-            # Se o attr está untyped, tentar preencher via inferência do initialize
-            if sig.end_with?(": untyped") && attr_types[member.name]
-              sig = "#{member.name}: #{attr_types[member.name]}"
-            end
-            prefix = member.kind.to_s.sub("_", "_")
-            lines << "#{member_indent}#{member.kind} #{sig}"
-          end
+          # Generated instance accessors live in the nested module, not
+          # flat (felixefelip/rbs_infer#19). Overrides are excluded from
+          # the skip set, so they stay flat and `super` reaches the
+          # module version.
+          next if member.kind == :method && skip_instance_methods.include?(member.name)
+          line = render_value_member(member, member_indent, init_arg_types, attr_types, method_param_types, optional_params)
+          lines << line if line
         end
       end
 
@@ -144,6 +133,57 @@ module RbsInfer
     end
 
     private
+
+    # Renders a single value member (method / attr_*) as one RBS line, or
+    # nil for other kinds. Shared between the class body and nested-module
+    # emission (felixefelip/rbs_infer#22).
+    def render_value_member(member, indent, init_arg_types, attr_types, method_param_types, optional_params)
+      case member.kind
+      when :method
+        sig = member.signature
+        if member.name == "initialize" && !init_arg_types.empty?
+          sig = apply_inferred_init_types(sig, init_arg_types, optional_params)
+        elsif method_param_types[member.name]
+          sig = apply_inferred_param_types(sig, method_param_types[member.name])
+        end
+        "#{indent}def #{sig}"
+      when :attr_accessor, :attr_reader, :attr_writer
+        sig = member.signature
+        sig = "#{member.name}: #{attr_types[member.name]}" if sig.end_with?(": untyped") && attr_types[member.name]
+        "#{indent}#{member.kind} #{sig}"
+      end
+    end
+
+    # Reconstructs `module X ... end` blocks for members collected with an
+    # `owner` (parsed from a nested module inside the target class). The
+    # parsed `include X` is emitted separately as a direct member, so the
+    # module declaration here gives that include a real target — no
+    # dangling mixin (felixefelip/rbs_infer#22).
+    def emit_parsed_nested_modules(lines, members, member_indent, attr_types, method_param_types)
+      owned = members.reject { |m| m.owner.nil? }
+      return if owned.empty?
+
+      owned.group_by(&:owner).each do |owner, mod_members|
+        inner_indent = member_indent + "  "
+        lines << "#{member_indent}module #{owner}"
+
+        mod_members.select { |m| m.kind == :include }.each do |inc|
+          lines << "#{inner_indent}include #{qualify(inc.name)}"
+        end
+        mod_members.select { |m| m.kind == :extend }.each do |ext|
+          lines << "#{inner_indent}extend #{qualify(ext.name)}"
+        end
+        mod_members.select { |m| m.kind == :class_method }.each do |m|
+          lines << "#{inner_indent}def self.#{m.signature}"
+        end
+        mod_members.each do |m|
+          line = render_value_member(m, inner_indent, {}, attr_types, method_param_types, Set.new)
+          lines << line if line
+        end
+
+        lines << "#{member_indent}end"
+      end
+    end
 
     def emit_marker(lines, marker, member_indent)
       override_indent = member_indent + "  "

--- a/lib/rbs_infer/rbs_builder.rb
+++ b/lib/rbs_infer/rbs_builder.rb
@@ -7,7 +7,7 @@ module RbsInfer
       @is_module = is_module
     end
 
-    def build(members, init_arg_types, attr_types, optional_params = Set.new, method_param_types = {}, ivar_types: {}, markers: [], nested_modules: [], skip_instance_methods: Set.new)
+    def build(members, init_arg_types, attr_types, optional_params = Set.new, method_param_types = {}, ivar_types: {}, markers: [])
       parts = @target_class.split("::")
       class_name = parts.pop
       modules = parts
@@ -29,26 +29,13 @@ module RbsInfer
         lines << "#{member_indent}@#{name}: #{type}"
       end
 
-      # Nested modules included into the class (e.g.
-      # `GeneratedAttributeMethods` mirroring Rails' CurrentAttributes
-      # runtime chain — instance accessors live in an included module so
-      # cross-file resolution and overrides' `super` flow through the
-      # ancestor chain. Include-only, like the runtime; singleton
-      # accessors stay flat — felixefelip/rbs_infer#19.
-      nested_modules.each do |mod|
-        lines << "#{member_indent}module #{mod[:name]}"
-        mod[:methods].each_with_index do |m, i|
-          lines << "" if i.positive?
-          lines << "#{member_indent}  def #{m[:signature]}"
-        end
-        lines << "#{member_indent}end"
-        lines << "#{member_indent}include #{mod[:name]}"
-      end
-
       # Módulos aninhados definidos no corpo da classe-alvo
       # (felixefelip/rbs_infer#22). Membros coletados com `owner` vêm de
       # um `module X ... end` dentro da classe; reconstruímos o container
       # aqui em vez de achatá-los (o que deixaria o `include X` pendurado).
+      # É por aqui que o `GeneratedAttributeMethods` do CurrentAttributes
+      # é emitido — agora vem do parsing do pseudo-source, sem o core
+      # conhecer a extensão (felixefelip/rbs_infer#19, #22).
       emit_parsed_nested_modules(lines, members, member_indent, attr_types, method_param_types)
 
       # Emitir extend para módulos estendidos (e.g. ActiveSupport::Concern)
@@ -97,11 +84,6 @@ module RbsInfer
         end
 
         vis_members.each do |member|
-          # Generated instance accessors live in the nested module, not
-          # flat (felixefelip/rbs_infer#19). Overrides are excluded from
-          # the skip set, so they stay flat and `super` reaches the
-          # module version.
-          next if member.kind == :method && skip_instance_methods.include?(member.name)
           line = render_value_member(member, member_indent, init_arg_types, attr_types, method_param_types, optional_params)
           lines << line if line
         end

--- a/lib/rbs_infer/return_type_resolver.rb
+++ b/lib/rbs_infer/return_type_resolver.rb
@@ -31,6 +31,13 @@ module RbsInfer
       # Aplicar tipos já resolvidos pelo resolver (ex: chamadas a métodos herdados)
       untyped_methods.each do |m|
         next if m.name == "initialize"
+        # Setters' return is body/assignment-specific (`obj.x = v` evaluates
+        # to the RHS, not the method's return) and is set by the owner-aware
+        # TypeMerger passes from each def's body. `known_return_types` is
+        # name-keyed, so resolving a setter here would leak a colliding
+        # setter's return (e.g. a CurrentAttributes override onto the
+        # generated module accessor) — felixefelip/rbs_infer#22.
+        next if setter_name?(m.name)
         resolved = known_return_types[m.name]
         if resolved && resolved != "untyped"
           m.signature = m.signature.sub(/-> untyped$/, "-> #{RbsParserUtil.parenthesize_union(resolved)}")
@@ -52,6 +59,7 @@ module RbsInfer
           self_types = Set.new([@target_class] + @instance_types)
 
           still_untyped.each do |m|
+            next if setter_name?(m.name)
             steep_type = steep_returns[m.name]
             if steep_type && steep_type != "untyped" && steep_type != "nil" && steep_type != "bot"
               # Instance methods returning the same class (or host class for concerns) → self
@@ -170,6 +178,11 @@ module RbsInfer
     private
 
     attr_reader :method_type_resolver
+
+    # `user=`-style writer (not `==`/`<=`/`[]=` operators).
+    def setter_name?(name)
+      name.to_s.match?(/[A-Za-z0-9_]=\z/) && !name.to_s.start_with?("[")
+    end
 
     # Singleton (`def self.X`) é coletado como `:class_method` em
     # `class_member_collector.rb` mas tem o mesmo tratamento de inferência de

--- a/lib/rbs_infer/type_merger.rb
+++ b/lib/rbs_infer/type_merger.rb
@@ -49,7 +49,7 @@ module RbsInfer
 
       # Collect mapping: [kind, method_name] -> last expression of the body
       method_last_exprs = {}
-      collector = DefCollector.new
+      collector = DefCollector.new(target_class: @target_class)
       parsed_target.tree.accept(collector)
 
       collector.defs.each do |defn|
@@ -67,7 +67,8 @@ module RbsInfer
         # avoids updating the wrong member when instance and singleton
         # share a name (e.g. expanded CurrentAttributes accessors).
         kind = defn.receiver.is_a?(Prism::SelfNode) ? :class_method : :method
-        member = members.find { |m| m.kind == kind && m.name == method_name }
+        owner = collector.owner_of(defn)
+        member = members.find { |m| m.kind == kind && m.name == method_name && m.owner == owner }
         next unless member
         next unless member.signature.end_with?("-> untyped")
         next if method_name == "initialize"
@@ -162,7 +163,8 @@ module RbsInfer
         # via the attribute-write rule.
         next if method_name == "initialize"
         kind = defn.receiver.is_a?(Prism::SelfNode) ? :class_method : :method
-        member = members.find { |m| m.kind == kind && m.name == method_name }
+        owner = collector.owner_of(defn)
+        member = members.find { |m| m.kind == kind && m.name == method_name && m.owner == owner }
         next unless member
         next unless member.signature.end_with?("-> untyped")
 

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/current.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/current.rb
@@ -9,9 +9,21 @@
 # `Current.with(user: ...)` in ProfileFormatterJob), unlocking the type
 # of the derived method `self.author_full_name`.
 class Current < ActiveSupport::CurrentAttributes
-  def user
-    @user
+  module GeneratedAttributeMethods
+    def user
+      @user
+    end
+    def user=(value)
+      @user = value
+    end
+    def author_name
+      @author_name
+    end
+    def author_name=(value)
+      @author_name = value
+    end
   end
+  include GeneratedAttributeMethods
 
   def self.user
     @user
@@ -19,14 +31,6 @@ class Current < ActiveSupport::CurrentAttributes
 
   def self.user=(value)
     @user = value
-  end
-
-  def author_name
-    @author_name
-  end
-
-  def author_name=(value)
-    @author_name = value
   end
 
   def self.author_name

--- a/spec/dummy/sig/rbs_infer/app/models/current.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/current.rbs
@@ -3,20 +3,17 @@ class Current < ActiveSupport::CurrentAttributes
   @author_name: String?
   module GeneratedAttributeMethods
     def user: () -> (User | (User & User::Validated))?
-
-    def user=: ((User | (User & User::Validated))? value) -> (User | (User & User::Validated))?
-
+    def user=: (User? value) -> (User | (User & User::Validated))?
     def author_name: () -> String?
-
     def author_name=: (String? value) -> String?
   end
   include GeneratedAttributeMethods
-  def self.user: () -> (User | (User & User::Validated) | nil)
-  def self.user=: (User? value) -> String?
+  def self.user: () -> (User | (User & User::Validated))?
+  def self.user=: (User? value) -> (User | (User & User::Validated))?
   def self.author_name: () -> String?
   def self.author_name=: (String? value) -> String?
   def self.set: (?user: (User | (User & User::Validated))?, ?author_name: String?) ?{ (untyped) -> untyped } -> untyped
   def self.with: (?user: (User & User::Validated)?, ?author_name: String?) ?{ (untyped) -> untyped } -> untyped
   def self.author_full_name: () -> String?
-  def user=: (User? value) -> String?
+  def user=: (User? value) -> String
 end

--- a/spec/expectations/expanded/current.rb
+++ b/spec/expectations/expanded/current.rb
@@ -6,9 +6,21 @@
 # `Current.with(user: ...)` in ProfileFormatterJob), unlocking the type
 # of the derived method `self.author_full_name`.
 class Current < ActiveSupport::CurrentAttributes
-  def user
-    @user
+  module GeneratedAttributeMethods
+    def user
+      @user
+    end
+    def user=(value)
+      @user = value
+    end
+    def author_name
+      @author_name
+    end
+    def author_name=(value)
+      @author_name = value
+    end
   end
+  include GeneratedAttributeMethods
 
   def self.user
     @user
@@ -16,14 +28,6 @@ class Current < ActiveSupport::CurrentAttributes
 
   def self.user=(value)
     @user = value
-  end
-
-  def author_name
-    @author_name
-  end
-
-  def author_name=(value)
-    @author_name = value
   end
 
   def self.author_name

--- a/spec/expectations/models/current.rbs
+++ b/spec/expectations/models/current.rbs
@@ -3,20 +3,17 @@ class Current < ActiveSupport::CurrentAttributes
   @author_name: String?
   module GeneratedAttributeMethods
     def user: () -> (User | (User & User::Validated))?
-
-    def user=: ((User | (User & User::Validated))? value) -> (User | (User & User::Validated))?
-
+    def user=: (User? value) -> (User | (User & User::Validated))?
     def author_name: () -> String?
-
     def author_name=: (String? value) -> String?
   end
   include GeneratedAttributeMethods
-  def self.user: () -> (User | (User & User::Validated) | nil)
-  def self.user=: (User? value) -> String?
+  def self.user: () -> (User | (User & User::Validated))?
+  def self.user=: (User? value) -> (User | (User & User::Validated))?
   def self.author_name: () -> String?
   def self.author_name=: (String? value) -> String?
   def self.set: (?user: (User | (User & User::Validated))?, ?author_name: String?) ?{ (untyped) -> untyped } -> untyped
   def self.with: (?user: (User & User::Validated)?, ?author_name: String?) ?{ (untyped) -> untyped } -> untyped
   def self.author_full_name: () -> String?
-  def user=: (User? value) -> String?
+  def user=: (User? value) -> String
 end

--- a/spec/lib/rbs_infer/analyzer_spec.rb
+++ b/spec/lib/rbs_infer/analyzer_spec.rb
@@ -846,6 +846,73 @@ RSpec.describe RbsInfer::Analyzer do
     end
   end
 
+  # ─── módulos aninhados (felixefelip/rbs_infer#22) ───────────────
+
+  describe "#generate_rbs com módulo aninhado incluído" do
+    # Carrega o RBS gerado num ambiente RBS real (com core) e resolve a
+    # classe — falha com NoMixinFoundError se houver `include` pendurado.
+    def assert_valid_rbs(rbs, class_name)
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "generated.rbs")
+        File.write(path, rbs)
+        loader = RBS::EnvironmentLoader.new
+        loader.add(path: Pathname(path))
+        env = RBS::Environment.from_loader(loader).resolve_type_names
+        expect { RBS::DefinitionBuilder.new(env: env).build_instance(RBS::TypeName.parse(class_name)) }
+          .not_to raise_error
+      end
+    end
+
+    let(:report_source) do
+      <<~RUBY
+        class Report
+          module Formatting
+            def title
+              @title
+            end
+
+            def title=(value)
+              @title = value
+            end
+          end
+          include Formatting
+
+          def header
+            title
+          end
+        end
+      RUBY
+    end
+
+    it "preserva o módulo aninhado em vez de achatar os métodos" do
+      with_temp_files("report.rb" => report_source) do |_dir, paths|
+        rbs = described_class.new(target_file: paths.first, source_files: paths).generate_rbs
+
+        expect(rbs).to include("module Formatting")
+        # métodos do módulo ficam DENTRO dele, não no corpo da classe
+        expect(rbs).to match(/module Formatting.*def title.*def title=.*end/m)
+        expect(rbs).to include("include Formatting")
+      end
+    end
+
+    it "gera RBS válido (sem include pendurado)" do
+      with_temp_files("report.rb" => report_source) do |_dir, paths|
+        rbs = described_class.new(target_file: paths.first, source_files: paths).generate_rbs
+
+        assert_valid_rbs(rbs, "::Report")
+      end
+    end
+
+    it "mantém métodos diretos da classe fora do módulo" do
+      with_temp_files("report.rb" => report_source) do |_dir, paths|
+        rbs = described_class.new(target_file: paths.first, source_files: paths).generate_rbs
+
+        # `header` é método direto de Report, não do módulo Formatting
+        expect(rbs).to match(/^  def header:/)
+      end
+    end
+  end
+
   # ─── resolve_namespace_classes ─────────────────────────────────
 
   describe "#resolve_namespace_classes (via generate_rbs)" do

--- a/spec/lib/rbs_infer/extensions/rails/current_attributes_expander_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/current_attributes_expander_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe RbsInfer::Extensions::Rails::CurrentAttributesExpander do
     RUBY
   end
 
-  it "expands attribute into the four accessors plus set/with" do
+  it "puts instance accessors in an included module and keeps singletons flat" do
     expanded = expand(<<~RUBY)
       class Current < ActiveSupport::CurrentAttributes
         attribute :user
@@ -35,13 +35,15 @@ RSpec.describe RbsInfer::Extensions::Rails::CurrentAttributesExpander do
 
     expect(expanded).to eq(<<~RUBY)
       class Current < ActiveSupport::CurrentAttributes
-        def user
-          @user
+        module GeneratedAttributeMethods
+          def user
+            @user
+          end
+          def user=(value)
+            @user = value
+          end
         end
-
-        def user=(value)
-          @user = value
-        end
+        include GeneratedAttributeMethods
 
         def self.user
           @user
@@ -95,8 +97,8 @@ RSpec.describe RbsInfer::Extensions::Rails::CurrentAttributesExpander do
       end
     RUBY
 
-    expect(expanded).to include("def user\n    @user\n  end")
-    expect(expanded).to include("def account\n    @account\n  end")
+    expect(expanded).to include("module GeneratedAttributeMethods")
+    expect(expanded).to match(/module GeneratedAttributeMethods.*def user\b.*def account\b.*end/m)
     expect(expanded).to include("def self.set(user: nil, account: nil, &block)\n    @user = user\n    @account = account\n    block.call\n  end")
   end
 
@@ -134,8 +136,11 @@ RSpec.describe RbsInfer::Extensions::Rails::CurrentAttributesExpander do
     expect(expanded).to include("@counter = 0")
   end
 
-  it "skips accessors the class body overrides and desugars their super" do
-    # Padrão dos Rails guides: override do setter chamando super.
+  it "generates the module accessor (super target) and desugars the override's super" do
+    # Rails-guides pattern: setter override calling super. The generated
+    # instance accessor lives in the module (the override's `super` target
+    # at runtime); the override stays in the class body with its `super`
+    # desugared to the ivar write so rbs_infer can infer its body.
     expanded = expand(<<~RUBY)
       class Current < ActiveSupport::CurrentAttributes
         attribute :user, :caderneta
@@ -150,15 +155,13 @@ RSpec.describe RbsInfer::Extensions::Rails::CurrentAttributesExpander do
       end
     RUBY
 
-    # O setter de instância NÃO é gerado (a classe define o seu)...
-    expect(expanded.scan(/def user=/).length).to eq(1)
-    # ...e o super vira o write de ivar (o accessor gerado É o ivar write)
-    expect(expanded).to include("def user=(value)\n    @user = value\n")
+    # Two `user=`: the generated one in the module + the class override.
+    expect(expanded.scan(/def user=\(value\)/).length).to eq(2)
+    # The override's `super` becomes the ivar write (no dangling super).
     expect(expanded).not_to include("super")
-    # Os demais accessors continuam gerados
-    expect(expanded).to include("def user\n    @user\n  end")
+    # All instance accessors are generated in the module.
+    expect(expanded).to match(/module GeneratedAttributeMethods.*def user\b.*def caderneta\b.*end/m)
     expect(expanded).to include("def self.user=(value)")
-    expect(expanded).to include("def caderneta=(value)")
     expect(Prism.parse(expanded).success?).to be(true)
   end
 


### PR DESCRIPTION
Closes #22. Também resolve o acoplamento gem-specific no core que motivou a investigação (`Analyzer` chamava `Extensions::Rails::CurrentAttributesExpander` direto).

## O bug (#22)

Classe Ruby comum com módulo inline incluído gerava **RBS inválido** — os coletores flat achatavam os métodos do módulo na classe e emitiam um `include` pendurado:

```ruby
class Report
  module Formatting
    def title; @title; end
  end
  include Formatting
end
```
→ gerava `include Formatting` mas **sem** `module Formatting` → `RBS::NoMixinFoundError: Could not find mixin: Formatting`.

## A correção (suporte genérico a módulo aninhado)

- `Member` ganha `owner` opcional (caminho do módulo aninhado; nil = membro direto — default preserva todo output existente).
- `LexicalScope` (mixin compartilhado pelos dois coletores) computa o owner relativo ao **target**, não à classe externa — então `class User; module Idade` gerado como `User::Idade` mantém os métodos de Idade como diretos, enquanto `class Current; module GeneratedAttributeMethods` faz o módulo dono dos accessors.
- `ClassMemberCollector` é nesting-aware (escopo + visibilidade por módulo); `RbsBuilder` reconstrói `module X ... end` a partir dos membros com owner (`emit_parsed_nested_modules`), dando ao `include X` parseado um alvo real.
- Fixture PORO test-first pina a capacidade geral (módulo preservado, RBS carrega no `RBS::DefinitionBuilder` sem `NoMixinFoundError`), independente de qualquer extensão.

## Decoupling do core (a dor que você apontou)

Com módulo aninhado suportado genericamente, o `CurrentAttributesExpander` agora emite `module GeneratedAttributeMethods ... include` no **pseudo-source**, e o core deixou de ter caso especial:

- Removido `Analyzer#generated_accessor_module` + toda referência a `Extensions::Rails::...`.
- Removidos os params `nested_modules:`/`skip_instance_methods:` do builder (o caminho parseado os substitui).
- `grep Extensions:: lib/rbs_infer/{analyzer,rbs_builder,type_merger,return_type_resolver,class_member_collector,def_collector}.rb` → **vazio**.

## Correlação owner-aware (a parte que tornou isso não-trivial)

O override (`def user=; super; ...`) e o accessor gerado no módulo têm o **mesmo nome** (`user=`, owners diferentes). Sem desambiguação, o tipo do corpo de um vazava no outro via `find`-por-nome:

- `DefCollector` carrega owner por def; `TypeMerger` casa def→member por `(kind, name, owner)`.
- `ReturnTypeResolver` não resolve setters por nome (return de setter é body/assignment-specific; `known_return_types` name-keyed conflaciona setters colidentes).

## Validação

- Core agnóstico (grep vazio); PORO + Current geram RBS válido.
- App real (carteira-de-vacinacao) sob template **strict**: regenera limpo, **137 problemas — idêntico ao baseline pré-refactor** (zero regressão; `User::Idade` intacto); `rbs validate` limpo; `current.rb`/`application_controller.rb` com 0 erros.
- Geração idempotente; **unit 437/437, integração 48/48**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
