### PR TITLE
feat(current_attributes): narrow Current.* in convention views under the guard (#25)

### DIFF
--- a/lib/rbs_infer/extensions/rails/current_attributes_callbacks_generator.rb
+++ b/lib/rbs_infer/extensions/rails/current_attributes_callbacks_generator.rb
@@ -5,6 +5,7 @@ require "yaml"
 require "prism"
 require "active_support/core_ext/string/inflections"
 require_relative "before_action_scanner"
+require_relative "erb_convention_generator/view_path_naming"
 require_relative "../../param_guarded_self_writes"
 require_relative "../../rbs_parser_util"
 require_relative "../../method_type_resolver"
@@ -157,26 +158,73 @@ module RbsInfer
         # carries the `applies_self` narrowing for the same methods; the
         # Steep callbacks loader merges entries across sidecar files.
         def sidecar_yaml(populated)
-          entries = scanner.guarded_controllers.filter_map do |controller|
+          entries = scanner.guarded_controllers.flat_map do |controller|
             constants = populated.select do |p|
               p[:scope] == controller[:scope] && scanner.descends_from?(controller[:class_name], p[:defining_class])
             end
-            next if constants.empty?
+            next [] if constants.empty?
 
-            {
+            applies = applies_constants_map(constants)
+            # The action carries the narrowing at its entry...
+            controller_entry = {
               "class" => controller[:class_name],
-              # A constant can be populated in several attributes (the
-              # direct write + transitive ones), each with its own marker
-              # module — intersect them all, else only one would narrow.
-              "applies_constants" => constants.group_by { |c| c[:const_name] }.transform_values do |cs|
-                markers = cs.map { |c| "#{c[:const_name]}::#{marker_name(c)}" }.uniq
-                (["singleton(#{cs.first[:const_name]})"] + markers).join(" & ")
-              end,
+              "applies_constants" => applies,
               "runs_before" => controller[:actions],
             }
+            # ...and the convention view each guarded action renders sees
+            # the same populated Current at its top-level body (the ERB
+            # class has no method, so `toplevel: true` — felixefelip/steep#42).
+            [controller_entry] + erb_view_entries(controller[:class_name], controller[:actions], applies)
           end
 
           { "version" => 1, "callbacks" => entries }.to_yaml
+        end
+
+        # A constant can be populated in several attributes (the direct
+        # write + transitive ones), each with its own marker module —
+        # intersect them all, else only one would narrow.
+        def applies_constants_map(constants)
+          constants.group_by { |c| c[:const_name] }.transform_values do |cs|
+            markers = cs.map { |c| "#{c[:const_name]}::#{marker_name(c)}" }.uniq
+            (["singleton(#{cs.first[:const_name]})"] + markers).join(" & ")
+          end
+        end
+
+        # One `toplevel: true` entry per guarded action whose convention
+        # view exists. Sound for convention views (rendered by that single
+        # action). NOT emitted for partials/layouts (no single rendering
+        # action) nor checked against explicit cross-renders by an
+        # unguarded action — same heterogeneous-render scope as the issue.
+        def erb_view_entries(controller_class, actions, applies)
+          actions.filter_map do |action|
+            erb_class = erb_view_class(controller_class, action)
+            next unless erb_class
+
+            # Fresh hash per entry — sharing `applies` would serialize as a
+            # YAML alias.
+            { "class" => erb_class, "applies_constants" => applies.dup, "toplevel" => true }
+          end
+        end
+
+        # Convention view class for `Controller#action`, or nil when no
+        # template file exists. `AdminUsersController#show` → app/views/
+        # admin_users/show.html.erb → "ERBAdminUsersShow".
+        def erb_view_class(controller_class, action)
+          path = controller_class.sub(/Controller\z/, "").underscore
+          return nil if path.empty?
+
+          fmt = %w[html turbo_stream].find do |f|
+            File.exist?(File.join(app_dir, "app/views", path, "#{action}.#{f}.erb"))
+          end
+          return nil unless fmt
+
+          view_path_naming.erb_class_name("#{path}/#{action}.#{fmt}.erb")
+        end
+
+        # Stateless holder for `ViewPathNaming#erb_class_name` (view path →
+        # ERB class name), reused without dragging in the ERB generator.
+        def view_path_naming
+          @view_path_naming ||= Object.new.extend(ErbConventionGenerator::ViewPathNaming)
         end
 
         def marker_name(constant)

--- a/spec/lib/rbs_infer/extensions/rails/current_attributes_callbacks_generator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/current_attributes_callbacks_generator_spec.rb
@@ -70,6 +70,43 @@ RSpec.describe RbsInfer::Extensions::Rails::CurrentAttributesCallbacksGenerator 
     ])
     # No applies_self — self-narrowing belongs to the Devise sidecar
     expect(sidecar["callbacks"].first).not_to have_key("applies_self")
