### PR TITLE
fix(return-types): resolve instance and class methods against their own kind (#33)

### DIFF
--- a/lib/rbs_infer/known_return_types_builder.rb
+++ b/lib/rbs_infer/known_return_types_builder.rb
@@ -36,5 +36,29 @@ module RbsInfer
 
       types
     end
+
+    # The class-method counterpart of `build_known_return_types`: a
+    # name→type map built ONLY from `:class_method` members and the class's
+    # singleton RBS. Kept separate from the instance map so a class method
+    # and an instance method that share a name resolve against their own
+    # surface, never each other's (felixefelip/rbs_infer#33).
+    def build_class_method_return_types(members, method_type_resolver:, target_class:)
+      types = {}
+
+      members.each do |m|
+        next unless m.kind == :class_method
+        if m.signature =~ /.*->\s*(.+)$/ && $1.strip != "untyped" && $1.strip != "void"
+          types[m.name] = $1.strip
+        end
+      end
+
+      if method_type_resolver && target_class
+        method_type_resolver.resolve_all_class_methods(target_class).each do |name, type|
+          types[name] ||= type
+        end
+      end
+
+      types
+    end
   end
 end

--- a/lib/rbs_infer/method_type_resolver.rb
+++ b/lib/rbs_infer/method_type_resolver.rb
@@ -101,6 +101,15 @@ module RbsInfer
       @cache[class_name] ||= build_class_types(class_name)
     end
 
+    # All class (singleton) method return types for a class, keyed by name —
+    # the singleton counterpart of `resolve_all`. Lets callers resolve a
+    # class method's body against other class methods without pulling in the
+    # instance-method table (felixefelip/rbs_infer#33).
+    def resolve_all_class_methods(class_name)
+      return {} unless class_name && class_name != "untyped"
+      lookup_class_methods(class_name)
+    end
+
     # Retorna os tipos dos parâmetros do initialize inferidos via call-sites
     # Ex: Entity.new(nome: "x", email: "y") → {"nome" => "String", "email" => "String"}
     def resolve_init_param_types(class_name)

--- a/lib/rbs_infer/return_type_resolver.rb
+++ b/lib/rbs_infer/return_type_resolver.rb
@@ -27,6 +27,12 @@ module RbsInfer
       return if untyped_methods.empty?
 
       known_return_types = build_known_return_types(members, attr_types, method_type_resolver: method_type_resolver, target_class: @target_class, instance_types: @instance_types)
+      # A class method resolves against its OWN surface. The map above is
+      # built from instance members, so applying it to a `:class_method`
+      # would leak a homonymous instance method's return type onto it (and
+      # the reverse, via the name-keyed Steep map below) —
+      # felixefelip/rbs_infer#33.
+      class_return_types = build_class_method_return_types(members, method_type_resolver: method_type_resolver, target_class: @target_class)
 
       # Aplicar tipos já resolvidos pelo resolver (ex: chamadas a métodos herdados)
       untyped_methods.each do |m|
@@ -38,7 +44,7 @@ module RbsInfer
         # setter's return (e.g. a CurrentAttributes override onto the
         # generated module accessor) — felixefelip/rbs_infer#22.
         next if setter_name?(m.name)
-        resolved = known_return_types[m.name]
+        resolved = return_types_for(m, known_return_types, class_return_types)[m.name]
         if resolved && resolved != "untyped"
           m.signature = m.signature.sub(/-> untyped$/, "-> #{RbsParserUtil.parenthesize_union(resolved)}")
         end
@@ -47,9 +53,11 @@ module RbsInfer
       # Use Steep for any remaining untyped methods and to correct wrong block generic types
       if @steep_bridge && parsed_target.source
         still_untyped = members.select { |m| method_member?(m) && m.name != "initialize" && m.signature =~ /->\s*untyped$/ }
-        steep_returns = @steep_bridge.method_return_types(parsed_target.source)
+        # Kind-split so a `def self.x` reads Steep's singleton-method type,
+        # not a homonymous `def x`'s (felixefelip/rbs_infer#33).
+        steep_returns = @steep_bridge.method_return_types_by_kind(parsed_target.source)
 
-        unless steep_returns.empty?
+        unless steep_returns[:instance].empty? && steep_returns[:singleton].empty?
           # Build def map for nil-return detection
           collector = DefCollector.new
           parsed_target.tree.accept(collector)
@@ -60,7 +68,7 @@ module RbsInfer
 
           still_untyped.each do |m|
             next if setter_name?(m.name)
-            steep_type = steep_returns[m.name]
+            steep_type = steep_returns_for(m, steep_returns)[m.name]
             if steep_type && steep_type != "untyped" && steep_type != "nil" && steep_type != "bot"
               # Instance methods returning the same class (or host class for concerns) → self
               steep_type = "self" if self_types.include?(steep_type)
@@ -81,7 +89,7 @@ module RbsInfer
             next unless method_member?(m)
             next if m.name == "initialize"
             next if m.signature =~ /->\s*untyped$/
-            steep_type = steep_returns[m.name]
+            steep_type = steep_returns_for(m, steep_returns)[m.name]
             next unless steep_type && steep_type != "untyped" && steep_type != "nil" && steep_type != "bot"
             current_type = m.signature[/->\s*(.+)$/, 1]&.strip
             next if current_type == steep_type
@@ -97,7 +105,7 @@ module RbsInfer
             current_type = m.signature[/->\s*(.+)$/, 1]&.strip
             next unless current_type&.start_with?("{") && current_type.include?("untyped")
 
-            steep_type = steep_returns[m.name]
+            steep_type = steep_returns_for(m, steep_returns)[m.name]
             next unless steep_type && steep_type != "untyped" && steep_type != "nil" && steep_type != "bot"
             next unless steep_type.start_with?("{")
             next if current_type == steep_type
@@ -189,6 +197,17 @@ module RbsInfer
     # retorno que `:method` (steep_bridge devolve por nome para ambos).
     def method_member?(member)
       member.kind == :method || member.kind == :class_method
+    end
+
+    # Pick the return-type map matching a member's kind so instance and
+    # class methods never read each other's types (felixefelip/rbs_infer#33).
+    def return_types_for(member, instance_map, class_map)
+      member.kind == :class_method ? class_map : instance_map
+    end
+
+    # Same selection for the kind-split Steep map (`{instance:, singleton:}`).
+    def steep_returns_for(member, steep_returns)
+      member.kind == :class_method ? steep_returns[:singleton] : steep_returns[:instance]
     end
 
     # Verifica se o corpo do método contém `return nil` ou `return` (implícito nil)

--- a/lib/rbs_infer/steep_bridge.rb
+++ b/lib/rbs_infer/steep_bridge.rb
@@ -140,9 +140,21 @@ module RbsInfer
 
     # Returns { "method_name" => "ReturnType" } for all def nodes.
     # The return type is inferred from the body of the method.
+    # Return types of instance methods (`def x`), keyed by name. Singleton
+    # methods (`def self.x`) are excluded — fetch those via
+    # `method_return_types_by_kind(...)[:singleton]` so a class method and an
+    # instance method sharing a name don't clobber each other's entry.
     def method_return_types(source_code)
+      method_return_types_by_kind(source_code)[:instance]
+    end
+
+    # Return types split by receiver kind: `{ instance: {name=>type},
+    # singleton: {name=>type} }`. `def x` (Prism `:def`) and `def self.x`
+    # (`:defs`) used to write the same name-keyed entry, so a homonymous
+    # pair leaked one type onto the other (felixefelip/rbs_infer#33).
+    def method_return_types_by_kind(source_code)
       typing = type_check(source_code)
-      return {} unless typing
+      return { instance: {}, singleton: {} } unless typing
 
       # Index BlockBodyTypeMismatch errors by block node identity
       block_mismatches = {}
@@ -151,12 +163,14 @@ module RbsInfer
         block_mismatches[err.node.__id__] = err
       end
 
-      result = {}
+      instance = {}
+      singleton = {}
 
       typing.each_typing do |node, _type|
         next unless node.type == :def || node.type == :defs
-        method_name = node.type == :def ? node.children[0].to_s : node.children[1].to_s
-        body = node.type == :def ? node.children[2] : node.children[3]
+        singleton_def = node.type == :defs
+        method_name = singleton_def ? node.children[1].to_s : node.children[0].to_s
+        body = singleton_def ? node.children[3] : node.children[2]
         next unless body
 
         body_type = typing.type_of(node: body)
@@ -169,10 +183,10 @@ module RbsInfer
 
         next if type_str == "untyped"
 
-        result[method_name] = type_str
+        (singleton_def ? singleton : instance)[method_name] = type_str
       end
 
-      result
+      { instance: instance, singleton: singleton }
     end
 
     BLOCK_GENERIC_METHODS = %w[map collect].freeze

--- a/lib/rbs_infer/type_merger.rb
+++ b/lib/rbs_infer/type_merger.rb
@@ -46,6 +46,11 @@ module RbsInfer
       return unless parsed_target
 
       known_return_types = build_known_return_types(members, attr_types, method_type_resolver: method_type_resolver, target_class: @target_class, instance_types: @instance_types)
+      # Separate surface for class methods: a `def self.x` body resolves
+      # against (and feeds) class-method types only, never the instance map
+      # above — otherwise a homonymous instance method's type leaks across
+      # (felixefelip/rbs_infer#33).
+      class_return_types = build_class_method_return_types(members, method_type_resolver: method_type_resolver, target_class: @target_class)
 
       # Collect mapping: [kind, method_name] -> last expression of the body
       method_last_exprs = {}
@@ -69,6 +74,9 @@ module RbsInfer
         # (expanded CurrentAttributes accessors, or a `consume` defined both
         # ways). DefCollector carries the singleton context the bare node lacks.
         kind = collector.class_method?(defn) ? :class_method : :method
+        # Resolve this body against (and write back into) the map for its
+        # own kind, so class and instance methods never cross (#33).
+        own_return_types = kind == :class_method ? class_return_types : known_return_types
         owner = collector.owner_of(defn)
         member = members.find { |m| m.kind == kind && m.name == method_name && m.owner == owner }
         next unless member
@@ -82,7 +90,7 @@ module RbsInfer
           resolved = ivar_types[last_stmt.name.to_s.sub(/\A@/, "")]
           if resolved && resolved != "untyped"
             member.signature = member.signature.sub(/-> untyped\z/, "-> #{RbsParserUtil.parenthesize_union(resolved)}")
-            known_return_types[method_name] = resolved
+            own_return_types[method_name] = resolved
             next
           end
         end
@@ -91,7 +99,7 @@ module RbsInfer
         literal_type = infer_literal_type(last_stmt)
         if literal_type
           member.signature = member.signature.sub(/-> untyped\z/, "-> #{RbsParserUtil.parenthesize_union(literal_type)}")
-          known_return_types[method_name] = literal_type
+          own_return_types[method_name] = literal_type
           next
         end
 
@@ -100,7 +108,7 @@ module RbsInfer
           class_name = RbsInfer::Analyzer.extract_constant_path(last_stmt.receiver)
           if class_name
             member.signature = member.signature.sub(/-> untyped\z/, "-> #{RbsParserUtil.parenthesize_union(class_name)}")
-            known_return_types[method_name] = class_name
+            own_return_types[method_name] = class_name
             next
           end
         end
@@ -113,10 +121,10 @@ module RbsInfer
         # 4. attr.mutation_method(expr) → return type é o tipo do attr (Array retorna self)
         if last_stmt.is_a?(Prism::CallNode) && ARRAY_SELF_RETURN_METHODS.include?(last_stmt.name) && last_stmt.receiver
           receiver_name = implicit_self_method_name(last_stmt.receiver)
-          if receiver_name && known_return_types[receiver_name]
-            resolved = known_return_types[receiver_name]
+          if receiver_name && own_return_types[receiver_name]
+            resolved = own_return_types[receiver_name]
             member.signature = member.signature.sub(/-> untyped\z/, "-> #{RbsParserUtil.parenthesize_union(resolved)}")
-            known_return_types[method_name] = resolved
+            own_return_types[method_name] = resolved
             next
           end
         end
@@ -124,10 +132,10 @@ module RbsInfer
         # 5. receiver.method() na última expressão
         if last_stmt.is_a?(Prism::CallNode) && last_stmt.receiver && method_type_resolver
           local_types = method_param_types[method_name] || {}
-          resolved = infer_call_return_type(last_stmt, known_return_types, method_type_resolver, local_types: local_types)
+          resolved = infer_call_return_type(last_stmt, own_return_types, method_type_resolver, local_types: local_types)
           if resolved
             member.signature = member.signature.sub(/-> untyped\z/, "-> #{RbsParserUtil.parenthesize_union(resolved)}")
-            known_return_types[method_name] = resolved
+            own_return_types[method_name] = resolved
             next
           end
         end
@@ -141,7 +149,10 @@ module RbsInfer
         called_name = method_last_exprs[[member.kind, member.name]]
         next unless called_name
 
-        resolved_type = known_return_types[called_name]
+        # Resolve the called name against the member's own kind: a class
+        # method's receiverless call refers to another class method, not a
+        # homonymous instance one (#33).
+        resolved_type = (member.kind == :class_method ? class_return_types : known_return_types)[called_name]
         next unless resolved_type
 
         member.signature = member.signature.sub(/-> untyped\z/, "-> #{RbsParserUtil.parenthesize_union(resolved_type)}")
@@ -165,6 +176,7 @@ module RbsInfer
         # via the attribute-write rule.
         next if method_name == "initialize"
         kind = collector.class_method?(defn) ? :class_method : :method
+        own_return_types = kind == :class_method ? class_return_types : known_return_types
         owner = collector.owner_of(defn)
         member = members.find { |m| m.kind == kind && m.name == method_name && m.owner == owner }
         next unless member
@@ -172,10 +184,10 @@ module RbsInfer
 
         if last_stmt.is_a?(Prism::CallNode) && last_stmt.receiver && method_type_resolver
           local_types = method_param_types[method_name] || {}
-          resolved = infer_call_return_type(last_stmt, known_return_types, method_type_resolver, local_types: local_types)
+          resolved = infer_call_return_type(last_stmt, own_return_types, method_type_resolver, local_types: local_types)
           if resolved
             member.signature = member.signature.sub(/-> untyped\z/, "-> #{RbsParserUtil.parenthesize_union(resolved)}")
-            known_return_types[method_name] = resolved
+            own_return_types[method_name] = resolved
           end
         end
       end

--- a/spec/lib/rbs_infer/analyzer_spec.rb
+++ b/spec/lib/rbs_infer/analyzer_spec.rb
@@ -318,12 +318,16 @@ RSpec.describe RbsInfer::Analyzer do
       end
     end
 
-    it "atualiza def self.X mesmo quando há um def X (instance) homônimo no mesmo lugar" do
+    it "resolve def self.X via cadeia entre class methods, sem herdar do def X homônimo" do
       files = {
         "factory.rb" => <<~RUBY
           class TwinNames
             def self.run
-              new.run.upcase
+              build
+            end
+
+            def self.build
+              42
             end
 
             def run
@@ -337,9 +341,43 @@ RSpec.describe RbsInfer::Analyzer do
         analyzer = described_class.new(target_file: paths.first, source_files: paths)
         rbs = analyzer.generate_rbs
 
-        # Both surfaces should resolve away from untyped.
-        expect(rbs).to include("def self.run: () -> String")
+        # `self.run` resolves against the class method `build` (Integer) it
+        # calls — NOT the homonymous instance `run` (String). Return types no
+        # longer cross the instance/singleton boundary (felixefelip#33).
+        expect(rbs).to include("def self.run: () -> Integer")
+        expect(rbs).to include("def self.build: () -> Integer")
         expect(rbs).to include("def run: () -> String")
+      end
+    end
+
+    # Regression for felixefelip/rbs_infer#33: a class method and an instance
+    # method sharing a name used to swap return types, because the resolver's
+    # name-keyed maps (known_return_types and Steep's) didn't distinguish
+    # `:method` from `:class_method`. The class `normalize` can't resolve on
+    # its own (`fetch` is unknown), so the instance `normalize`'s String used
+    # to leak onto it. It must stay untyped.
+    it "não vaza o return type do método de instância para o def self homônimo" do
+      files = {
+        "doohickey.rb" => <<~RUBY
+          class Doohickey
+            def self.normalize(value)
+              fetch(value)
+            end
+
+            def normalize
+              "instance-result"
+            end
+          end
+        RUBY
+      }
+
+      with_temp_files(files) do |dir, paths|
+        analyzer = described_class.new(target_file: paths.first, source_files: paths)
+        rbs = analyzer.generate_rbs
+
+        expect(rbs).to include("def normalize: () -> String")
+        # Without the fix this would inherit the instance method's String.
+        expect(rbs).to include("def self.normalize: (untyped value) -> untyped")
       end
     end
 

--- a/spec/lib/rbs_infer/steep_bridge_spec.rb
+++ b/spec/lib/rbs_infer/steep_bridge_spec.rb
@@ -285,6 +285,28 @@ RSpec.describe RbsInfer::SteepBridge, :dummy_app do
       result = bridge.method_return_types("!!!invalid ruby")
       expect(result).to eq({})
     end
+
+    # felixefelip/rbs_infer#33: `def x` and `def self.x` used to write the
+    # same name-keyed entry, so one clobbered the other.
+    it "keeps instance and singleton methods sharing a name in separate maps" do
+      code = <<~RUBY
+        class Foo
+          def self.tally
+            "big"
+          end
+
+          def tally
+            42
+          end
+        end
+      RUBY
+
+      by_kind = bridge.method_return_types_by_kind(code)
+      expect(by_kind[:singleton]["tally"]).to eq("String")
+      expect(by_kind[:instance]["tally"]).to eq("Integer")
+      # The name-keyed accessor returns instance methods only.
+      expect(bridge.method_return_types(code)["tally"]).to eq("Integer")
+    end
   end
 
   describe "#method_return_types block generic resolution" do


### PR DESCRIPTION
Fixes #33.

## Problema

Um método de classe e um de instância com o **mesmo nome** trocavam return types. O return type de um podia vazar para o outro:

```ruby
class Tag
  def self.normalize(value)
    value.to_s.downcase
  end

  def normalize
    self.name = name.to_s.downcase
    self
  end
end
```

Antes:

```rbs
def self.normalize: (untyped value) -> Tag   # ❌ herdou o tipo do método de instância
def normalize: () -> self
```

## Causa raiz

A propagação de return types era feita por **nome puro**, sem distinguir `:method` de `:class_method`. Duas fontes alimentavam o vazamento:

1. **`KnownReturnTypesBuilder`** construía um mapa só de membros de instância e o `ReturnTypeResolver` o aplicava a *qualquer* membro untyped — inclusive class methods.
2. **`SteepBridge#method_return_types`** gravava `def x` e `def self.x` na mesma chave (`result[name]`), então um sobrescrevia o outro.

(O `TypeMerger` tinha o vetor análogo via `known_return_types[called_name]`.)

## Correção — separar os namespaces por kind

- **`SteepBridge#method_return_types_by_kind`** retorna `{ instance:, singleton: }`; `method_return_types` mantém a forma só-instância para os callers existentes.
- **`build_class_method_return_types`** + **`MethodTypeResolver#resolve_all_class_methods`** dão aos class methods sua própria superfície de return types.
- **`ReturnTypeResolver`** e **`TypeMerger`** resolvem (e gravam de volta) cada membro contra o mapa do seu próprio kind, nunca o do outro.

Depois:

```rbs
def self.normalize: (untyped value) -> untyped
def normalize: () -> self
```

E um class method que resolve legitimamente continua resolvendo — inclusive via cadeia entre class methods (`def self.run; build; end` → o tipo de `self.build`), sem tocar num `def run` de instância homônimo.

## Testes

- **Unit** (`steep_bridge_spec`): `method_return_types_by_kind` mantém `def x` e `def self.x` homônimos em mapas separados; `method_return_types` retorna só instância.
- **Integração** (`analyzer_spec`): (a) `self.run` resolve contra o class method `build` (Integer), não contra o `run` de instância (String); (b) regressão direta do #33 — o tipo do método de instância não vaza para o `def self` homônimo.
- O teste `TwinNames` existente (`new.run.upcase`) foi reescrito: ele resolvia via o próprio vazamento (o Steep não tipa `new.run` sem o RBS da classe). A nova forma cobre a mesma intenção (resolução de return-type de singleton) pela rota legítima.
- Suíte completa: **533 examples, 0 failures**. Nenhum snapshot da dummy mudou.

## Limitação conhecida

`def self.x; new.instance_method; end` (factory que chama um método de instância homônimo) agora resolve para `untyped`, onde antes herdava o tipo via o vazamento. Recuperar isso corretamente exige resolução de chamada `new` → instância da própria classe — uma melhoria de inferência separada, não um vazamento por nome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)