### PR TITLE
feat(current_attributes): narrow Current.* in partials via render-graph reachability

### DIFF
--- a/lib/rbs_infer/extensions/rails/current_attributes_callbacks_generator.rb
+++ b/lib/rbs_infer/extensions/rails/current_attributes_callbacks_generator.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 require "fileutils"
+require "set"
 require "yaml"
 require "prism"
 require "active_support/core_ext/string/inflections"
 require_relative "before_action_scanner"
+require_relative "partial_render_graph"
 require_relative "erb_convention_generator/view_path_naming"
 require_relative "../../param_guarded_self_writes"
 require_relative "../../rbs_parser_util"
@@ -154,39 +156,72 @@ module RbsInfer
         end
 
         # One constants-only entry per guarded controller that descends
-        # from the populating handler's class. The Devise-side sidecar
-        # carries the `applies_self` narrowing for the same methods; the
-        # Steep callbacks loader merges entries across sidecar files.
+        # from the populating handler's class, plus the `toplevel: true`
+        # entries for every ERB context (convention view or partial) reached
+        # only through those guarded actions. The Devise-side sidecar carries
+        # the `applies_self` narrowing for the same methods; the Steep
+        # callbacks loader merges entries across sidecar files.
         def sidecar_yaml(populated)
-          entries = scanner.guarded_controllers.flat_map do |controller|
-            constants = populated.select do |p|
-              p[:scope] == controller[:scope] && scanner.descends_from?(controller[:class_name], p[:defining_class])
-            end
-            next [] if constants.empty?
+          # Canonical marker order (direct writes before transitive) so every
+          # stringified intersection lists markers the same way.
+          @marker_order = populated.map { |c| marker_fqn(c) }.uniq
+          facts = guarded_controller_facts(populated)
 
-            applies = applies_constants_map(constants)
+          controller_entries = facts.flat_map do |fact|
+            applies = stringify_set_map(fact[:set_map])
+            controller = fact[:controller]
             # The action carries the narrowing at its entry...
             controller_entry = {
               "class" => controller[:class_name],
               "applies_constants" => applies,
               "runs_before" => controller[:actions],
             }
-            # ...and the convention view each guarded action renders sees
-            # the same populated Current at its top-level body (the ERB
-            # class has no method, so `toplevel: true` — felixefelip/steep#42).
+            # ...and the convention view each guarded action renders sees the
+            # same populated Current at its top-level body (the ERB class has
+            # no method, so `toplevel: true` — felixefelip/steep#42).
             [controller_entry] + erb_view_entries(controller[:class_name], controller[:actions], applies)
           end
 
+          entries = controller_entries + partial_toplevel_entries(facts)
           { "version" => 1, "callbacks" => entries }.to_yaml
         end
 
-        # A constant can be populated in several attributes (the direct
-        # write + transitive ones), each with its own marker module —
-        # intersect them all, else only one would narrow.
-        def applies_constants_map(constants)
+        # Guarded controllers that descend from a populating handler, each
+        # paired with the marker set it proves present.
+        # => [{ controller:, set_map: { const => Set[marker_fqn] } }, ...]
+        def guarded_controller_facts(populated)
+          scanner.guarded_controllers.filter_map do |controller|
+            constants = populated.select do |p|
+              p[:scope] == controller[:scope] && scanner.descends_from?(controller[:class_name], p[:defining_class])
+            end
+            next if constants.empty?
+
+            { controller: controller, set_map: marker_set_map(constants) }
+          end
+        end
+
+        # A constant can be populated in several attributes (the direct write
+        # + transitive ones), each with its own marker module. Represent the
+        # narrowing as a per-constant SET of marker FQNs so it can be
+        # intersected across render sites before being stringified.
+        def marker_set_map(constants)
           constants.group_by { |c| c[:const_name] }.transform_values do |cs|
