### PR TITLE
refactor(constants): make ConstantTypeResolver#resolve steep_type required

### DIFF
--- a/lib/rbs_infer/inference/constant_type_resolver.rb
+++ b/lib/rbs_infer/inference/constant_type_resolver.rb
@@ -30,9 +30,11 @@ module RbsInfer::Inference
     end
 
     # @param node [Prism::Node, nil] the constant's RHS
-    # @param steep_type [String, nil] Steep's type for this constant
+    # @param steep_type [String, nil] Steep's type for this constant, or nil
+    #   when Steep had none — required (not defaulted) so a caller that has a
+    #   Steep type can't silently drop it; pass `nil` explicitly to opt out.
     # @return [String] an RBS type (never nil; falls back to "untyped")
-    def resolve(node, steep_type: nil)
+    def resolve(node, steep_type:)
       return "untyped" if node.nil?
 
       @constructor_inferrer.infer(node) ||

--- a/spec/lib/rbs_infer/inference/constant_type_resolver_spec.rb
+++ b/spec/lib/rbs_infer/inference/constant_type_resolver_spec.rb
@@ -9,58 +9,64 @@ RSpec.describe RbsInfer::Inference::ConstantTypeResolver do
     Prism.parse(code).value.statements.body.first.value
   end
 
+  # Test-only wrapper: #resolve requires steep_type (no production default),
+  # so default it here for the cases that exercise the non-Steep paths.
+  def resolve(node, steep_type: nil)
+    resolver.resolve(node, steep_type: steep_type)
+  end
+
   describe "#resolve" do
     it "infere literais via NodeTypeInferrer (sem Steep)" do
-      expect(resolver.resolve(rhs("MAX = 8"))).to eq("Integer")
-      expect(resolver.resolve(rhs('NAME = "Blue"'))).to eq("String")
-      expect(resolver.resolve(rhs("PI = 3.14"))).to eq("Float")
-      expect(resolver.resolve(rhs("FLAG = true"))).to eq("bool")
-      expect(resolver.resolve(rhs("SYM = :blue"))).to eq("Symbol")
+      expect(resolve(rhs("MAX = 8"))).to eq("Integer")
+      expect(resolve(rhs('NAME = "Blue"'))).to eq("String")
+      expect(resolve(rhs("PI = 3.14"))).to eq("Float")
+      expect(resolve(rhs("FLAG = true"))).to eq("bool")
+      expect(resolve(rhs("SYM = :blue"))).to eq("Symbol")
     end
 
     it "resolve Klass.new para a classe (single-pass, sem RBS de Klass)" do
-      expect(resolver.resolve(rhs("BUILDER = Widget.new"), steep_type: "untyped")).to eq("Widget")
+      expect(resolve(rhs("BUILDER = Widget.new"), steep_type: "untyped")).to eq("Widget")
     end
 
     it "resolve new / self.new sem receiver para a classe-alvo" do
-      expect(resolver.resolve(rhs("INSTANCE = new"))).to eq("Color")
-      expect(resolver.resolve(rhs("INSTANCE = self.new"))).to eq("Color")
+      expect(resolve(rhs("INSTANCE = new"))).to eq("Color")
+      expect(resolve(rhs("INSTANCE = self.new"))).to eq("Color")
     end
 
     it "resolve a cadeia coletora {...}.collect { new(...) }.freeze para Array[alvo]" do
       code = 'COLORS = { "Blue" => "v1" }.collect { |name, value| new(name, value) }.freeze'
-      expect(resolver.resolve(rhs(code), steep_type: "Array[Object]")).to eq("Array[Color]")
+      expect(resolve(rhs(code), steep_type: "Array[Object]")).to eq("Array[Color]")
     end
 
     it "resolve .map { Klass.new } para Array[Klass]" do
-      expect(resolver.resolve(rhs("LIST = [1, 2].map { |i| Widget.new(i) }"))).to eq("Array[Widget]")
+      expect(resolve(rhs("LIST = [1, 2].map { |i| Widget.new(i) }"))).to eq("Array[Widget]")
     end
 
     it "trata freeze/dup como passagem do tipo do receiver" do
-      expect(resolver.resolve(rhs("A = new.freeze"))).to eq("Color")
-      expect(resolver.resolve(rhs("B = Widget.new.dup"))).to eq("Widget")
+      expect(resolve(rhs("A = new.freeze"))).to eq("Color")
+      expect(resolve(rhs("B = Widget.new.dup"))).to eq("Widget")
     end
 
     it "usa o tipo do Steep quando o Prism não consegue (arrays/hashes precisos)" do
-      expect(resolver.resolve(rhs("WEIGHTS = [1, 2, 3]"), steep_type: "Array[Integer]")).to eq("Array[Integer]")
+      expect(resolve(rhs("WEIGHTS = [1, 2, 3]"), steep_type: "Array[Integer]")).to eq("Array[Integer]")
     end
 
     it "prioriza a inferência de construtor do Prism sobre o Steep" do
       # Steep, single-pass, tipa `Widget.new` como untyped; o Prism crava Widget.
-      expect(resolver.resolve(rhs("X = Widget.new"), steep_type: "untyped")).to eq("Widget")
+      expect(resolve(rhs("X = Widget.new"), steep_type: "untyped")).to eq("Widget")
     end
 
     it "cai para untyped quando nada estático decide" do
-      expect(resolver.resolve(rhs("X = some_runtime_call"))).to eq("untyped")
-      expect(resolver.resolve(rhs("X = some_runtime_call"), steep_type: "untyped")).to eq("untyped")
+      expect(resolve(rhs("X = some_runtime_call"))).to eq("untyped")
+      expect(resolve(rhs("X = some_runtime_call"), steep_type: "untyped")).to eq("untyped")
     end
 
     it "trata RHS nil como untyped" do
-      expect(resolver.resolve(nil)).to eq("untyped")
+      expect(resolve(nil)).to eq("untyped")
     end
 
     it "ignora um tipo do Steep não-utilizável (bot/void/nil) e cai para o leaf" do
-      expect(resolver.resolve(rhs("MAX = 8"), steep_type: "bot")).to eq("Integer")
+      expect(resolve(rhs("MAX = 8"), steep_type: "bot")).to eq("Integer")
     end
   end
 end


### PR DESCRIPTION
`ConstantTypeResolver#resolve` declared `steep_type: nil`, but the **sole
production caller** — `Analyzer#assign_constant_signatures` — always passes
Steep's type for the constant:

```ruby
steep_types = ... steep_bridge.constant_types(@parsed_target.source) ...
resolver.resolve(member.value_node, steep_type: steep_types[member.name])
```

Applying the litmus from
[`required-threaded-deps.md`](docs/engineering/required-threaded-deps.md):
a caller that *has* a Steep type and forgets to pass it gets the wrong
answer silently — the constant falls through to leaf/`untyped` inference
instead of Steep's precise type (`Array[Integer]`, range/chain types, …),
with no error. That's the textbook silent-wrong case → **required**.

## Change

```ruby
def resolve(node, steep_type:)   # was: steep_type: nil
```

`nil` stays a valid, expressible value — "Steep had nothing for this
constant" is passed explicitly as `steep_type: nil`, which is honest about
opting out of the Steep oracle.

Only specs omitted the arg (exercising the Prism/leaf paths); per the doc,
they get a small test-only wrapper that defaults it, keeping the production
API strict:

```ruby
def resolve(node, steep_type: nil)
  resolver.resolve(node, steep_type: steep_type)
end
```

## Tests

No behavior change. `spec/lib` (532) and `spec/integration` (51) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