+    # No view file written for `index` → no ERB toplevel entry.
+    expect(sidecar["callbacks"].none? { |e| e["toplevel"] }).to be(true)
+  end
+
+  it "emits a toplevel ERB entry for the convention view of a guarded action" do
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "app/controllers"))
+      File.write(File.join(dir, "app/controllers/application_controller.rb"), APP_CONTROLLER)
+      File.write(File.join(dir, "app/controllers/posts_controller.rb"), <<~RUBY)
+        class PostsController < ApplicationController
+          def show; end
+          def new; end
+        end
+      RUBY
+      # Only `show` has a convention view; `new` has none.
+      FileUtils.mkdir_p(File.join(dir, "app/views/posts"))
+      File.write(File.join(dir, "app/views/posts/show.html.erb"), "<%= Current.user %>\n")
+
+      scanner = RbsInfer::Extensions::Rails::BeforeActionScanner.new(app_dir: dir, scopes: ["user"])
+      output_dir = File.join(dir, "sig/rbs_infer_current_attributes")
+      described_class.new(
+        app_dir: dir, output_dir: output_dir, scanner: scanner,
+        resource_types: { "user" => "(User & User::Validated)" }, source_files: []
+      ).generate_all
+
+      sidecar = YAML.safe_load(File.read(File.join(output_dir, ".steep_callbacks.yml")))
+
+      expect(sidecar["callbacks"]).to include(
+        {
+          "class" => "ERBPostsShow",
+          "applies_constants" => { "Current" => "singleton(Current) & Current::UserPopulated" },
+          "toplevel" => true,
+        }
+      )
+      # `new` has no template → no ERB entry for it.
+      expect(sidecar["callbacks"].any? { |e| e["class"] == "ERBPostsNew" }).to be(false)
+    end
   end
 
   describe "transitive population through the setter override" do


### PR DESCRIPTION
Closes #25 (lado rbs_infer). Par do felixefelip/steep#42 (lado-Steep).

## Contexto

O narrowing de CurrentAttributes (#24) prova `Current.*` não-nil **dentro de actions guardadas**, mas não alcançava as **views** que essas actions renderizam — `Current.caderneta` numa view guardada continuava nilável. Views ERB são checadas como código top-level (`# @type self: ERBClass`), sem método pra ancorar o `applies_constants`; o fork do Steep ganhou `toplevel: true` pra isso (#42). Este PR é o emissor.

## Mudança

O `CurrentAttributesCallbacksGenerator` agora emite, junto com a entry de cada action guardada, uma entry `toplevel: true` pra **view de convenção** de cada action guardada — reusando o mapeamento view↔classe do `ViewPathNaming`. A view carrega os mesmos markers intersectados da action:

```yaml
- class: ERBCadernetaShow
  applies_constants:
    Current: "singleton(Current) & Current::UserPopulated & Current::CadernetaPopulated"
  toplevel: true
```

## Soundness

- **Emitido** só pra views de convenção (renderizadas por aquela única action) cujo template existe.
- **Não emitido** pra partials/layouts (sem action renderizadora única), nem verificado contra cross-render explícito por uma action não-guardada — o mesmo escopo de "render heterogêneo" que a issue pôs de lado.
- Cada entry ERB tem seu próprio hash `applies_constants` (YAML sem aliases).

## Validação no app (com steep#42)

`caderneta/show.html.erb` e `sugestoes/index.html.erb` — leituras de `Current.*` narrowam (steep **132 → 130**). O partial `_doses.html.erb` permanece (fora de escopo). `caderneta/show.html.erb:1 notice` que sobra é helper não-declarado, não-relacionado.

## Testes

- Gerador: entry `toplevel` emitida pra view de convenção de action guardada; **não** emitida pra action sem template; sidecar sem aliases. 7/7 no arquivo.
- Suíte: 452 unit + 48 integração.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
