### PR TITLE
fix(class-methods): collect `class << self` defs as singleton methods

### DIFF
--- a/lib/rbs_infer/class_member_collector.rb
+++ b/lib/rbs_infer/class_member_collector.rb
@@ -48,8 +48,23 @@ module RbsInfer
       with_scope(:class, segment) { super }
     end
 
+    # `class << self` — methods defined inside define singleton (class)
+    # methods of the enclosing class, indistinguishable from instance defs
+    # by node shape alone (no `self.` receiver). Push a :singleton scope so
+    # `class_method_def?` classifies them correctly; reuse `with_scope` so a
+    # `private` inside the block does not leak its visibility outward.
+    # `class << other` opens another object's singleton (not this class's
+    # methods), so leave its body untouched — same behavior as before.
+    def visit_singleton_class_node(node)
+      if node.expression.is_a?(Prism::SelfNode)
+        with_scope(:singleton, nil) { super }
+      else
+        super
+      end
+    end
+
     def visit_def_node(node)
-      is_class_method = node.receiver.is_a?(Prism::SelfNode)
+      is_class_method = class_method_def?(node)
       name = node.name.to_s
       sig = find_rbs_signature(@comments, @lines, node.location.start_line)
 

--- a/lib/rbs_infer/def_collector.rb
+++ b/lib/rbs_infer/def_collector.rb
@@ -12,6 +12,11 @@ module RbsInfer
       # that collide across a module and the class (e.g. an expanded
       # CurrentAttributes accessor and its override) — felixefelip#22.
       @owners = {}
+      # def node => whether it defines a class (singleton) method, so
+      # consumers match the same kind ClassMemberCollector assigned — an
+      # instance and a singleton method sharing a name (`def consume` vs
+      # `class << self; def consume`) are distinct members.
+      @class_methods = {}
       self.scope_target = target_class
     end
 
@@ -29,15 +34,33 @@ module RbsInfer
       pop_scope
     end
 
+    # `class << self` opens the enclosing class's singleton; push a
+    # :singleton frame so `class_method_def?` sees nested defs as class
+    # methods. `class << other` is a different object's singleton — leave it.
+    def visit_singleton_class_node(node)
+      singleton = node.expression.is_a?(Prism::SelfNode)
+      push_scope(:singleton, nil) if singleton
+      super
+    ensure
+      pop_scope if singleton
+    end
+
     def visit_def_node(node)
       @defs << node
       @owners[node] = current_owner
+      @class_methods[node] = class_method_def?(node)
       super
     end
 
     # Owner of a previously-collected def node (nil = direct class member).
     def owner_of(node)
       @owners[node]
+    end
+
+    # Whether a previously-collected def node defines a class (singleton)
+    # method — covers both `def self.x` and `class << self; def x`.
+    def class_method?(node)
+      @class_methods[node]
     end
   end
 end

--- a/lib/rbs_infer/lexical_scope.rb
+++ b/lib/rbs_infer/lexical_scope.rb
@@ -44,5 +44,21 @@ module RbsInfer
       mods = scope_stack[(target_idx + 1)..].select { |f| f[:kind] == :module && f[:name] }
       mods.empty? ? nil : mods.map { |f| f[:name] }.join("::")
     end
+
+    # True when the innermost open class/module scope is a `class << self`
+    # block (pushed as a :singleton frame). `def`s collected here define
+    # class (singleton) methods even though they carry no `self.` receiver.
+    def in_singleton_self?
+      scope_stack.last&.dig(:kind) == :singleton
+    end
+
+    # Whether a `def` node at the current traversal position defines a
+    # singleton (class) method — either `def self.name` (explicit receiver)
+    # or a plain `def name` nested in `class << self`. The single source of
+    # truth for this classification, shared by ClassMemberCollector and
+    # DefCollector so they never disagree on a method's kind.
+    def class_method_def?(node)
+      node.receiver.is_a?(Prism::SelfNode) || in_singleton_self?
+    end
   end
 end

--- a/lib/rbs_infer/type_merger.rb
+++ b/lib/rbs_infer/type_merger.rb
@@ -63,10 +63,12 @@ module RbsInfer
         next unless last_stmt
 
         method_name = defn.name.to_s
-        # `def self.x` is collected as :class_method — matching the kind
-        # avoids updating the wrong member when instance and singleton
-        # share a name (e.g. expanded CurrentAttributes accessors).
-        kind = defn.receiver.is_a?(Prism::SelfNode) ? :class_method : :method
+        # Class methods (`def self.x` or `class << self; def x`) are
+        # collected as :class_method — matching the kind avoids updating the
+        # wrong member when an instance and a singleton method share a name
+        # (expanded CurrentAttributes accessors, or a `consume` defined both
+        # ways). DefCollector carries the singleton context the bare node lacks.
+        kind = collector.class_method?(defn) ? :class_method : :method
         owner = collector.owner_of(defn)
         member = members.find { |m| m.kind == kind && m.name == method_name && m.owner == owner }
         next unless member
