### PR TITLE
feat(core): emit every type a file defines (multi-target)

### DIFF
--- a/docs/engineering/required-threaded-deps.md
+++ b/docs/engineering/required-threaded-deps.md
@@ -15,3 +15,19 @@ A default silently hides un-wired callers, turning a loud `ArgumentError` into a
 Litmus test: *if a caller forgets this, is the result silently wrong or loudly broken?*
 Silent-wrong → required. Default only when some callers legitimately lack the dependency
 and both behaviors are valid.
+
+### Don't copy a neighbor's default
+
+A new kwarg sitting next to already-defaulted ones is **not** license to default it too —
+match the principle, not the surrounding signature. Those neighbors may themselves be debt:
+run the litmus on each, and if every production caller already passes it, make them all
+required (a unit spec that omitted them is a test-ergonomics concern — give it a small
+builder helper with test-only defaults, keep the production API strict).
+
+Real miss (felixefelip/rbs_infer#38): `RbsBuilder.new` was given a defaulted `type_params:`
+mirroring its existing `namespace_classes:`/`is_module:` defaults. All three were in fact
+passed by every production call-site, and omitting `type_params` is the textbook silent-wrong
+case — it reopens a generic class without its parameters
+(`class Array` instead of `class Array[unchecked out Elem]`), which RBS rejects with
+`GenericParameterMismatchError` and which poisons the whole shared environment, not just the
+one file. All three became required.

--- a/lib/rbs_infer.rb
+++ b/lib/rbs_infer.rb
@@ -45,5 +45,9 @@ require_relative "rbs_infer/dependency_sorter"
 # (no Rails at runtime) and self-gates on the superclass, so it is always
 # safe to load.
 require_relative "rbs_infer/extensions/rails/current_attributes_expander"
+# The on_load expander rewrites `ActiveSupport.on_load :hook do ... end`
+# into a plain class reopening (felixefelip/rbs_infer#38) — pure Prism,
+# self-gates on the `on_load` substring, so it is always safe to load.
+require_relative "rbs_infer/extensions/rails/on_load_expander"
 
 require_relative "rbs_infer/railtie" if defined?(Rails::Railtie)

--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -154,7 +154,8 @@ module RbsInfer
       target_class: receiver,
       superclass_name: nil,
       namespace_classes: resolve_namespace_classes(receiver),
-      is_module: false
+      is_module: false,
+      type_params: method_type_resolver.type_param_string(receiver)
     ).build(members, {}, {})
   end
 
@@ -250,7 +251,7 @@ module RbsInfer
     markers = synthesize_markers(target_members, attr_types, ivar_types)
 
     namespace_classes = resolve_namespace_classes
-    rbs_builder = RbsBuilder.new(target_class: @target_class, superclass_name: @superclass_name, namespace_classes: namespace_classes, is_module: @is_module)
+    rbs_builder = RbsBuilder.new(target_class: @target_class, superclass_name: @superclass_name, namespace_classes: namespace_classes, is_module: @is_module, type_params: method_type_resolver.type_param_string(@target_class))
     rbs_builder.build(target_members, init_arg_types, attr_types, optional_params, method_param_types, ivar_types: ivar_types, markers: markers)
   end
 

--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -49,6 +49,12 @@ module RbsInfer
     @target_class = target_class
     @extra_caller_sources = extra_caller_sources
 
+    # An explicitly-supplied target_class means "generate just this one
+    # class" — single-target mode, preserving the API/test contract. When
+    # only a file is given (the CLI path), the analyzer is free to emit
+    # every target the file defines (felixefelip/rbs_infer#38).
+    @explicit_target_class = !target_class.nil?
+
     if @target_file && !@target_class
       @target_class = extract_class_name_from_file(@target_file)
     elsif @target_class && !@target_file
@@ -57,8 +63,23 @@ module RbsInfer
   end
 
   def generate_rbs
-    return nil unless @target_file && @target_class && File.exist?(@target_file)
+    return nil unless @target_file && File.exist?(@target_file)
 
+    load_and_parse_target
+
+    # Single-target mode: an explicit target_class was requested, so emit
+    # exactly that one declaration (API/test contract, zero churn).
+    if @explicit_target_class
+      return nil unless @target_class
+      return build_single_target_rbs
+    end
+
+    generate_multi_target_rbs
+  end
+
+  # Parse the target file once (with macro expansion) into @parsed_target,
+  # shared by the single-target pipeline and multi-target discovery.
+  def load_and_parse_target
     # Parsear o arquivo-alvo uma única vez e reutilizar em todo o pipeline
     source = File.read(@target_file)
 
@@ -78,7 +99,66 @@ module RbsInfer
       comments: result.comments,
       lines: source.lines
     )
+  end
 
+  # A single file can define or reopen several types (initializers,
+  # `lib/rails_ext/*.rb`, `on_load`/`to_prepare` blocks). Discover every
+  # top-level target and emit one RBS block per target, reusing the
+  # single-target pipeline for each declaration (felixefelip/rbs_infer#38).
+  def generate_multi_target_rbs
+    discovery = TargetDiscovery.new
+    @parsed_target.tree.accept(discovery)
+    decl_targets = discovery.declaration_targets
+    include_targets = discovery.include_targets
+
+    # The common case (one class/module, no reopen-includes) takes the
+    # exact single-target path — the ClassNameExtractor pick already in
+    # @target_class — so existing output is untouched.
+    if decl_targets.size <= 1 && include_targets.empty?
+      return nil unless @target_class
+      return build_single_target_rbs
+    end
+
+    blocks = []
+
+    decl_targets.each do |target|
+      sub = self.class.new(
+        target_class: target[:name],
+        target_file: @target_file,
+        source_files: @source_files,
+        extra_caller_sources: @extra_caller_sources
+      )
+      block = sub.generate_rbs
+      blocks << block if block && !block.strip.empty?
+    end
+
+    include_targets.each do |receiver, modules|
+      blocks << build_include_reopen(receiver, modules)
+    end
+
+    return nil if blocks.empty?
+
+    blocks.join("\n")
+  end
+
+  # Synthesizes a reopen block for `Receiver.include Mod` call-sites: the
+  # receiver has no body in this file, just the mixin. RbsBuilder handles
+  # the namespace wrapping (`module ActiveStorage; module Blobs; class
+  # RedirectController; include ...`).
+  def build_include_reopen(receiver, modules)
+    members = modules.map do |mod|
+      Member.new(kind: :include, name: mod, signature: mod, visibility: :public, owner: nil)
+    end
+
+    RbsBuilder.new(
+      target_class: receiver,
+      superclass_name: nil,
+      namespace_classes: resolve_namespace_classes(receiver),
+      is_module: false
+    ).build(members, {}, {})
+  end
+
+  def build_single_target_rbs
     # Parsear o arquivo-alvo para extrair todos os membros da classe
     target_members = parse_target_class
     resolve_delegate_methods(target_members)