-            markers = cs.map { |c| "#{c[:const_name]}::#{marker_name(c)}" }.uniq
-            (["singleton(#{cs.first[:const_name]})"] + markers).join(" & ")
+            cs.map { |c| marker_fqn(c) }.uniq.to_set
+          end
+        end
+
+        def marker_fqn(constant)
+          "#{constant[:const_name]}::#{marker_name(constant)}"
+        end
+
+        # { const => Set[marker_fqn] } => { const => "singleton(C) & C::M1 & …" },
+        # markers ordered canonically. Empty markers yield no key.
+        def stringify_set_map(set_map)
+          set_map.each_with_object({}) do |(const_name, markers), acc|
+            next if markers.empty?
+
+            ordered = markers.to_a.sort_by { |m| @marker_order.index(m) || Float::INFINITY }
+            acc[const_name] = (["singleton(#{const_name})"] + ordered).join(" & ")
           end
         end
 
@@ -210,6 +245,13 @@ module RbsInfer
         # template file exists. `AdminUsersController#show` → app/views/
         # admin_users/show.html.erb → "ERBAdminUsersShow".
         def erb_view_class(controller_class, action)
+          vr = convention_view_relative(controller_class, action)
+          vr && view_path_naming.erb_class_name(vr)
+        end
+
+        # View-relative path of `Controller#action`'s convention template
+        # ("admin_users/show.html.erb"), or nil when none exists.
+        def convention_view_relative(controller_class, action)
           path = controller_class.sub(/Controller\z/, "").underscore
           return nil if path.empty?
 
@@ -218,7 +260,76 @@ module RbsInfer
           end
           return nil unless fmt
 
-          view_path_naming.erb_class_name("#{path}/#{action}.#{fmt}.erb")
+          "#{path}/#{action}.#{fmt}.erb"
+        end
+
+        # `toplevel: true` entries for partials proven reachable ONLY through
+        # guard-covered render sites (felixefelip/rbs_infer#25). Bails on the
+        # whole set when the app has any unresolvable dynamic render — the
+        # graph can't then be proven complete (see PartialRenderGraph).
+        def partial_toplevel_entries(facts)
+          graph = PartialRenderGraph.new(app_dir: app_dir).build
+          return [] if graph.dynamic?
+
+          covered = covered_partials(graph, convention_view_seed(facts))
+          covered.sort.map do |view_relative, set_map|
+            {
+              "class" => view_path_naming.erb_class_name(view_relative),
+              "applies_constants" => stringify_set_map(set_map),
+              "toplevel" => true,
+            }
+          end
+        end
+
+        # Seed of the reachability fixpoint: each guarded action's convention
+        # view (the file it renders) mapped to that action's proven markers.
+        # => { "caderneta/index.html.erb" => { const => Set[marker_fqn] } }
+        def convention_view_seed(facts)
+          facts.each_with_object({}) do |fact, seed|
+            fact[:controller][:actions].each do |action|
+              vr = convention_view_relative(fact[:controller][:class_name], action)
+              seed[vr] = fact[:set_map] if vr
+            end
+          end
+        end
+
+        # Fixpoint over the render graph: a partial is covered iff it isn't
+        # rendered externally (controller/layout) and ALL of its render sites
+        # are themselves covered — its markers are the intersection across
+        # those sites. Partials in an uncovered cycle never enter `covered`.
+        # => { partial_file_view_relative => { const => Set[marker_fqn] } }
+        def covered_partials(graph, seed)
+          covered = seed.dup
+
+          loop do
+            progressed = false
+            graph.partial_files.each do |partial_key, view_relative|
+              next if covered.key?(view_relative) || graph.external.include?(partial_key)
+
+              sites = graph.renderers_of(partial_key)
+              site_maps = sites.map { |s| covered[s] }
+              next if sites.empty? || site_maps.any?(&:nil?)
+
+              merged = intersect_set_maps(site_maps)
+              next if merged.empty?
+
+              covered[view_relative] = merged
+              progressed = true
+            end
+            break unless progressed
+          end
+
+          covered.reject { |view_relative, _| seed.key?(view_relative) }
+        end
+
+        # Per-constant intersection of marker sets: a constant survives only
+        # if every site narrows it, with the markers common to all sites.
+        def intersect_set_maps(maps)
+          common_consts = maps.map(&:keys).reduce(:&) || []
+          common_consts.each_with_object({}) do |const_name, acc|
+            markers = maps.map { |m| m[const_name] }.reduce(:&)
+            acc[const_name] = markers unless markers.empty?
+          end
         end
 
         # Stateless holder for `ViewPathNaming#erb_class_name` (view path →

