### PR TITLE
feat(rails_custom): include all app helpers in ActionViewContext

### DIFF
--- a/lib/rbs_infer.rb
+++ b/lib/rbs_infer.rb
@@ -17,6 +17,16 @@ module RbsInfer
               .downcase
   end
 
+  # Path (sem extensão) → nome da constante, pela mesma convenção de
+  # camelização que o rbs_infer usa para nomear a classe/módulo de um arquivo
+  # (e que o Zeitwerk garante para apps Rails). Inverso conveniente de
+  # `class_name_to_path` no caso convencional.
+  #   "sugestoes_helper"   → "SugestoesHelper"
+  #   "admin/posts_helper" → "Admin::PostsHelper"
+  def self.path_to_class_name(path)
+    path.split("/").map { |segment| segment.split(/[_-]/).map(&:capitalize).join }.join("::")
+  end
+
   # Verifica se um caminho de arquivo corresponde exatamente ao path da classe,
   # evitando falsos positivos como "via_magic_link.rb" ao buscar "magic_link.rb".
   def self.file_matches_class_path?(file, class_path, ext: ".rb")

--- a/lib/rbs_infer/extensions/rails/custom_generator.rb
+++ b/lib/rbs_infer/extensions/rails/custom_generator.rb
@@ -3,6 +3,7 @@
 require "fileutils"
 require "prism"
 require "set"
+require_relative "../../../rbs_infer"
 
 module RbsInfer
   module Extensions
@@ -117,7 +118,12 @@ module RbsInfer
           lines << "  include _RbsRailsPathHelpers" if path_helpers_available?
           lines << "  include _RbsRailsFlashHelpers" if flash_helpers_available?
           lines << "  include Kaminari::Helpers::HelperMethods" if kaminari_installed?
-          lines << "  include ApplicationHelper"
+          # Rails' default `include_all_helpers` mixes every helper module into
+          # every view AND partial. ActionViewContext is included by every
+          # generated ERB context, so surfacing the helpers here is what lets a
+          # partial resolve a convention helper (e.g. SugestoesHelper) it never
+          # includes directly. (`= false` → just ApplicationHelper.)
+          app_helper_modules.each { |mod| lines << "  include #{mod}" }
 
           extract_app_controller_helper_methods.each do |name, signature|
             lines << ""
@@ -136,6 +142,33 @@ module RbsInfer
         def flash_helpers_available?
           flash_helpers_rbs = Dir[File.join(@app_dir, "sig/**/flash_helpers.rbs")].first
           flash_helpers_rbs && File.read(flash_helpers_rbs).include?("_RbsRailsFlashHelpers")
+        end
+
+        # Helper modules to mix into ActionViewContext. With Rails' default
+        # `include_all_helpers`, that's every `app/helpers/**/*.rb` module
+        # (sorted, so method-name collisions resolve deterministically);
+        # otherwise just ApplicationHelper. Names use the same path→constant
+        # convention rbs_infer applies when naming each helper's RBS, so every
+        # emitted `include` resolves to a generated module.
+        def app_helper_modules
+          return ["ApplicationHelper"] unless include_all_helpers?
+
+          helpers_root = File.join(@app_dir, "app/helpers")
+          Dir[File.join(helpers_root, "**/*.rb")].map do |path|
+            relative = path.delete_prefix("#{helpers_root}/").delete_suffix(".rb")
+            RbsInfer.path_to_class_name(relative)
+          end.sort
+        end
+
+        # `config.action_controller.include_all_helpers` defaults to true, so we
+        # only scan for an explicit opt-out under config/. A dynamic/unreadable
+        # setting falls back to the default (true).
+        def include_all_helpers?
+          Dir[File.join(@app_dir, "config/**/*.rb")].none? do |file|
+            File.read(file).match?(/\.include_all_helpers\s*=\s*false\b/)
+          end
+        rescue SystemCallError
+          true
         end
 
         def extract_app_controller_helper_methods

--- a/spec/dummy/sig/rbs_rails_custom/action_view_context.rbs
+++ b/spec/dummy/sig/rbs_rails_custom/action_view_context.rbs
@@ -3,7 +3,9 @@
 module ActionViewContext
   include ActionView::Helpers
   include _RbsRailsPathHelpers
+  include _RbsRailsFlashHelpers
   include ApplicationHelper
+  include PostsHelper
 
-  def current_user: () -> User?
+  def current_user: () -> (User & User::Validated)?
 end

--- a/spec/dummy/sig/rbs_rails_custom/application_controller.rbs
+++ b/spec/dummy/sig/rbs_rails_custom/application_controller.rbs
@@ -8,13 +8,6 @@ class ApplicationController < ActionController::Base
 
   include _RbsRailsPathHelpers
 
-  # Convenience accessor for <tt>flash[:alert]</tt>.
-  def alert: () -> String
-
-  # Convenience accessor for <tt>flash[:notice]</tt>.
-
-  def notice: () -> String
-
   def user_signed_in?: () -> bool
 end
 

--- a/spec/expectations/rails_custom_action_view_context.rbs
+++ b/spec/expectations/rails_custom_action_view_context.rbs
@@ -5,6 +5,7 @@ module ActionViewContext
   include _RbsRailsPathHelpers
   include _RbsRailsFlashHelpers
   include ApplicationHelper