@@ -665,8 +745,8 @@ module RbsInfer
 
   # ─── Resolver quais namespaces da classe-alvo são class (não module) ──
 
-  def resolve_namespace_classes
-    parts = @target_class.split("::")
+  def resolve_namespace_classes(class_name = @target_class)
+    parts = class_name.split("::")
     parts.pop
 
     classes = Set.new
@@ -699,6 +779,7 @@ require_relative "known_return_types_builder"
 require_relative "rbs_annotation_parser"
 require_relative "optional_param_extractor"
 require_relative "class_name_extractor"
+require_relative "target_discovery"
 require_relative "class_body_attr_analyzer"
 require_relative "intra_class_call_analyzer"
 require_relative "initialize_body_analyzer"

--- a/lib/rbs_infer/class_member_collector.rb
+++ b/lib/rbs_infer/class_member_collector.rb
@@ -29,23 +29,45 @@ module RbsInfer
       self.scope_target = target_class
     end
 
+    # is_module/superclass/is_controller are read off the node that IS the
+    # target — not the first declaration in the file. A multi-target file
+    # reopens several classes/modules; keying on "first seen" would leak
+    # one target's superclass onto another. `at_target?` (LexicalScope)
+    # pins the capture to the matching frame. With no target set (the
+    # collector used standalone), fall back to the legacy "first
+    # declaration wins" behavior.
     def visit_module_node(node)
-      @is_module = true unless @superclass_name
       segment = RbsInfer::Analyzer.extract_constant_path(node.constant_path)
-      with_scope(:module, segment) { super }
+      with_scope(:module, segment) do
+        @is_module = true unless @superclass_name if capture_metadata_here?
+        super
+      end
     end
 
     def visit_class_node(node)
-      @is_module = false
-      unless @primary_class_seen
-        @primary_class_seen = true
-        if node.superclass
-          @superclass_name = RbsInfer::Analyzer.extract_constant_path(node.superclass)
-          @is_controller = CONTROLLER_BASES.include?(@superclass_name)
-        end
-      end
       segment = RbsInfer::Analyzer.extract_constant_path(node.constant_path)
-      with_scope(:class, segment) { super }
+      with_scope(:class, segment) do
+        capture_class_metadata(node) if capture_metadata_here?
+        super
+      end
+    end
+
+    # When a target is set, only the matching frame contributes metadata
+    # (multi-target correctness); otherwise every declaration does, so the
+    # legacy first-wins guards below decide.
+    def capture_metadata_here?
+      scope_target ? at_target? : true
+    end
+
+    def capture_class_metadata(node)
+      @is_module = false
+      return if @primary_class_seen
+
+      @primary_class_seen = true
+      return unless node.superclass
+
+      @superclass_name = RbsInfer::Analyzer.extract_constant_path(node.superclass)
+      @is_controller = CONTROLLER_BASES.include?(@superclass_name)
     end
 
     # `class << self` — methods defined inside define singleton (class)
@@ -64,6 +86,12 @@ module RbsInfer
     end
 
     def visit_def_node(node)
+      # Only collect defs lexically inside the target. A def in a sibling
+      # declaration or a bare block (e.g. `on_load do def x; end end` that
+      # wasn't expanded) is not this target's method — attributing it here
+      # is exactly the multi-target leak this gate closes.
+      return super unless inside_target?
+
       is_class_method = class_method_def?(node)
       name = node.name.to_s
       sig = find_rbs_signature(@comments, @lines, node.location.start_line)
@@ -136,6 +164,13 @@ module RbsInfer
     end
 
     def extract_includes(node)
+      # `Receiver.include Mod` (explicit constant receiver) reopens another
+      # class — it is NOT a mixin of the current target. The multi-target
+      # core picks these up as separate reopen targets (TargetDiscovery);
+      # collecting them here would emit a bogus self-include. A `self.`
+      # receiver is still the current target, so only skip real constants.
+      return if node.receiver && !node.receiver.is_a?(Prism::SelfNode)
+      return unless inside_target?
       return unless node.arguments
 
       node.arguments.arguments.each do |arg|
@@ -153,6 +188,8 @@ module RbsInfer
     end
 
     def extract_extends(node)
+      return if node.receiver && !node.receiver.is_a?(Prism::SelfNode)
+      return unless inside_target?
       return unless node.arguments
 
       node.arguments.arguments.each do |arg|
@@ -170,6 +207,7 @@ module RbsInfer
     end
 
     def extract_delegates(node)
+      return unless inside_target?
       return unless node.arguments
 
       args = node.arguments.arguments
@@ -210,6 +248,7 @@ module RbsInfer
     end
 
     def extract_attrs(node)
+      return unless inside_target?
       return unless node.arguments
 
       # Buscar anotação inline na mesma linha: attr_accessor :foo #: Type