--- a/lib/rbs_infer/extensions/rails/partial_render_graph.rb
+++ b/lib/rbs_infer/extensions/rails/partial_render_graph.rb
@@ -109,7 +109,10 @@ module RbsInfer
 
             layout ? @external << key : @edges[view_relative] << key
           end
-        rescue StandardError
+        rescue SystemCallError
+          # Couldn't read the view file (the only non-bug error here — parse
+          # failures surface via `success?`, not exceptions). A view we can't
+          # read could hide a render → bail conservatively.
           @dynamic = true
         end
 
@@ -120,8 +123,11 @@ module RbsInfer
             key = render_key(target, nil)
             @external << key if key
           end
-        rescue StandardError
-          nil
+        rescue SystemCallError
+          # Couldn't read the file → we may have missed an `external` mark that
+          # keeps a partial uncovered. Bail rather than risk narrowing a
+          # partial that's actually reachable without the guard.
+          @dynamic = true
         end
 
         # Resolves a yielded render target to a partial key, or nil to skip.
@@ -199,8 +205,6 @@ module RbsInfer
         def erb_to_ruby(erb_source)
           require "herb"
           Herb.extract_ruby(erb_source, comments: true)
-        rescue StandardError
-          nil
         end
       end
     end

--- a/lib/rbs_infer/extensions/rails/partial_render_graph.rb
+++ b/lib/rbs_infer/extensions/rails/partial_render_graph.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require "prism"
+
+module RbsInfer
+  module Extensions
+    module Rails
+      # Builds the static render graph for partials (felixefelip/rbs_infer#25):
+      # which ERB view/partial renders which html/turbo_stream partial. Used
+      # to decide whether a partial is reachable ONLY from guard-covered
+      # contexts, so its `Current.*` reads can be narrowed soundly.
+      #
+      # Conservative on completeness — `dynamic?` is set (the consumer must
+      # then narrow NO partial) when the render surface can't be proven
+      # complete:
+      #   - a render whose partial target isn't a literal string
+      #     (`render partial: var`, `render @collection`, `render method`);
+      #   - a view that fails to convert/parse;
+      #   - an alternative HTML template language we can't parse
+      #     (`.haml`/`.slim`) — it could render an html partial unseen.
+      # A partial rendered from a controller, layout, helper or component is
+      # marked `external` (no single guarded action covers it → uncovered).
+      #
+      # Known boundary (not modeled): a partial reached via a *receivered*
+      # render — `SomeController.render(partial:)` / `render_to_string` from a
+      # job or service. Those run without the request guard; they're rare and
+      # left out so unrelated `obj.render(...)` calls don't trip the bail.
+      class PartialRenderGraph
+        # Ruby surfaces where a bare `render` renders a view partial.
+        RUBY_RENDER_DIRS = %w[controllers helpers components].freeze
+
+        # renderer view-relative ("caderneta/index.html.erb") => Set of
+        # partial keys ("caderneta/doses") it renders.
+        attr_reader :edges
+        # partial keys rendered from a controller, layout, helper or component
+        # (→ uncovered: no single guarded action covers them).
+        attr_reader :external
+        # true when the render surface can't be proven complete.
+        attr_reader :dynamic
+        # partial key ("caderneta/doses") => its file view-relative
+        # ("caderneta/_doses.html.erb"). The renderer-side node identity, so
+        # a partial that itself renders other partials is found by key.
+        attr_reader :partial_files
+
+        def initialize(app_dir:)
+          @app_dir = app_dir
+          @edges = Hash.new { |h, k| h[k] = Set.new }
+          @external = Set.new
+          @partial_files = {}
+          @dynamic = false
+        end
+
+        def dynamic? = @dynamic
+
+        # File view-relative of `partial_key`, or nil if no partial file was
+        # found for it (rendered but missing → nothing to narrow).
+        def file_for(partial_key) = @partial_files[partial_key]
+
+        # Renderer view-relatives ("caderneta/index.html.erb", …) that render
+        # `partial_key`.
+        def renderers_of(partial_key)
+          @edges.each_with_object([]) do |(renderer, targets), acc|
+            acc << renderer if targets.include?(partial_key)
+          end
+        end
+
+        def build
+          # An HTML template language we can't parse could render an html
+          # partial we'd never see → can't prove completeness.
+          @dynamic = true if Dir[File.join(@app_dir, "app/views/**/*.{haml,slim}")].any?
+
+          Dir[File.join(@app_dir, "app/views/**/*.{html,turbo_stream}.erb")].sort.each do |erb_path|
+            view_relative = erb_path.sub("#{@app_dir}/", "").sub(%r{\Aapp/views/}, "")
+            scan_view(erb_path, view_relative)
+          end
+
+          RUBY_RENDER_DIRS.each do |dir|
+            Dir[File.join(@app_dir, "app", dir, "**/*.rb")].sort.each { |path| scan_ruby(path) }
+          end
+
+          self
+        end
+
+        private
+
+        def scan_view(erb_path, view_relative)
+          record_partial_file(view_relative)
+
+          ruby = erb_to_ruby(File.read(erb_path))
+          # An ERB template compiles into a method body, so `<%= yield %>` and
+          # friends are valid only inside one — wrap before parsing, else a
+          # plain layout would spuriously fail and bail. A genuinely broken
+          # template still fails to parse.
+          parsed = ruby && Prism.parse("def __erb__\n#{ruby}\nend\n")
+          # A view we can't convert/parse could hide a render → can't prove
+          # the graph complete, so bail globally.
+          if parsed.nil? || !parsed.success?
+            @dynamic = true
+            return
+          end
+
+          caller_dir = File.dirname(view_relative)
+          caller_dir = nil if caller_dir == "."
+          layout = view_relative.start_with?("layouts/")
+
+          each_render(parsed.value) do |target|
+            key = render_key(target, caller_dir)
+            next unless key
+
+            layout ? @external << key : @edges[view_relative] << key
+          end
+        rescue StandardError
+          @dynamic = true
+        end
+
+        # A bare `render` in controller/helper/component ruby isn't covered by
+        # a single guarded action → mark its partial external (uncovered).
+        def scan_ruby(path)
+          each_render(Prism.parse(File.read(path)).value) do |target|
+            key = render_key(target, nil)
+            @external << key if key
+          end
+        rescue StandardError
+          nil
+        end
+
+        # Resolves a yielded render target to a partial key, or nil to skip.
+        # `:dynamic` flips the global bail.
+        def render_key(target, caller_dir)
+          case target
+          when :dynamic
+            @dynamic = true
+            nil
+          when nil
+            nil # not a partial render (template/symbol/component)
+          else
+            resolve_partial_key(target, caller_dir)
+          end
+        end
+
+        # Yields each `render` call's partial target: a String (literal
+        # partial name), `:dynamic` (unresolvable partial render), or nil (not
+        # a partial render). Only bare `render` counts — `obj.render(...)` is
+        # an unrelated method.
+        def each_render(node, &block)
+          if node.is_a?(Prism::CallNode) && node.name == :render && node.receiver.nil?
+            yield render_target(node)
+          end
+          node.compact_child_nodes.each { |c| each_render(c, &block) }
+        end
+
+        def render_target(call)
+          args = call.arguments&.arguments
+          return nil if args.nil? || args.empty?
+
+          first = args[0]
+          # `render partial: ...` / explicit kwargs.
+          if (kw = args.find { |a| a.is_a?(Prism::KeywordHashNode) })
+            partial = kw.elements.find do |e|
+              e.is_a?(Prism::AssocNode) && e.key.is_a?(Prism::SymbolNode) && e.key.value == "partial"
+            end
+            if partial
+              return partial.value.is_a?(Prism::StringNode) ? partial.value.unescaped : :dynamic
+            end
+            # `render json:/plain:/template:/...` with no `partial:` and a
+            # non-string first arg → not a partial render.
+            return nil unless first.is_a?(Prism::StringNode)
+          end
+
+          case first
+          when Prism::StringNode then first.unescaped # render "doses"
+          when Prism::SymbolNode then nil             # render :new (template)
+          when Prism::ConstantReadNode, Prism::ConstantPathNode then nil # render Component
+          when Prism::CallNode then first.name == :new ? nil : :dynamic  # render Comp.new | render method
+          else :dynamic                               # render @x / render var (collection/object)
+          end
+        end
+
+        # "caderneta/_doses.html.erb" → records key "caderneta/doses". Only
+        # html/turbo_stream partials become narrowable nodes.
+        def record_partial_file(view_relative)
+          return unless view_relative =~ %r{/_[^/]+\.(?:html|turbo_stream)\.erb\z}
+
+          stem = File.basename(view_relative).sub(/\.(html|turbo_stream)\.erb\z/, "").sub(/\A_/, "")
+          dir = File.dirname(view_relative)
+          key = dir == "." ? stem : "#{dir}/#{stem}"
+          @partial_files[key] = view_relative
+        end
+
+        # "doses" + caller_dir "caderneta" → "caderneta/doses"; already
+        # qualified stays; nil when unresolvable without a caller dir.
+        def resolve_partial_key(name, caller_dir)
+          return name if name.include?("/")
+          return nil unless caller_dir
+
+          "#{caller_dir}/#{name}"
+        end
+
+        def erb_to_ruby(erb_source)
+          require "herb"
+          Herb.extract_ruby(erb_source, comments: true)
+        rescue StandardError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/rbs_infer/extensions/rails/current_attributes_callbacks_generator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/current_attributes_callbacks_generator_spec.rb
@@ -193,6 +193,82 @@ RSpec.describe RbsInfer::Extensions::Rails::CurrentAttributesCallbacksGenerator 
     end
   end
 
