### PR TITLE
fix(param-inference): resolve self.<association> against the refined self in call-sites

### DIFF
--- a/lib/rbs_infer/new_call_collector.rb
+++ b/lib/rbs_infer/new_call_collector.rb
@@ -126,10 +126,55 @@ module RbsInfer
 
     def match_class?(name)
       normalized_target = @target_class.sub(/\A::/, "")
-      normalized_name = name.sub(/\A::/, "")
-      # Match exato ou referência relativa (ex: Email == Academico::Aluno::Email)
-      normalized_name == normalized_target ||
-        normalized_target.end_with?("::#{normalized_name}")
+      # A marker-decorated receiver is an intersection (`Caderneta &
+      # Caderneta::Validated`); match if any component is the target.
+      intersection_components(name).any? do |component|
+        normalized_name = component.sub(/\A::/, "")
+        # Match exato ou referência relativa (ex: Email == Academico::Aluno::Email)
+        normalized_name == normalized_target ||
+          normalized_target.end_with?("::#{normalized_name}")
+      end
+    end
+
+    # Top-level components of an intersection type, respecting [] / ()
+    # nesting so generics aren't split: "Caderneta & Caderneta::Validated"
+    # → ["Caderneta", "Caderneta::Validated"]. A non-intersection type
+    # returns itself. Outer enveloping parens are stripped first.
+    def intersection_components(type_str)
+      inner = strip_enveloping_parens(type_str.strip)
+      components = []
+      depth = 0
+      buffer = +""
+      inner.each_char do |char|
+        case char
+        when "[", "(" then depth += 1; buffer << char
+        when "]", ")" then depth -= 1; buffer << char
+        when "&"
+          if depth.zero?
+            components << buffer.strip
+            buffer = +""
+          else
+            buffer << char
+          end
+        else buffer << char
+        end
+      end
+      components << buffer.strip
+      components.reject(&:empty?)
+    end
+
+    # Strips parens only when they envelop the whole string ("(A & B)" → "A &
+    # B"); leaves "(A) & (B)" untouched.
+    def strip_enveloping_parens(str)
+      return str unless str.start_with?("(") && str.end_with?(")")
+
+      depth = 0
+      str.each_char.with_index do |char, i|
+        depth += 1 if char == "("
+        depth -= 1 if char == ")"
+        return str if depth.zero? && i < str.length - 1
+      end
+      str[1..-2].strip
     end
 
     def collect_local_assignments(defn)
@@ -268,7 +313,7 @@ module RbsInfer
         lookup_ivar_type(node) || "untyped"
       when Prism::CallNode
         if node.receiver.nil?
-          @method_return_types[node.name.to_s] || "untyped"
+          refined_self_method_type(node.name.to_s) || @method_return_types[node.name.to_s] || "untyped"
         elsif node.name == :new && node.receiver
           RbsInfer::Analyzer.extract_constant_path(node.receiver) || "untyped"
         else
@@ -321,6 +366,23 @@ module RbsInfer
       @in_singleton_method ? "singleton(#{base})" : base
     end
 
+    # Resolves a `self.<method>` against the refined `self` type when the
+    # enclosing method is covered by an after-validation callback (its `self`
+    # is `Model & Model::Validated`). This makes `self.<association>` resolve
+    # to the marker-decorated reader (e.g. `Caderneta & Caderneta::Validated`)
+    # rather than the base nilable reader. Returns nil outside such methods,
+    # so the normal `@method_return_types` path is preserved unchanged.
+    def refined_self_method_type(method_name)
+      return nil if @in_singleton_method
+      return nil unless @method_type_resolver
+
+      refined = @current_method && @self_types_by_method[@current_method]
+      return nil if refined.nil? || refined.empty?
+
+      resolved = @method_type_resolver.resolve(refined, method_name)
+      resolved if resolved && resolved != "untyped"
+    end
+
     # Resolver receiver.method() → tipo do retorno do method no receiver
     def resolve_method_chain(node)
       return nil unless @method_type_resolver
@@ -357,8 +419,11 @@ module RbsInfer
         lookup_ivar_type(node)
       when Prism::CallNode
         if node.receiver.nil?
-          # Implicit method call (ex: attr_reader como aluno_dto)
-          @method_return_types[node.name.to_s]
+          # Implicit `self.<method>` (ex: attr_reader/association). Inside a
+          # callback-refined method, resolve against the refined self so a
+          # `self.<association>` picks up the marker-decorated reader instead
+          # of the base nilable one.
+          refined_self_method_type(node.name.to_s) || @method_return_types[node.name.to_s]
         elsif node.name == :new && node.receiver
           RbsInfer::Analyzer.extract_constant_path(node.receiver)
         else

--- a/spec/lib/rbs_infer/new_call_collector_spec.rb
+++ b/spec/lib/rbs_infer/new_call_collector_spec.rb
@@ -306,4 +306,83 @@ RSpec.describe RbsInfer::NewCallCollector do
       expect(usages.first["value"]).to eq("LegacyCompany")
     end
   end