--- a/lib/rbs_infer/extensions/rails/on_load_expander.rb
+++ b/lib/rbs_infer/extensions/rails/on_load_expander.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "prism"
+require_relative "../../source_expanders"
+
+module RbsInfer
+  module Extensions
+    module Rails
+      # Desugars `ActiveSupport.on_load :hook do ... end` into a plain
+      # `class <MappedClass> ... end` reopening, so the generic
+      # multi-target pipeline sees the methods defined on the right class
+      # (felixefelip/rbs_infer#38).
+      #
+      #   ActiveSupport.on_load :active_storage_blob do
+      #     def accessible_to?(user); ...; end
+      #   end
+      #   # becomes:
+      #   class ActiveStorage::Blob
+      #     def accessible_to?(user); ...; end
+      #   end
+      #
+      # The Rails-specific knowledge lives entirely in LOAD_HOOKS — the
+      # core never learns a load-hook symbol. Like CurrentAttributesExpander
+      # this is pure Prism (no Rails at runtime) and self-gates on the
+      # `on_load` substring, so it is always safe to register by default.
+      module OnLoadExpander
+        # Built-in `ActiveSupport.on_load` hooks → the class each one
+        # reopens. Names mirror the `run_load_hooks`/`on_load` calls across
+        # the Rails framework.
+        LOAD_HOOKS = {
+          "active_record" => "ActiveRecord::Base",
+          "active_record_fixture_set" => "ActiveRecord::FixtureSet",
+          "active_storage_record" => "ActiveStorage::Record",
+          "active_storage_blob" => "ActiveStorage::Blob",
+          "active_storage_attachment" => "ActiveStorage::Attachment",
+          "active_storage_variant_record" => "ActiveStorage::VariantRecord",
+          "action_controller" => "ActionController::Base",
+          "action_controller_base" => "ActionController::Base",
+          "action_controller_api" => "ActionController::API",
+          "action_mailer" => "ActionMailer::Base",
+          "action_view" => "ActionView::Base",
+          "action_text_content" => "ActionText::Content",
+          "action_text_rich_text" => "ActionText::RichText",
+          "action_text_encrypted_rich_text" => "ActionText::EncryptedRichText",
+          "active_job" => "ActiveJob::Base",
+        }.freeze
+
+        module_function
+
+        # Returns the expanded source, or nil when there is nothing to
+        # rewrite (no recognized `on_load` block).
+        def expand(source)
+          return nil unless source.include?("on_load")
+
+          result = Prism.parse(source)
+          return nil unless result.success?
+
+          calls = RbsInfer::Analyzer.find_all_nodes(result.value) { |node| on_load_call?(node) }
+          replacements = calls.filter_map { |call| replacement_for(source, call) }
+          return nil if replacements.empty?
+
+          apply_replacements(source, replacements)
+        end
+
+        # `ActiveSupport.on_load :known_hook do ... end` — explicit
+        # `ActiveSupport` receiver, a recognized symbol as first argument,
+        # and a block to lift into the class body.
+        def on_load_call?(node)
+          return false unless node.is_a?(Prism::CallNode)
+          return false unless node.name == :on_load
+          return false unless node.block.is_a?(Prism::BlockNode)
+
+          receiver = node.receiver
+          return false unless receiver.is_a?(Prism::ConstantReadNode) && receiver.name == :ActiveSupport
+
+          first_arg = node.arguments&.arguments&.first
+          first_arg.is_a?(Prism::SymbolNode) && LOAD_HOOKS.key?(first_arg.unescaped)
+        end
+
+        def replacement_for(source, call)
+          klass = LOAD_HOOKS[call.arguments.arguments.first.unescaped]
+          body = call.block.body
+          body_source = body ? slice(source, body) : ""
+
+          {
+            start: call.location.start_offset,
+            end: call.location.end_offset,
+            text: "class #{klass}\n#{body_source}\nend",
+          }
+        end
+
+        def slice(source, node)
+          source.byteslice(node.location.start_offset, node.location.end_offset - node.location.start_offset)
+        end
+
+        # Applies the replacements back to front so earlier byte offsets
+        # stay valid (mirrors CurrentAttributesExpander).
+        def apply_replacements(source, replacements)
+          out = source.dup
+          replacements.sort_by { |r| -r[:start] }.each do |r|
+            out = out.byteslice(0, r[:start]) + r[:text] + out.byteslice(r[:end]..)
+          end
+          out
+        end
+      end
+
+      # Pure Prism, self-gating — safe to register by default.
+      SourceExpanders.register(OnLoadExpander)
+    end
+  end
+end

--- a/lib/rbs_infer/lexical_scope.rb
+++ b/lib/rbs_infer/lexical_scope.rb
@@ -31,11 +31,17 @@ module RbsInfer
       scope_stack.pop
     end
 
+    # The target's fully-qualified name with any leading `::` stripped, or
+    # nil when no target is set (flat consumers like DefCollector).
+    def normalized_target
+      scope_target&.sub(/\A::/, "")
+    end
+
     # The nested-module path owning members at the current position
     # (relative to the target scope), or nil for direct members of the
     # target / positions outside it.
     def current_owner
-      target = scope_target&.sub(/\A::/, "")
+      target = normalized_target
       return nil unless target
 
       target_idx = scope_stack.index { |f| f[:path] == target }
@@ -43,6 +49,28 @@ module RbsInfer
 
       mods = scope_stack[(target_idx + 1)..].select { |f| f[:kind] == :module && f[:name] }
       mods.empty? ? nil : mods.map { |f| f[:name] }.join("::")
+    end
+
+    # True when the current traversal position is lexically inside the
+    # target declaration (the target frame is open on the scope stack).
+    # Members collected outside it belong to a sibling target or are
+    # orphan defs (e.g. a `def` in a bare block) — the multi-target core
+    # must not attribute those to this target. With no target set, every
+    # position counts as "inside" (flat default, preserving DefCollector).
+    def inside_target?
+      target = normalized_target
+      return true unless target
+
+      scope_stack.any? { |f| f[:path] == target }
+    end
+
+    # True when the innermost open scope IS the target declaration itself
+    # — the point at which is_module/superclass must be read off the node.
+    def at_target?
+      target = normalized_target
+      return false unless target
+
+      scope_stack.last && scope_stack.last[:path] == target
     end
 
     # True when the innermost open class/module scope is a `class << self`

--- a/lib/rbs_infer/method_type_resolver.rb
+++ b/lib/rbs_infer/method_type_resolver.rb
@@ -19,6 +19,13 @@ module RbsInfer
       @rbs_definition_resolver = RbsDefinitionResolver.new
     end
 
+    # The RBS type-parameter list of an existing class ("[unchecked out
+    # Elem]"), or "" — used when reopening a generic class so the emitted
+    # declaration matches (felixefelip/rbs_infer#38).
+    def type_param_string(class_name)
+      @rbs_definition_resolver.type_param_string(class_name)
+    end
+
     def resolve(class_name, method_name, block_body_type: nil)
       return nil unless class_name && class_name != "untyped"
 

--- a/lib/rbs_infer/rbs_builder.rb
+++ b/lib/rbs_infer/rbs_builder.rb
@@ -1,12 +1,18 @@
 module RbsInfer
   class RbsBuilder