+  include PostsHelper
 
   def current_user: () -> (User & User::Validated)?
 end

--- a/spec/lib/rbs_infer/extensions/rails/custom_generator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/custom_generator_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rbs_infer/extensions/rails/custom_generator"
+require "tmpdir"
+
+RSpec.describe RbsInfer::Extensions::Rails::CustomGenerator do
+  # Build a throwaway app dir with the given helper files (relative path =>
+  # source) and optional config files, run the generator, and return the
+  # generated ActionViewContext RBS.
+  def action_view_context(helpers:, config: {})
+    Dir.mktmpdir do |dir|
+      helpers.each do |rel, source|
+        path = File.join(dir, "app/helpers", rel)
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, source)
+      end
+      config.each do |rel, source|
+        path = File.join(dir, "config", rel)
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, source)
+      end
+
+      output_dir = File.join(dir, "sig/rbs_rails_custom")
+      described_class.new(output_dir: output_dir, app_dir: dir, source_files: []).generate_all
+      File.read(File.join(output_dir, "action_view_context.rbs"))
+    end
+  end
+
+  it "includes every app helper module by default (include_all_helpers on)" do
+    rbs = action_view_context(helpers: {
+      "application_helper.rb" => "module ApplicationHelper\nend\n",
+      "posts_helper.rb" => "module PostsHelper\nend\n",
+      "sugestoes_helper.rb" => "module SugestoesHelper\nend\n",
+    })
+
+    expect(rbs).to include("include ApplicationHelper")
+    expect(rbs).to include("include PostsHelper")
+    expect(rbs).to include("include SugestoesHelper")
+    expect { RBS::Parser.parse_signature(rbs) }.not_to raise_error
+  end
+
+  it "names namespaced helpers by the path -> constant convention" do
+    rbs = action_view_context(helpers: {
+      "admin/widgets_helper.rb" => "module Admin\n  module WidgetsHelper\n  end\nend\n",
+    })
+
+    expect(rbs).to include("include Admin::WidgetsHelper")
+  end
+
+  it "emits helpers sorted, for deterministic collision order" do
+    rbs = action_view_context(helpers: {
+      "posts_helper.rb" => "module PostsHelper\nend\n",
+      "application_helper.rb" => "module ApplicationHelper\nend\n",
+    })
+
+    expect(rbs.index("include ApplicationHelper")).to be < rbs.index("include PostsHelper")
+  end
+
+  it "falls back to ApplicationHelper only when include_all_helpers is disabled" do
+    rbs = action_view_context(
+      helpers: {
+        "application_helper.rb" => "module ApplicationHelper\nend\n",
+        "posts_helper.rb" => "module PostsHelper\nend\n",
+      },
+      config: {
+        "application.rb" => <<~RUBY,
+          module Dummy
+            class Application < Rails::Application
+              config.action_controller.include_all_helpers = false
+            end
+          end
+        RUBY
+      }
+    )
+
+    expect(rbs).to include("include ApplicationHelper")
+    expect(rbs).not_to include("include PostsHelper")
+  end
+end


### PR DESCRIPTION
## Problema

`ActionViewContext` — incluído por **todo** contexto ERB gerado (views completas e partials) — só mixava `ApplicationHelper`. Views completas ganham o helper de convenção do controller (ex.: `PostsHelper`) via o ERB generator, mas **partials incluem só `ActionViewContext`**. Logo, uma partial que chama um método de helper de convenção era marcada pelo Steep como indefinida.

Caso concreto: `app/views/sugestoes/_recomendacao_vacina.html.erb` chama `idade_recomendada_para` (definido em `SugestoesHelper`) → erro no Steep, embora o Rails o disponibilize em runtime.

## Correção

Modela a semântica real do Rails. Com o default `config.action_controller.include_all_helpers` (true), o Rails mixa **todo** módulo de helper em toda view e partial. Então `ActionViewContext` agora inclui todo `app/helpers/**/*.rb` (ordenado, pra colisão de nome de método resolver de forma determinística). Como é o módulo que todo contexto ERB já inclui, isso corrige views, partials e uso cross-helper de forma uniforme.

- Nomes de módulo seguem a mesma convenção path→constante que o rbs_infer usa pra nomear o RBS de cada helper (o Zeitwerk garante o casamento), então todo `include` resolve.
- Config-aware: um `include_all_helpers = false` explícito cai de volta pra só `ApplicationHelper`.
- Adiciona `RbsInfer.path_to_class_name`, o forward de `class_name_to_path`.

## Limitação conhecida

Sob `include_all_helpers = false`, partials voltam a ver só `ApplicationHelper` (views completas seguem cobertas via o ERB generator). Narrowing de partials nesse opt-out — via o partial render graph — fica como follow-up.

## Testes

- Novo `spec/lib/rbs_infer/extensions/rails/custom_generator_spec.rb`: enumeração + ordenação, helper namespaced (`Admin::WidgetsHelper`), e o fallback `include_all_helpers = false`.
- Expectation `rails_custom_action_view_context.rbs` atualizada (o `PostsHelper` do dummy agora incluído); saída real do generator contra o dummy bate exatamente.
- Suíte unit completa verde (461 examples, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)