@@ -162,7 +164,7 @@ module RbsInfer
         # this skip, a trailing `self.x = param` would leak the RHS type
         # via the attribute-write rule.
         next if method_name == "initialize"
-        kind = defn.receiver.is_a?(Prism::SelfNode) ? :class_method : :method
+        kind = collector.class_method?(defn) ? :class_method : :method
         owner = collector.owner_of(defn)
         member = members.find { |m| m.kind == kind && m.name == method_name && m.owner == owner }
         next unless member

--- a/spec/dummy/app/models/tag.rb
+++ b/spec/dummy/app/models/tag.rb
@@ -6,10 +6,16 @@ class Tag < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
 
-  def self.popular(limit = 10)
-    joins(:post_tags)
-      .group(:id)
-      .order("COUNT(post_tags.id) DESC")
-      .limit(limit)
+  # `class << self` form (instead of `def self.popular`): both must yield
+  # the same `def self.popular` singleton method in the generated RBS. A
+  # regression that mis-collected singleton-class methods as instance
+  # methods would surface here as a `def popular:` instance member.
+  class << self
+    def popular(limit = 10)
+      joins(:post_tags)
+        .group(:id)
+        .order("COUNT(post_tags.id) DESC")
+        .limit(limit)
+    end
   end
 end

--- a/spec/lib/rbs_infer/analyzer_spec.rb
+++ b/spec/lib/rbs_infer/analyzer_spec.rb
@@ -343,6 +343,43 @@ RSpec.describe RbsInfer::Analyzer do
       end
     end
 
+    # Regression: methods inside `class << self` are singleton (class)
+    # methods, but the `self.` receiver is absent on the node, so they were
+    # collected as instance methods. A `consume` defined both as a class
+    # method (in `class << self`) and an instance method then collapsed into
+    # two `def consume:` lines in the same (instance) scope. They must split
+    # into `def self.consume` and `def consume`, each resolving on its own.
+    it "separa class << self e instância homônimos em def self.X e def X" do
+      files = {
+        "magic_link.rb" => <<~RUBY
+          class MagicLink
+            class << self
+              def consume(code)
+                42
+              end
+            end
+
+            def consume
+              "done"
+            end
+          end
+        RUBY
+      }
+
+      with_temp_files(files) do |dir, paths|
+        analyzer = described_class.new(target_file: paths.first, source_files: paths)
+        rbs = analyzer.generate_rbs
+
+        # Exactly one of each surface — no duplicated `def consume:`.
+        expect(rbs.scan(/^\s*def self\.consume:/).size).to eq(1)
+        expect(rbs.scan(/^\s*def consume:/).size).to eq(1)
+        # Distinct scopes keep distinct signatures — the return types do not
+        # bleed between the singleton and the instance method.
+        expect(rbs).to include("def self.consume: (untyped code) -> Integer")
+        expect(rbs).to include("def consume: () -> String")
+      end
+    end
+
     # Regression: `has_nil_return?` annotates a method whose body has an
     # early `return` (implicit nil) with `?`. The selectors that invoke it
     # were `m.kind == :method`, so singleton methods missed the wrap.

--- a/spec/lib/rbs_infer/class_member_collector_spec.rb
+++ b/spec/lib/rbs_infer/class_member_collector_spec.rb
@@ -127,6 +127,84 @@ RSpec.describe RbsInfer::ClassMemberCollector do
     expect(collector.members.find { |m| m.name == "build_count" }.signature).to include("-> Integer")
   end
 