-    def initialize(target_class:, superclass_name:, namespace_classes: Set.new, is_module: false, type_params: "")
+    # All keyword args are required: both call-sites always supply them, and
+    # omitting any would be silently wrong (a missing `type_params` reopens a
+    # generic class without its params → GenericParameterMismatchError; a
+    # missing `is_module`/`namespace_classes` mis-renders the declaration).
+    # Per docs/engineering/required-threaded-deps.md, that's "required", not
+    # "defaulted".
+    def initialize(target_class:, superclass_name:, namespace_classes:, is_module:, type_params:)
       @target_class = target_class
       @superclass_name = superclass_name
       @namespace_classes = namespace_classes
       @is_module = is_module
       # Generic type-parameter list ("[unchecked out Elem]") for the leaf
-      # declaration when reopening a generic class — empty for the common
+      # declaration when reopening a generic class; "" for the common
       # non-generic case (felixefelip/rbs_infer#38).
       @type_params = type_params
     end

--- a/lib/rbs_infer/rbs_builder.rb
+++ b/lib/rbs_infer/rbs_builder.rb
@@ -1,10 +1,14 @@
 module RbsInfer
   class RbsBuilder
-    def initialize(target_class:, superclass_name:, namespace_classes: Set.new, is_module: false)
+    def initialize(target_class:, superclass_name:, namespace_classes: Set.new, is_module: false, type_params: "")
       @target_class = target_class
       @superclass_name = superclass_name
       @namespace_classes = namespace_classes
       @is_module = is_module
+      # Generic type-parameter list ("[unchecked out Elem]") for the leaf
+      # declaration when reopening a generic class — empty for the common
+      # non-generic case (felixefelip/rbs_infer#38).
+      @type_params = type_params
     end
 
     def build(members, init_arg_types, attr_types, optional_params = Set.new, method_param_types = {}, ivar_types: {}, markers: [])
@@ -22,7 +26,7 @@ module RbsInfer
         lines << "#{"  " * i}#{keyword} #{mod}"
       end
       keyword = @is_module ? "module" : "class"
-      lines << "#{base_indent}#{keyword} #{class_name}#{!@is_module && @superclass_name ? " < #{qualify(@superclass_name)}" : ""}"
+      lines << "#{base_indent}#{keyword} #{class_name}#{@type_params}#{!@is_module && @superclass_name ? " < #{qualify(@superclass_name)}" : ""}"
 
       # Emitir instance variables tipadas (@post: Post, @posts: ...)
       ivar_types.each do |name, type|

--- a/lib/rbs_infer/rbs_definition_resolver.rb
+++ b/lib/rbs_infer/rbs_definition_resolver.rb
@@ -126,6 +126,34 @@ module RbsInfer
       nil
     end
 
+    # The RBS type-parameter list of an existing class/module, rendered as a
+    # string ("[unchecked out Elem]"), or "" when it has none or is unknown.
+    #
+    # Reopening a generic class (e.g. `Array.include M` → `class Array ...`)
+    # must repeat its EXACT params: RBS validates arity plus
+    # variance/bounds/defaults after renaming, raising
+    # GenericParameterMismatchError otherwise — which poisons the whole Steep
+    # environment, not just the one file (felixefelip/rbs_infer#38). Emitting
+    # the params verbatim from the primary declaration guarantees the match.
+    def type_param_string(class_name)
+      return "" unless rbs_builder
+
+      type_name = build_rbs_type_name(class_name)
+      return "" unless type_name
+
+      entry = rbs_builder.env.class_decls[type_name]
+      return "" unless entry
+
+      params = entry.type_params
+      return "" if params.empty?
+
+      "[#{params.map(&:to_s).join(", ")}]"
+    rescue StandardError
+      # A lookup failure must never break generation — fall back to no params
+      # (correct for the overwhelmingly common non-generic case).
+      ""
+    end
+
     private
 
     def rbs_builder

--- a/lib/rbs_infer/target_discovery.rb
+++ b/lib/rbs_infer/target_discovery.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module RbsInfer
+  # Walks a (possibly macro-expanded) file tree and enumerates every
+  # top-level type the file defines or reopens — the input to the
+  # multi-target core (felixefelip/rbs_infer#38).
+  #
+  # Two kinds of target:
+  #
+  # - **declaration targets**: each `class`/`module` declared at
+  #   class/module-nesting depth 0. Blocks (`on_load`, `to_prepare`, any
+  #   `do ... end`) do NOT count as nesting, so a `module M` inside a
+  #   `to_prepare` block is still depth 0. Declarations nested inside
+  #   another class/module are left out — the owner mechanism in
+  #   ClassMemberCollector/RbsBuilder already emits them in place.
+  #
+  # - **include targets**: `Receiver.include Mod` calls with an explicit
+  #   constant receiver. These reopen `Receiver` to mix in `Mod`; there is
+  #   no class body to analyze, so the core synthesizes a reopen block.
+  class TargetDiscovery < Prism::Visitor
+    attr_reader :declaration_targets, :include_targets
+
+    def initialize
+      @depth = 0
+      @declaration_targets = []
+      # receiver name => ordered, de-duplicated list of included module names
+      @include_targets = {}
+    end
+
+    def visit_module_node(node)
+      record_declaration(node, is_module: true)
+      nest { super }
+    end
+
+    def visit_class_node(node)
+      record_declaration(node, is_module: false)
+      nest { super }
+    end
+
+    def visit_call_node(node)
+      record_include_target(node) if node.name == :include
+      super
+    end
+
+    private
+
+    def nest
+      @depth += 1
+      yield
+    ensure
+      @depth -= 1
+    end
+
+    def record_declaration(node, is_module:)
+      return unless @depth.zero?
+
+      name = RbsInfer::Analyzer.extract_constant_path(node.constant_path)
+      return unless name && !name.empty?
+
+      @declaration_targets << { name: name, is_module: is_module }
+    end
+
+    def record_include_target(node)
+      receiver = node.receiver
+      return unless receiver.is_a?(Prism::ConstantReadNode) || receiver.is_a?(Prism::ConstantPathNode)
+
+      receiver_name = RbsInfer::Analyzer.extract_constant_path(receiver)
+      return unless receiver_name && node.arguments
+
+      modules = node.arguments.arguments.filter_map { |arg| RbsInfer::Analyzer.extract_constant_path(arg) }
+      return if modules.empty?
+
+      list = (@include_targets[receiver_name] ||= [])
+      list.concat(modules)
+      list.uniq!
+    end
+  end
+end

--- a/spec/dummy/Steepfile
+++ b/spec/dummy/Steepfile
@@ -39,6 +39,11 @@ target :app do
   check "lib"
   check "app/views/**/*.erb"
   ignore "app/views/pwa/**"