+
+  describe "target-method calls through marker-decorated / self-refined receivers" do
+    # Peça B: the receiver type carries markers, i.e. it's an intersection
+    # like `Caderneta & Caderneta::Validated`. `match_class?` must recognize
+    # the target class as one of the intersection's components, otherwise the
+    # call is silently dropped and the argument types are never collected.
+    it "matches a target call whose receiver resolves to an intersection type" do
+      source = "caderneta.qtde_por_vacina(v)"
+      result = Prism.parse(source)
+      visitor = described_class.new(
+        target_class: "Caderneta",
+        method_return_types: { "caderneta" => "Caderneta & Caderneta::Validated", "v" => "Vacina" },
+        local_var_types: {},
+        target_methods: { "qtde_por_vacina" => ["vacina"] }
+      )
+      result.value.accept(visitor)
+
+      expect(visitor.method_call_usages["qtde_por_vacina"]).to eq([{ "vacina" => "Vacina" }])
+    end
+
+    # Peça A: inside a method whose `self` is callback-refined, a
+    # `self.<association>` used as the receiver OR as an argument resolves
+    # against that refined self (the marker-decorated reader), not the base
+    # nilable reader — so both the receiver match and the argument type pick
+    # up the validated type.
+    it "resolves self.<association> receiver and argument against the refined self" do
+      files = {
+        "sig/holder.rbs" => <<~RBS,
+          class Holder
+            def thing: () -> Thing?
+            def other: () -> Other?
+          end
+
+          class Holder::Validated
+            def thing: () -> (Thing & Thing::Validated)
+            def other: () -> (Other & Other::Validated)
+          end
+
+          class Thing
+          end
+          class Thing::Validated
+          end
+          class Other
+          end
+          class Other::Validated
+          end
+        RBS
+        "caller.rb" => <<~RUBY
+          class Holder
+            def m
+              thing.target_method(other)
+            end
+          end
+        RUBY
+      }
+
+      with_temp_files(files) do |dir, paths|
+        Dir.chdir(dir) do
+          resolver = RbsInfer::MethodTypeResolver.new(paths)
+          source = File.read(File.join(dir, "caller.rb"))
+          result = Prism.parse(source)
+          visitor = described_class.new(
+            target_class: "Thing",
+            method_return_types: {},
+            local_var_types: {},
+            method_type_resolver: resolver,
+            caller_class_name: "Holder",
+            target_methods: { "target_method" => ["arg"] },
+            self_types_by_method: { "m" => "Holder & Holder::Validated" }
+          )
+          result.value.accept(visitor)
+
+          expect(visitor.method_call_usages["target_method"]).to eq(
+            [{ "arg" => "Other & Other::Validated" }]
+          )
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problema

A inferência de tipos de **parâmetros** por call-sites descartava silenciosamente a chamada sempre que o receiver era uma association nilable (`belongs_to`), e mesmo quando casava, o argumento era resolvido pelo reader base — nunca o tipo decorado pelos markers que o Steep vê no contexto.

Caso real: `Caderneta#qtde_por_vacina(vacina)` saía como `(untyped vacina) -> Integer`. O único call-site analisável (`recomendacao_vacina.rb:29 → caderneta.qtde_por_vacina(vacina)`) era jogado fora porque:
1. o receiver `caderneta` resolvia como `::Caderneta?` (reader base nilable), e `match_class?` comparava `"Caderneta?"` com `"Caderneta"` → não casava (o `?`);
2. e o argumento `vacina` resolvia pelo reader base, não pelo `Vacina & Vacina::Validated` que o Steep infere ali (via o self-narrowing do closure do `before_save`).

## Correção (duas peças aditivas em `NewCallCollector`)

- **`refined_self_method_type`** — dentro de um método cujo `self` é refinado por callback (`self_types_by_method`, vindo de `SteepBridge#callback_self_types`), um `self.<método>` é resolvido contra esse self refinado, pegando o reader decorado pelos markers (`Caderneta & Caderneta::Validated`) em vez do base nilable. Fora desses métodos retorna `nil`, então o caminho atual (`@method_return_types`) fica inalterado.
- **`match_class?`** — desembrulha interseções (`A & B & C`, respeitando aninhamento de `[]`/`()`) e casa se algum componente for o target, reconhecendo um receiver decorado por markers.

## Efeito

`Caderneta#qtde_por_vacina` passa a inferir `(Vacina & Vacina::Validated vacina) -> Integer`.

## Testes / validação

- 2 specs novos em `new_call_collector_spec.rb` (match em receiver-interseção; resolução de `self.<assoc>` receiver+arg contra o self refinado) — test-first.
- Suíte completa: 526 examples, 0 failures.
- App real (carteira): parâmetro sai de `untyped` para `Vacina & Vacina::Validated`; Steep 109 → 108, sem erro novo.

Observação: a mudança é geral — beneficia qualquer método cujo call-site seja um `self.<association>` em contexto validado, ou cujo receiver seja uma interseção decorada por markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)