+  describe "class << self (métodos singleton)" do
+    it "classifica métodos definidos em `class << self` como class_method" do
+      source = <<~RUBY
+        class Foo
+          class << self
+            def build(name)
+            end
+
+            def reset
+            end
+          end
+        end
+      RUBY
+
+      collector = collect(source)
+      build = collector.members.find { |m| m.name == "build" }
+      reset = collector.members.find { |m| m.name == "reset" }
+      expect(build.kind).to eq(:class_method)
+      expect(reset.kind).to eq(:class_method)
+    end
+
+    it "mantém método de classe e de instância de mesmo nome como membros distintos" do
+      source = <<~RUBY
+        class MagicLink
+          class << self
+            def consume(code)
+            end
+          end
+
+          def consume
+          end
+        end
+      RUBY
+
+      consumes = collect(source).members.select { |m| m.name == "consume" }
+      expect(consumes.map(&:kind)).to contain_exactly(:class_method, :method)
+      # o método de classe carrega o parâmetro; o de instância não
+      class_consume = consumes.find { |m| m.kind == :class_method }
+      inst_consume = consumes.find { |m| m.kind == :method }
+      expect(class_consume.signature).to include("code")
+      expect(inst_consume.signature).not_to include("code")
+    end
+
+    it "não vaza visibilidade de dentro de `class << self` para os métodos seguintes" do
+      source = <<~RUBY
+        class Foo
+          class << self
+            private
+
+            def secret_builder
+            end
+          end
+
+          def public_api
+          end
+        end
+      RUBY
+
+      collector = collect(source)
+      expect(collector.members.find { |m| m.name == "public_api" }.visibility).to eq(:public)
+    end
+
+    it "não classifica métodos de `class << outro_objeto` como class_method" do
+      source = <<~RUBY
+        class Foo
+          OBJ = Object.new
+          class << OBJ
+            def bar
+            end
+          end
+        end
+      RUBY
+
+      bar = collect(source).members.find { |m| m.name == "bar" }
+      expect(bar.kind).not_to eq(:class_method)
+    end
+  end
+
   describe "delegate parsing" do
     it "collects a basic delegate call" do
       source = <<~RUBY


### PR DESCRIPTION
## Problema

Para um modelo como:

```ruby
class MagicLink < ApplicationRecord
  class << self
    def consume(code) = active.find_by(code:)&.consume
    def cleanup       = stale.delete_all
  end

  def consume
    destroy
    self
  end
end
```

o RBS gerado emitia os métodos do `class << self` **como métodos de instância**, produzindo um `def consume:` duplicado no mesmo escopo:

```rbs
class MagicLink < ApplicationRecord
  def consume: (untyped code) -> MagicLink   # deveria ser def self.consume
  def cleanup: () -> untyped                  # deveria ser def self.cleanup
  def consume: () -> MagicLink                # instância (correto)
  ...
end
```

## Causa raiz

A classificação de método de classe dependia **apenas** de `node.receiver.is_a?(Prism::SelfNode)`, que só reconhece a forma `def self.foo`. Os `def` dentro de `class << self` (`Prism::SingletonClassNode`) têm `receiver == nil`, e nenhum visitor tratava o nó singleton — então eram visitados como métodos de instância comuns (`ClassMemberCollector`) e reclassificados como `:method` (`TypeMerger`).

## Correção

- **`LexicalScope`** passa a ser a fonte única da regra: `class_method_def?(node)` cobre tanto `def self.x` quanto `def x` aninhado em `class << self` (via `in_singleton_self?`).
- **`ClassMemberCollector`** e **`DefCollector`** abrem um frame de escopo `:singleton` ao percorrer `class << self` e compartilham a mesma regra — nunca mais divergem no `kind`. O `with_scope` reutilizado garante que um `private` dentro do bloco não vaze a visibilidade para fora.
- **`TypeMerger`** (2 sítios) casa o mesmo `kind` via `collector.class_method?`, então o return type do método singleton continua resolvendo em vez de regredir para `untyped`.
- `class << outro_objeto` (singleton de outro objeto) é deixado intacto — mesmo comportamento de antes.

Resultado:

```rbs
class MagicLink < ApplicationRecord
  def self.consume: (untyped code) -> MagicLink
  def self.cleanup: () -> untyped
  def consume: () -> MagicLink
  ...
end
```

## Testes

- **Unit** (`class_member_collector_spec`): classificação de `class << self` como `class_method`; método de classe + instância homônimos como membros distintos; visibilidade não vaza do bloco singleton; `class << outro_objeto` não vira `class_method`.
- **Integração** (`analyzer_spec`): caso "MagicLink-like" — `def self.consume` e `def consume` coexistem sem duplicação, com return types independentes (`Integer` vs `String`), provando que os escopos não se misturam.
- **Dummy/snapshot**: `Tag.popular` migrado de `def self.popular` para `class << self`; o snapshot `tag.rbs` permanece **idêntico** (`def self.popular`), provando a equivalência e servindo de guarda de regressão.
- Suíte completa: **531 examples, 0 failures**.

## Fora de escopo

Ao montar o fixture notei um bug **pré-existente e independente**: quando um método de classe e um de instância compartilham nome e o de classe não resolve via literal, o return type de um pode contaminar o do outro (`known_return_types` é indexado só por nome). Reproduz igual com `def self.x` explícito — não é introduzido por esta mudança. Candidato a issue separada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)