+  # Framework-patching files (raw `on_load`/`to_prepare` reopenings) cannot
+  # be impl-checked by stock Steep — the block receiver is unknown to it.
+  # rbs_infer's value here is the GENERATED RBS (felixefelip/rbs_infer#38),
+  # validated by the snapshot test; the raw source is not type-checked.
+  ignore "lib/rails_ext/**/*.rb"
   signature "sig"
   signature "app"
   signature "lib"

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -26,7 +26,10 @@ module Dummy
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks])
+    # `rails_ext` holds framework-patching files (on_load/to_prepare
+    # reopenings) that are not Zeitwerk-autoloadable constants — the
+    # rbs_infer multi-target fixture (felixefelip/rbs_infer#38).
+    config.autoload_lib(ignore: %w[assets tasks rails_ext])
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/spec/dummy/lib/rails_ext/active_storage_authorization.rb
+++ b/spec/dummy/lib/rails_ext/active_storage_authorization.rb
@@ -1,0 +1,60 @@
+# Multi-target fixture (felixefelip/rbs_infer#38): one file that reopens
+# several classes via `ActiveSupport.on_load`, defines a module inside a
+# `to_prepare` block, and mixes that module into four controllers with
+# `Receiver.include`. Exercises items 1 (multi-target), 2 (Receiver.include)
+# and 3 (on_load expander) together.
+ActiveSupport.on_load :active_storage_blob do
+  def accessible_to?(user)
+    attachments.includes(:record).any? { |attachment| attachment.accessible_to?(user) } || attachments.none?
+  end
+
+  def publicly_accessible?
+    attachments.includes(:record).any? { |attachment| attachment.publicly_accessible? }
+  end
+end
+
+ActiveSupport.on_load :active_storage_attachment do
+  def accessible_to?(user)
+    record.try(:accessible_to?, user)
+  end
+
+  def publicly_accessible?
+    record.try(:publicly_accessible?)
+  end
+end
+
+Rails.application.config.to_prepare do
+  module ActiveStorage::Authorize
+    extend ActiveSupport::Concern
+
+    included do
+      # Ensure require_authentication runs after set_blob.
+      skip_before_action :require_authentication
+      before_action :require_authentication, :ensure_accessible, unless: :publicly_accessible_blob?
+    end
+
+    private
+      def bearer_token_authenticatable_request?
+        true
+      end
+
+      def publicly_accessible_blob?
+        @blob.publicly_accessible?
+      end
+
+      def ensure_accessible
+        unless @blob.accessible_to?(Current.user)
+          head :forbidden
+        end
+      end
+
+      def http_cache_forever(public: false, &block)
+        super(public: public && publicly_accessible_blob?, &block)
+      end
+  end
+
+  ActiveStorage::Blobs::RedirectController.include ActiveStorage::Authorize
+  ActiveStorage::Blobs::ProxyController.include ActiveStorage::Authorize
+  ActiveStorage::Representations::RedirectController.include ActiveStorage::Authorize
+  ActiveStorage::Representations::ProxyController.include ActiveStorage::Authorize
+end

--- a/spec/dummy/lib/rails_ext/array_conversions.rb
+++ b/spec/dummy/lib/rails_ext/array_conversions.rb
@@ -1,0 +1,12 @@
+# Reopens a generic core class (`Array`) via `Receiver.include`
+# (felixefelip/rbs_infer#38). Regression guard: the emitted `class Array`
+# reopening must carry Array's exact type parameters (`[unchecked out Elem]`),
+# or RBS raises GenericParameterMismatchError and poisons the whole Steep
+# environment.
+module ChoiceSentenceArrayConversion
+  def to_choice_sentence
+    to_sentence two_words_connector: " or ", last_word_connector: ", or "
+  end
+end
+
+Array.include ChoiceSentenceArrayConversion

--- a/spec/expectations/lib/rails_ext/active_storage_authorization.rbs
+++ b/spec/expectations/lib/rails_ext/active_storage_authorization.rbs
@@ -1,0 +1,58 @@
+module ActiveStorage
+  class Blob
+    def accessible_to?: (untyped user) -> untyped
+    def publicly_accessible?: () -> untyped
+  end
+end
+
+module ActiveStorage
+  class Attachment
+    def accessible_to?: (untyped user) -> untyped
+    def publicly_accessible?: () -> untyped
+  end
+end
+
+module ActiveStorage
+  module Authorize
+    extend ActiveSupport::Concern
+
+    private
+
+    def bearer_token_authenticatable_request?: () -> bool
+    def publicly_accessible_blob?: () -> untyped
+    def ensure_accessible: () -> untyped
+    def http_cache_forever: (?public: untyped) ?{ (untyped) -> untyped } -> untyped
+  end
+end
+
+module ActiveStorage
+  module Blobs
+    class RedirectController
+      include ::ActiveStorage::Authorize
+    end
+  end
+end
+
+module ActiveStorage
+  module Blobs
+    class ProxyController
+      include ::ActiveStorage::Authorize
+    end
+  end
+end
+
+module ActiveStorage
+  module Representations
+    class RedirectController
+      include ::ActiveStorage::Authorize
+    end
+  end
+end
+
+module ActiveStorage
+  module Representations
+    class ProxyController
+      include ::ActiveStorage::Authorize
+    end
+  end
+end

--- a/spec/expectations/lib/rails_ext/array_conversions.rbs
+++ b/spec/expectations/lib/rails_ext/array_conversions.rbs
@@ -1,0 +1,7 @@
+module ChoiceSentenceArrayConversion
+  def to_choice_sentence: () -> untyped
+end
+
+class Array[unchecked out Elem]
+  include ChoiceSentenceArrayConversion
+end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -88,6 +88,27 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     expect(expanded).to eq(expectation_path.read)
   end
 
+  # Multi-target file (felixefelip/rbs_infer#38): no target_class is
+  # passed, so the analyzer discovers and emits every type the file
+  # reopens — the `on_load` blocks (expanded to `ActiveStorage::Blob` /
+  # `Attachment`), the `to_prepare` module, and the four
+  # `Receiver.include ActiveStorage::Authorize` controllers.
+  it "multi-target rails_ext file matches expected RBS" do
+    name = "lib/rails_ext/active_storage_authorization"
+    rbs = RbsInfer::Analyzer.new(
+      target_file: "#{name}.rb",
+      source_files: source_files
+    ).generate_rbs
+
+    if ENV["UPDATE_EXPECTATIONS"]
+      path = expectations_dir.join("#{name}.rbs")
+      path.dirname.mkpath
+      path.write(rbs)
+    end
+
+    expect(rbs.chomp).to eq(expected_rbs(name).chomp)
+  end
+
   it "PostsController matches expected RBS" do
     assert_snapshot("controllers/posts_controller", target_class: "PostsController", target_file: "app/controllers/posts_controller.rb")
   end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -113,6 +113,39 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     expect(rbs.chomp).to eq(expected_rbs(name).chomp)
   end
 
