### PR TITLE
feat(rails_custom): source flash accessors from rbs_rails _RbsRailsFlashHelpers

### DIFF
--- a/lib/rbs_infer/extensions/rails/custom_generator.rb
+++ b/lib/rbs_infer/extensions/rails/custom_generator.rb
@@ -38,13 +38,9 @@ module RbsInfer
           lines << ""
           lines << "  include _RbsRailsPathHelpers"
           lines << ""
-          lines << "  # Convenience accessor for <tt>flash[:alert]</tt>."
-          lines << "  def alert: () -> String"
-          lines << ""
-          lines << "  # Convenience accessor for <tt>flash[:notice]</tt>."
-          lines << ""
-          lines << "  def notice: () -> String"
-          lines << ""
+          # `notice`/`alert` (and any custom flash types) are inherited from
+          # ActionController::Base, where rbs_rails (felixefelip/rbs_rails) mixes
+          # _RbsRailsFlashHelpers — reflected from the real `_flash_types`.
           lines << "  def user_signed_in?: () -> bool"
           if kaminari_installed?
             lines << ""
@@ -119,6 +115,7 @@ module RbsInfer
           lines << "module ActionViewContext"
           lines << "  include ActionView::Helpers"
           lines << "  include _RbsRailsPathHelpers" if path_helpers_available?
+          lines << "  include _RbsRailsFlashHelpers" if flash_helpers_available?
           lines << "  include Kaminari::Helpers::HelperMethods" if kaminari_installed?
           lines << "  include ApplicationHelper"
 
@@ -134,6 +131,11 @@ module RbsInfer
         def path_helpers_available?
           path_helpers_rbs = Dir[File.join(@app_dir, "sig/**/path_helpers.rbs")].first
           path_helpers_rbs && File.read(path_helpers_rbs).include?("_RbsRailsPathHelpers")
+        end
+
+        def flash_helpers_available?
+          flash_helpers_rbs = Dir[File.join(@app_dir, "sig/**/flash_helpers.rbs")].first
+          flash_helpers_rbs && File.read(flash_helpers_rbs).include?("_RbsRailsFlashHelpers")
         end
 
         def extract_app_controller_helper_methods

--- a/spec/dummy/sig/rbs_rails/flash_helpers.rbs
+++ b/spec/dummy/sig/rbs_rails/flash_helpers.rbs
@@ -1,0 +1,12 @@
+# resolve-type-names: false
+
+interface ::_RbsRailsFlashHelpers
+  def alert: () -> ::String?
+  def notice: () -> ::String?
+end
+
+module ::ActionController
+  class ::ActionController::Base
+    include ::_RbsRailsFlashHelpers
+  end
+end

--- a/spec/expectations/controllers/application_controller.rbs
+++ b/spec/expectations/controllers/application_controller.rbs
@@ -8,13 +8,6 @@ class ApplicationController < ActionController::Base
 
   include _RbsRailsPathHelpers
 
-  # Convenience accessor for <tt>flash[:alert]</tt>.
-  def alert: () -> String
-
-  # Convenience accessor for <tt>flash[:notice]</tt>.
-
-  def notice: () -> String
-
   def user_signed_in?: () -> bool
 end
 

--- a/spec/expectations/rails_custom_action_view_context.rbs
+++ b/spec/expectations/rails_custom_action_view_context.rbs
@@ -3,6 +3,7 @@
 module ActionViewContext
   include ActionView::Helpers
   include _RbsRailsPathHelpers
+  include _RbsRailsFlashHelpers
   include ApplicationHelper
 
   def current_user: () -> (User & User::Validated)?


### PR DESCRIPTION
The view-side half of flash-accessor typing (pairs with felixefelip/rbs_rails#9).

## Problem
`notice`/`alert` (and custom flash types) are `helper_method`s registered by `ActionController::Flash#add_flash_types` — callable in both controllers and views. They were **hardcoded** on the custom `ApplicationController`, which the ERB view classes don't inherit (they `include ActionViewContext`), so `notice` was unresolved in views (`Type ::ERBLayoutsApplication does not have method notice`).

## Fix
- `ActionViewContext` now `include`s `_RbsRailsFlashHelpers` (generated by rbs_rails from the real `_flash_types`) when present — same conditional pattern already used for `_RbsRailsPathHelpers`.
- The hardcoded `notice`/`alert` are dropped from `ApplicationController`; it inherits them from `ActionController::Base` (where rbs_rails mixes the interface).

A single reflected source now resolves `notice`/`alert` in both views and controllers.

## Validation
- Integration spec (`custom_generator`) green with updated expectations.
- Real app: `notice`/`alert` resolved in views and controllers; Steep **117 → 109**, no regression.
- Unit suite: 520 examples, 0 failures.

Requires the `flash_helpers.rbs` produced by felixefelip/rbs_rails#9 (`rbs_rails all`) to be present; the `include` is conditional, so it no-ops until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)