+  describe "partial narrowing via the render graph" do
+    # Guarded ApplicationController + a CadernetaController#index whose
+    # convention view renders the `_doses` partial. Optional extra files
+    # let each example introduce a dynamic/unguarded render.
+    def generate_with_views(extra: {})
+      Dir.mktmpdir do |dir|
+        FileUtils.mkdir_p(File.join(dir, "app/controllers"))
+        File.write(File.join(dir, "app/controllers/application_controller.rb"), APP_CONTROLLER)
+        File.write(File.join(dir, "app/controllers/caderneta_controller.rb"), <<~RUBY)
+          class CadernetaController < ApplicationController
+            def index; end
+          end
+        RUBY
+        files = {
+          "app/views/caderneta/index.html.erb" => "<%= render 'doses', vacina: v %>\n",
+          "app/views/caderneta/_doses.html.erb" => "<%= Current.user %>\n",
+        }.merge(extra)
+        files.each do |rel, src|
+          full = File.join(dir, rel)
+          FileUtils.mkdir_p(File.dirname(full))
+          File.write(full, src)
+        end
+
+        scanner = RbsInfer::Extensions::Rails::BeforeActionScanner.new(app_dir: dir, scopes: ["user"])
+        output_dir = File.join(dir, "sig/rbs_infer_current_attributes")
+        described_class.new(
+          app_dir: dir, output_dir: output_dir, scanner: scanner,
+          resource_types: { "user" => "(User & User::Validated)" }, source_files: []
+        ).generate_all
+        YAML.safe_load(File.read(File.join(output_dir, ".steep_callbacks.yml")))["callbacks"]
+      end
+    end
+
+    it "emits a toplevel entry for a partial rendered only from a guarded view" do
+      entries = generate_with_views
+
+      expect(entries).to include(
+        {
+          "class" => "ERBPartialCadernetaDoses",
+          "applies_constants" => { "Current" => "singleton(Current) & Current::UserPopulated" },
+          "toplevel" => true,
+        }
+      )
+    end
+
+    it "covers a partial rendered transitively (view → partial → partial)" do
+      entries = generate_with_views(extra: {
+        "app/views/caderneta/_doses.html.erb" => "<%= render 'dose_row' %>\n",
+        "app/views/caderneta/_dose_row.html.erb" => "<%= Current.user %>\n",
+      })
+
+      classes = entries.select { |e| e["toplevel"] }.map { |e| e["class"] }
+      expect(classes).to include("ERBPartialCadernetaDoses", "ERBPartialCadernetaDoseRow")
+    end
+
+    it "does NOT narrow any partial when a dynamic render exists anywhere" do
+      entries = generate_with_views(extra: {
+        "app/views/caderneta/_doses.html.erb" => "<%= render partial: dynamic_name %>\n",
+      })
+
+      # Convention-view narrowing still stands; partials are suppressed.
+      expect(entries.any? { |e| e["class"] == "ERBCadernetaIndex" }).to be(true)
+      expect(entries.any? { |e| e["class"]&.start_with?("ERBPartial") }).to be(false)
+    end
+
+    it "does NOT cover a partial also rendered from an unguarded view" do
+      entries = generate_with_views(extra: {
+        # `public/landing` belongs to no guarded controller → its render of
+        # `_doses` leaves the partial reachable without the guard.
+        "app/views/public/landing.html.erb" => "<%= render 'caderneta/doses' %>\n",
+      })
+
+      expect(entries.any? { |e| e["class"] == "ERBPartialCadernetaDoses" }).to be(false)
+    end
+  end
+
   it "writes nothing when no guarded handler populates a constant" do
     markers, sidecar = generate(
       "application_controller.rb" => <<~RUBY

--- a/spec/lib/rbs_infer/extensions/rails/partial_render_graph_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/partial_render_graph_spec.rb
@@ -156,4 +156,35 @@ RSpec.describe RbsInfer::Extensions::Rails::PartialRenderGraph do
       end
     end
   end
+
+  # A file we can't read could hide a render (or, for ruby, an `external`
+  # mark) → bail rather than risk an unsound narrowing. Only I/O failures are
+  # rescued; a bug in AST traversal must still surface.
+  describe "I/O errors degrade conservatively" do
+    def graph_with_unreadable(rel, src)
+      Dir.mktmpdir do |dir|
+        full = File.join(dir, rel)
+        FileUtils.mkdir_p(File.dirname(full))
+        File.write(full, src)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(full).and_raise(Errno::EACCES, full)
+        described_class.new(app_dir: dir).build
+      end
+    end
+
+    it "bails when a view file can't be read" do
+      g = graph_with_unreadable("app/views/posts/show.html.erb", "<%= render 'row' %>\n")
+      expect(g.dynamic?).to be(true)
+    end
+
+    it "bails when a render-source ruby file can't be read" do
+      # Regression: this used to be swallowed (`rescue => nil`), dropping the
+      # `external` mark and allowing an unsound narrowing.
+      g = graph_with_unreadable(
+        "app/controllers/posts_controller.rb",
+        "class PostsController; def show; render partial: 'posts/row'; end; end\n"
+      )
+      expect(g.dynamic?).to be(true)
+    end
+  end
 end

--- a/spec/lib/rbs_infer/extensions/rails/partial_render_graph_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/partial_render_graph_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rbs_infer/extensions/rails/partial_render_graph"
+require "tmpdir"
+require "fileutils"
+
+RSpec.describe RbsInfer::Extensions::Rails::PartialRenderGraph do
+  # Builds a graph over a tmp app whose files are { relative_path => source }.
+  def graph(files)
+    Dir.mktmpdir do |dir|
+      files.each do |rel, src|
+        full = File.join(dir, rel)
+        FileUtils.mkdir_p(File.dirname(full))
+        File.write(full, src)
+      end
+      yield described_class.new(app_dir: dir).build
+    end
+  end
+
+  it "records a shorthand `render 'doses'` edge resolved against the caller dir" do
+    graph(
+      "app/views/caderneta/index.html.erb" => "<%= render 'doses', vacina: v %>\n",
+      "app/views/caderneta/_doses.html.erb" => "<%= Current.caderneta %>\n"
+    ) do |g|
+      expect(g.dynamic?).to be(false)
+      expect(g.renderers_of("caderneta/doses")).to eq(["caderneta/index.html.erb"])
+      expect(g.file_for("caderneta/doses")).to eq("caderneta/_doses.html.erb")
+      expect(g.external).to be_empty
+    end
+  end
+
+  it "records `render partial: 'shared/menu'` with an explicit path" do
+    graph(
+      "app/views/posts/show.html.erb" => "<%= render partial: 'shared/menu' %>\n",
+      "app/views/shared/_menu.html.erb" => "x\n"
+    ) do |g|
+      expect(g.dynamic?).to be(false)
+      expect(g.renderers_of("shared/menu")).to eq(["posts/show.html.erb"])
+    end
+  end
+
+  it "captures partial→partial edges" do
+    graph(
+      "app/views/posts/show.html.erb" => "<%= render 'outer' %>\n",
+      "app/views/posts/_outer.html.erb" => "<%= render 'inner' %>\n",
+      "app/views/posts/_inner.html.erb" => "x\n"
+    ) do |g|
+      expect(g.renderers_of("posts/outer")).to eq(["posts/show.html.erb"])
+      expect(g.renderers_of("posts/inner")).to eq(["posts/_outer.html.erb"])
+    end
+  end
+
+  describe "dynamic renders (conservative completeness bail)" do
+    it "flags `render partial: variable`" do
+      graph("app/views/posts/show.html.erb" => "<%= render partial: name %>\n") do |g|
+        expect(g.dynamic?).to be(true)
+      end
+    end
+
+    it "flags `render @collection`" do
+      graph("app/views/posts/index.html.erb" => "<%= render @posts %>\n") do |g|
+        expect(g.dynamic?).to be(true)
+      end
+    end
+
+    it "flags a view it cannot parse to Ruby" do
+      graph("app/views/posts/show.html.erb" => "<%= render 'ok' %>\n<% def %>\n") do |g|
+        expect(g.dynamic?).to be(true)
+      end
+    end
+  end
+
+  describe "non-partial renders are ignored" do
+    it "ignores `render :action` (template render)" do
+      graph("app/views/posts/show.html.erb" => "<%= render :sidebar %>\n") do |g|
+        expect(g.dynamic?).to be(false)
+        expect(g.edges).to be_empty
+      end
+    end
+
+    it "ignores a ViewComponent render (`render Comp.new` / `render Comp`)" do
+      graph(
+        "app/views/posts/show.html.erb" => "<%= render PostCard.new(post) %>\n",
+        "app/views/posts/index.html.erb" => "<%= render PostCard %>\n"
+      ) do |g|
+        expect(g.dynamic?).to be(false)
+        expect(g.edges).to be_empty
+      end
+    end
+
+    it "ignores a receivered `obj.render(...)` (unrelated method)" do
+      graph("app/views/posts/show.html.erb" => "<% pdf.render 'doses' %>\n") do |g|
+        expect(g.dynamic?).to be(false)
+        expect(g.edges).to be_empty
+      end
+    end
+
+    it "ignores `render json:`/`render plain:` (no partial)" do
+      graph("app/controllers/api_controller.rb" => <<~RUBY) do |g|
+        class ApiController < ApplicationController
+          def show
+            render json: { ok: true }
+          end
+        end
+      RUBY
+        expect(g.dynamic?).to be(false)
+        expect(g.external).to be_empty
+      end
+    end
+  end
+
+  describe "external renders (no single guarded action covers them)" do
+    it "marks a partial rendered from a layout external" do
+      graph(
+        "app/views/layouts/application.html.erb" => "<%= render 'shared/flash' %>\n",
+        "app/views/shared/_flash.html.erb" => "x\n"
+      ) do |g|
+        expect(g.external).to include("shared/flash")
+        expect(g.renderers_of("shared/flash")).to be_empty
+      end
+    end
+
+    it "marks a partial rendered from a controller external" do
+      graph("app/controllers/posts_controller.rb" => <<~RUBY) do |g|
+        class PostsController < ApplicationController
+          def show
+            render partial: "posts/row"
+          end
+        end
+      RUBY
+        expect(g.external).to include("posts/row")
+      end
+    end
+
+    it "marks a partial rendered from a helper external" do
+      graph("app/helpers/posts_helper.rb" => <<~RUBY) do |g|
+        module PostsHelper
+          def widget
+            render "shared/widget"
+          end
+        end
+      RUBY
+        expect(g.external).to include("shared/widget")
+      end
+    end
+  end
+
+  describe "unparseable HTML template languages" do
+    it "bails when a .haml view exists (could render an html partial unseen)" do
+      graph(
+        "app/views/posts/show.html.erb" => "<%= render 'row' %>\n",
+        "app/views/posts/index.html.haml" => "= render 'row'\n"
+      ) do |g|
+        expect(g.dynamic?).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extends the convention-view `Current.*` narrowing from #27 to ERB **partials** (felixefelip/rbs_infer#25). A partial's `Current.*` reads are narrowed only when the partial is reachable **solely** through guard-covered render sites, proven by a static render graph.

## `PartialRenderGraph`
Maps which views/partials render which `html`/`turbo_stream` partials. **Conservative on completeness** — `dynamic?` (narrow *no* partial) trips when the render surface can't be proven complete:
- a non-literal render target (`render partial: var`, `render @collection`, `render method`);
- a view that fails to convert/parse;
- an unparseable HTML template language (`.haml`/`.slim`) that could render a partial unseen.

Partials rendered from a controller / layout / helper / component are marked `external` (no single guarded action covers them → uncovered). ViewComponents (`render Comp.new`) and receivered `obj.render(...)` are distinguished from partial renders; extracted ERB is wrapped in a method body so top-level `<%= yield %>` doesn't spuriously bail.

**Known boundary (documented):** a partial reached via a *receivered* render — `SomeController.render(partial:)` / `render_to_string` from a job/service — isn't modeled (rare, and excluded so unrelated `obj.render` calls don't trip the bail).

## Generator
A **coverage fixpoint** over the graph: a partial is covered iff it isn't external and **all** its render sites are covered, with markers **intersected** across sites (uncovered cycles never enter). Covered partials get `toplevel: true` sidecar entries for their ERB partial class. Marker handling was refactored to sets (intersectable) with a canonical-order stringifier.

## Verification
- rbs_infer suite green (14 new `PartialRenderGraph` specs, 4 new generator specs).
- Real app: a partial rendered only from a guarded convention view now resolves `Current.caderneta.<method>`. Rigorous before/after delta — Steep **130 → 129**, exactly one error removed, **zero regressions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)