+  # Reopening a generic core class via `Receiver.include` must repeat its
+  # exact type parameters, or RBS rejects the file with
+  # GenericParameterMismatchError (felixefelip/rbs_infer#38).
+  it "generic-class reopen carries the class's type parameters" do
+    require "tmpdir"
+    name = "lib/rails_ext/array_conversions"
+    rbs = RbsInfer::Analyzer.new(
+      target_file: "#{name}.rb",
+      source_files: source_files
+    ).generate_rbs
+
+    if ENV["UPDATE_EXPECTATIONS"]
+      path = expectations_dir.join("#{name}.rbs")
+      path.dirname.mkpath
+      path.write(rbs)
+    end
+
+    expect(rbs.chomp).to eq(expected_rbs(name).chomp)
+    expect(rbs).to include("class Array[unchecked out Elem]")
+
+    # The reopen must load cleanly alongside core RBS (the original crash
+    # was a GenericParameterMismatchError raised while building ::Array).
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, "gen.rbs"), rbs)
+      loader = RBS::EnvironmentLoader.new
+      loader.add(path: Pathname(dir))
+      env = RBS::Environment.from_loader(loader).resolve_type_names
+      defn = RBS::DefinitionBuilder.new(env: env)
+                                   .build_instance(RBS::TypeName.parse("::Array").absolute!)
+      expect(defn.methods).to have_key(:to_choice_sentence)
+    end
+  end
+
   it "PostsController matches expected RBS" do
     assert_snapshot("controllers/posts_controller", target_class: "PostsController", target_file: "app/controllers/posts_controller.rb")
   end

--- a/spec/lib/rbs_infer/extensions/rails/on_load_expander_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/on_load_expander_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rbs_infer/extensions/rails/on_load_expander"
+
+RSpec.describe RbsInfer::Extensions::Rails::OnLoadExpander do
+  def expand(source)
+    described_class.expand(source)
+  end
+
+  it "returns nil for sources without on_load" do
+    expect(expand(<<~RUBY)).to be_nil
+      class User < ApplicationRecord
+      end
+    RUBY
+  end
+
+  it "returns nil for an unrecognized load hook" do
+    expect(expand(<<~RUBY)).to be_nil
+      ActiveSupport.on_load :some_custom_hook do
+        def foo; end
+      end
+    RUBY
+  end
+
+  it "returns nil when on_load is not called on ActiveSupport" do
+    expect(expand(<<~RUBY)).to be_nil
+      Other.on_load :active_storage_blob do
+        def foo; end
+      end
+    RUBY
+  end
+
+  it "rewrites a known hook block into a class reopening" do
+    expanded = expand(<<~RUBY)
+      ActiveSupport.on_load :active_storage_blob do
+        def accessible_to?(user)
+          true
+        end
+      end
+    RUBY
+
+    expect(expanded).to eq(<<~RUBY.chomp + "\n")
+      class ActiveStorage::Blob
+      def accessible_to?(user)
+          true
+        end
+      end
+    RUBY
+    expect(Prism.parse(expanded).success?).to be(true)
+  end
+
+  it "rewrites multiple on_load blocks in one file" do
+    expanded = expand(<<~RUBY)
+      ActiveSupport.on_load :active_storage_blob do
+        def a; end
+      end
+
+      ActiveSupport.on_load :active_storage_attachment do
+        def b; end
+      end
+    RUBY
+
+    expect(expanded).to include("class ActiveStorage::Blob")
+    expect(expanded).to include("class ActiveStorage::Attachment")
+    expect(Prism.parse(expanded).success?).to be(true)
+  end
+
+  it "maps the common Rails framework hooks" do
+    {
+      "active_record" => "ActiveRecord::Base",
+      "action_controller" => "ActionController::Base",
+      "action_mailer" => "ActionMailer::Base",
+      "active_job" => "ActiveJob::Base",
+    }.each do |hook, klass|
+      expanded = expand("ActiveSupport.on_load :#{hook} do\n  def x; end\nend\n")
+      expect(expanded).to include("class #{klass}"), "expected :#{hook} → #{klass}"
+    end
+  end
+end

--- a/spec/lib/rbs_infer/rbs_builder_spec.rb
+++ b/spec/lib/rbs_infer/rbs_builder_spec.rb
@@ -2,9 +2,22 @@ require "spec_helper"
 require "rbs_infer"
 
 RSpec.describe RbsInfer::RbsBuilder do
+  # RbsBuilder's kwargs are all required (see its initialize). This helper
+  # supplies test-only defaults so each example states only what it cares
+  # about — keeping the production API strict while specs stay terse.
+  def make_builder(target_class:, superclass_name:, namespace_classes: Set.new, is_module: false, type_params: "")
+    described_class.new(
+      target_class: target_class,
+      superclass_name: superclass_name,
+      namespace_classes: namespace_classes,
+      is_module: is_module,
+      type_params: type_params
+    )
+  end
+
   describe "#has_class_methods_module?", :dummy_app do
     let(:builder) do
-      described_class.new(target_class: "Foo", superclass_name: nil)
+      make_builder(target_class: "Foo", superclass_name: nil)
     end
 
     it "retorna true para módulo que contém sub-módulo ClassMethods" do
@@ -29,7 +42,7 @@ RSpec.describe RbsInfer::RbsBuilder do
 
   describe "#build com namespaces" do
     it "usa 'module' para namespace que é módulo (sintaxe compacta)" do
-      builder = described_class.new(
+      builder = make_builder(
         target_class: "Card::Eventable::SystemCommenter",
         superclass_name: nil,
         namespace_classes: Set.new  # Card::Eventable NÃO está no set → deve ser module
@@ -43,7 +56,7 @@ RSpec.describe RbsInfer::RbsBuilder do
     end
 
     it "usa 'class' para namespace que é classe" do
-      builder = described_class.new(
+      builder = make_builder(
         target_class: "Card::Eventable::SystemCommenter",
         superclass_name: nil,
         namespace_classes: Set.new(["Card::Eventable"])
@@ -63,7 +76,7 @@ RSpec.describe RbsInfer::RbsBuilder do
       members = [
         RbsInfer::Member.new(kind: :include, name: "Storage::Totaled", signature: "", visibility: :public)
       ]
-      builder = described_class.new(target_class: "Account::Storage", superclass_name: nil)
+      builder = make_builder(target_class: "Account::Storage", superclass_name: nil)
       result = builder.build(members, {}, {})
 
       expect(result).to include("include ::Storage::Totaled")
@@ -71,7 +84,7 @@ RSpec.describe RbsInfer::RbsBuilder do
 
     it "prefixa superclass com :: quando o nome coincide com parte do namespace" do
       # Account::Export < Export → dentro de class Account, Export resolve como Account::Export
-      builder = described_class.new(target_class: "Account::Export", superclass_name: "Export")
+      builder = make_builder(target_class: "Account::Export", superclass_name: "Export")
       result = builder.build([], {}, {})
 
       expect(result).to include("class Export < ::Export")
@@ -81,7 +94,7 @@ RSpec.describe RbsInfer::RbsBuilder do
       members = [
         RbsInfer::Member.new(kind: :include, name: "ActiveSupport::Concern", signature: "", visibility: :public)
       ]
-      builder = described_class.new(target_class: "Account::Storage", superclass_name: nil)
+      builder = make_builder(target_class: "Account::Storage", superclass_name: nil)
       result = builder.build(members, {}, {})
 
       expect(result).to include("include ActiveSupport::Concern")
@@ -91,7 +104,7 @@ RSpec.describe RbsInfer::RbsBuilder do
 
   describe "#build com protected" do
     let(:builder) do
-      described_class.new(target_class: "Foo", superclass_name: nil)
+      make_builder(target_class: "Foo", superclass_name: nil)
     end
 
     it "não emite 'protected' no RBS (trata como public)" do
@@ -130,7 +143,7 @@ RSpec.describe RbsInfer::RbsBuilder do
     end
 
     it "emite NOME: Tipo na ordem de fonte (membros)" do
-      builder = described_class.new(target_class: "Color", superclass_name: nil)
+      builder = make_builder(target_class: "Color", superclass_name: nil)
       members = [
         const("COLORS", "Array[Color]"),
         const("MAX", "Integer"),
@@ -148,14 +161,14 @@ RSpec.describe RbsInfer::RbsBuilder do
     end
 
     it "gera RBS parseável" do
-      builder = described_class.new(target_class: "Color", superclass_name: nil)
+      builder = make_builder(target_class: "Color", superclass_name: nil)
       result = builder.build([const("MAX", "Integer")], {}, {})
 
       expect { RBS::Parser.parse_signature(result) }.not_to raise_error
     end
 
     it "emite constantes de módulo aninhado dentro do módulo (owner)" do
-      builder = described_class.new(target_class: "Outer", superclass_name: nil)
+      builder = make_builder(target_class: "Outer", superclass_name: nil)
       member = RbsInfer::Member.new(
         kind: :constant, name: "SEP", signature: "SEP: String", visibility: :public, owner: "Formatting"
       )
@@ -166,7 +179,7 @@ RSpec.describe RbsInfer::RbsBuilder do
     end
 
     it "emite constantes em escopo de módulo (is_module)" do
-      builder = described_class.new(target_class: "Settings", superclass_name: nil, is_module: true)
+      builder = make_builder(target_class: "Settings", superclass_name: nil, is_module: true)
       result = builder.build([const("VERSION", "String")], {}, {})
 
       expect(result).to include("module Settings")
@@ -174,7 +187,7 @@ RSpec.describe RbsInfer::RbsBuilder do
     end
 
     it "separa as constantes dos métodos com uma linha em branco" do
-      builder = described_class.new(target_class: "Color", superclass_name: nil)
+      builder = make_builder(target_class: "Color", superclass_name: nil)
       members = [
         const("MAX", "Integer"),
         RbsInfer::Member.new(kind: :method, name: "name", signature: "name: () -> String", visibility: :public)
@@ -186,7 +199,7 @@ RSpec.describe RbsInfer::RbsBuilder do
     end
 
     it "NÃO adiciona linha em branco quando só há constantes (sem corpo após)" do
-      builder = described_class.new(target_class: "Color", superclass_name: nil)
+      builder = make_builder(target_class: "Color", superclass_name: nil)
       result = builder.build([const("MAX", "Integer")], {}, {})
 
       # constante seguida direto do `end`, sem linha em branco pendurada
@@ -194,7 +207,7 @@ RSpec.describe RbsInfer::RbsBuilder do
     end
 
     it "não duplica a linha em branco quando a seção private segue as constantes" do
-      builder = described_class.new(target_class: "Color", superclass_name: nil)
+      builder = make_builder(target_class: "Color", superclass_name: nil)
       members = [
         const("MAX", "Integer"),
         RbsInfer::Member.new(kind: :method, name: "helper", signature: "helper: () -> void", visibility: :private)

--- a/spec/lib/rbs_infer/rbs_definition_resolver_spec.rb
+++ b/spec/lib/rbs_infer/rbs_definition_resolver_spec.rb
@@ -3,6 +3,25 @@ require "spec_helper"
 RSpec.describe RbsInfer::RbsDefinitionResolver do
   subject(:resolver) { described_class.new }
 
+  describe "#type_param_string" do
+    it "renders the exact params of a generic core class" do
+      expect(resolver.type_param_string("Array")).to eq("[unchecked out Elem]")
+      expect(resolver.type_param_string("Hash")).to eq("[unchecked out K, unchecked out V]")
+    end
+
+    it "returns '' for a non-generic class" do
+      expect(resolver.type_param_string("String")).to eq("")
+    end
+
+    it "returns '' for an unknown class" do
+      expect(resolver.type_param_string("Totally::Unknown::Klass")).to eq("")
+    end
+
+    it "returns '' for an unparseable name instead of raising" do
+      expect(resolver.type_param_string("@@ not a type")).to eq("")
+    end
+  end
+
   describe "#parse_intersection_components" do
     it "splits `A & B` into components" do
       expect(resolver.parse_intersection_components("Order & Order::Validated"))

--- a/spec/lib/rbs_infer/target_discovery_spec.rb
+++ b/spec/lib/rbs_infer/target_discovery_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rbs_infer"
+
+RSpec.describe RbsInfer::TargetDiscovery do
+  def discover(source)
+    visitor = described_class.new
+    Prism.parse(source).value.accept(visitor)
+    visitor
+  end
+
+  it "discovers a single top-level class" do
+    d = discover(<<~RUBY)
+      class User
+        def name; end
+      end
+    RUBY
+
+    expect(d.declaration_targets).to eq([{ name: "User", is_module: false }])
+    expect(d.include_targets).to be_empty
+  end
+
+  it "discovers sibling top-level declarations with their kind" do
+    d = discover(<<~RUBY)
+      class Foo; end
+      module Bar; end
+    RUBY
+
+    expect(d.declaration_targets).to eq([
+      { name: "Foo", is_module: false },
+      { name: "Bar", is_module: true },
+    ])
+  end
+
+  it "treats blocks as transparent (a module inside to_prepare is top-level)" do
+    d = discover(<<~RUBY)
+      Rails.application.config.to_prepare do
+        module Authorize
+          def call; end
+        end
+      end
+    RUBY
+
+    expect(d.declaration_targets).to eq([{ name: "Authorize", is_module: true }])
+  end
+
+  it "excludes declarations nested inside another class/module" do
+    d = discover(<<~RUBY)
+      class Report
+        module Formatting
+          def title; end
+        end
+        include Formatting
+      end
+    RUBY
+
+    # Only the top-level Report; Formatting is emitted in place by the
+    # owner mechanism, not as a separate target.
+    expect(d.declaration_targets).to eq([{ name: "Report", is_module: false }])
+    expect(d.include_targets).to be_empty
+  end
+
+  it "collects Receiver.include calls as include targets" do
+    d = discover(<<~RUBY)
+      Foo::Bar.include Mixin
+      Foo::Bar.include OtherMixin
+      Baz.include Mixin
+    RUBY
+
+    expect(d.include_targets).to eq({
+      "Foo::Bar" => ["Mixin", "OtherMixin"],
+      "Baz" => ["Mixin"],
+    })
+  end
+
+  it "does not treat an implicit include (self receiver) as a reopen target" do
+    d = discover(<<~RUBY)
+      class Foo
+        include Mixin
+      end
+    RUBY
+
+    expect(d.include_targets).to be_empty
+  end
+end


### PR DESCRIPTION
Closes #38.

## Problema

O core assumia **uma classe-primária por arquivo**: `ClassNameExtractor#pick_target` escolhia um único alvo e `ClassMemberCollector` despejava todo `def`/`include` solto nele (`owner: nil` = "membro direto do alvo"). Arquivos que reabrem várias classes — initializers, `lib/rails_ext/*.rb`, blocos `on_load`/`to_prepare` — geravam **RBS inválido**: self-includes circulares, métodos atribuídos à classe errada, duplicados.

Exemplo motivador (`lib/rails_ext/active_storage_authorization.rb`): antes, tudo colapsava em `module ActiveStorage::Authorize` com 4 `include ::ActiveStorage::Authorize` circulares e métodos de Blob/Attachment duplicados dentro do módulo errado.

## Solução — três peças compostas

**1. Emissão multi-alvo (item 1).** Novo `TargetDiscovery` enumera os tipos que o arquivo define: declarações `class`/`module` em profundidade-0 de aninhamento (blocos como `on_load`/`to_prepare` são transparentes; declarações aninhadas continuam tratadas pelo mecanismo de `owner`) + reaberturas `Receiver.include`. `Analyzer#generate_rbs` foi dividido em `load_and_parse_target` + `build_single_target_rbs` + `generate_multi_target_rbs`.

Contrato que **preserva toda a saída existente**: `target_class` explícito → modo single (API/testes, zero churn); invocação só com `target_file` (o CLI) → emite cada alvo descoberto, um bloco por alvo, via sub-analyzer. `ClassMemberCollector` ganhou o gate `inside_target?` (membros fora do alvo são descartados, não vazam) e lê `is_module`/`superclass` do frame correspondente (`at_target?`) em vez de "primeira declaração", com fallback legado quando não há alvo.

**2. `Receiver.include Mod` (item 2).** `extract_includes`/`extends` agora pulam receiver constante explícito (sem self-include espúrio); `TargetDiscovery` os coleta e `build_include_reopen` sintetiza o bloco de reabertura via `RbsBuilder` (com namespace wrapping).

**3. Expander `on_load` (item 3).** Plugin `SourceExpanders` no molde do `CurrentAttributesExpander`: reescreve `ActiveSupport.on_load :hook do … end` em `class <ClasseMapeada> … end` usando uma tabela de load-hooks do Rails. Prism puro, self-gating no substring `on_load`, registrado por padrão — toda a "railsidade" mora na tabela; o core nunca aprende um símbolo de hook.

## Saída resultante (exemplo)

Os 7 alvos corretos, sem includes circulares nem duplicados:

```rbs
class ActiveStorage::Blob          # via item 3 (on_load expander)
  def accessible_to?: (untyped user) -> untyped
  def publicly_accessible?: () -> untyped
end
class ActiveStorage::Attachment    # via item 3
  ...
end
module ActiveStorage::Authorize    # item 1, limpo
  extend ActiveSupport::Concern
  private
  def bearer_token_authenticatable_request?: () -> bool
  ...
end
class ActiveStorage::Blobs::RedirectController   # item 2 (×4 controllers)
  include ::ActiveStorage::Authorize
end
```

## Testes

- Specs unitários para `TargetDiscovery` e `OnLoadExpander`.
- Snapshot de integração multi-alvo (`spec/dummy/lib/rails_ext/active_storage_authorization.rb`) afirmando os 7 alvos emitidos; saída validada com `rbs parse`.
- Dummy app exclui `lib/rails_ext` do autoload Zeitwerk e do impl-check do Steep (blocos `on_load` crus não são checáveis estaticamente — o valor é o RBS **gerado**).
- **Snapshots existentes inalterados** (passam `target_class` → modo single). Suíte completa: 548 exemplos, 0 falhas.

## Fora de escopo (melhorias separadas já registradas no #38)

Hoje saem como `untyped` (honesto): retorno `bool` para corpos `any?`/`none?`/`||` (Blob), e `?public: bool` por inferência do literal default.

---

_Produzido com apoio de IA (Claude Code); sujeito a revisão humana, testes e homologação._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
