### PR TITLE
fix: parenthesize bare union/intersection in return position

### DIFF
--- a/bin/rbs_infer
+++ b/bin/rbs_infer
@@ -10,6 +10,13 @@ output_dir = "sig/generated"
 max_passes = 10
 files = []
 
+# When set, the stabilization loop prints a line-level diff every time a
+# file's regenerated RBS differs from the previous pass. This surfaces the
+# member/type that oscillates when a file never converges (the warning at
+# the end only reports the COUNT of still-changing files, not *what* keeps
+# changing). See felixefelip/rbs_infer#9 (Array[Array[...]] nesting growth).
+debug_convergence = ENV.key?("RBS_INFER_DEBUG_CONVERGENCE")
+
 parser = OptionParser.new do |opts|
   opts.banner = "Usage: rbs_infer [options] FILE_OR_DIR [...]"
 
@@ -123,7 +130,18 @@ generate = lambda do |inputs_to_process, silent: false|
       File.write(output_path, new_content)
       puts output_path unless silent
 
-      changed_files << input if new_content != old_content
+      if new_content != old_content
+        changed_files << input
+        if debug_convergence && old_content
+          old_lines = old_content.lines
+          new_lines = new_content.lines
+          removed = old_lines - new_lines
+          added   = new_lines - old_lines
+          warn "── #{output_path} changed ──"
+          removed.each { |l| warn "  - #{l.chomp}" }
+          added.each   { |l| warn "  + #{l.chomp}" }
+        end
+      end
     else
       puts rbs
     end

--- a/lib/rbs_infer/signatures/rbs_builder.rb
+++ b/lib/rbs_infer/signatures/rbs_builder.rb
@@ -89,7 +89,7 @@ module RbsInfer::Signatures
         if method_param_types[member.name]
           sig = apply_inferred_param_types(sig, method_param_types[member.name])
         end
-        lines << "#{member_indent}def self.#{sig}"
+        lines << "#{member_indent}def self.#{RbsInfer::Signatures::RbsParserUtil.parenthesize_return_type(sig)}"
       end
 
       # Agrupar por visibilidade: public -> protected -> private
@@ -114,7 +114,7 @@ module RbsInfer::Signatures
       if mailer_class?
         send_mail = members.find { |m| m.kind == :method && m.name == "send_mail" }
         if send_mail
-          lines << "#{member_indent}def self.#{send_mail.signature}"
+          lines << "#{member_indent}def self.#{RbsInfer::Signatures::RbsParserUtil.parenthesize_return_type(send_mail.signature)}"
         end
       end
 
@@ -157,7 +157,7 @@ module RbsInfer::Signatures
         elsif method_param_types[member.name]
           sig = apply_inferred_param_types(sig, method_param_types[member.name])
         end
-        "#{indent}def #{sig}"
+        "#{indent}def #{RbsInfer::Signatures::RbsParserUtil.parenthesize_return_type(sig)}"
       when :attr_accessor, :attr_reader, :attr_writer
         sig = member.signature
         sig = "#{member.name}: #{attr_types[member.name]}" if sig.end_with?(": untyped") && attr_types[member.name]
@@ -188,7 +188,7 @@ module RbsInfer::Signatures
           lines << "#{inner_indent}extend #{qualify(ext.name)}"
         end
         mod_members.select { |m| m.kind == :class_method }.each do |m|
-          lines << "#{inner_indent}def self.#{m.signature}"
+          lines << "#{inner_indent}def self.#{RbsInfer::Signatures::RbsParserUtil.parenthesize_return_type(m.signature)}"
         end
         mod_members.each do |m|
           line = render_value_member(m, inner_indent, {}, attr_types, method_param_types, Set.new)

--- a/lib/rbs_infer/signatures/rbs_parser_util.rb
+++ b/lib/rbs_infer/signatures/rbs_parser_util.rb
@@ -199,6 +199,60 @@ module RbsInfer::Signatures
       parenthesize_compound(type_str)
     end
 
+    # Emission-boundary guard: given a whole method signature string
+    # (`name: (params) -> ret`), parenthesizes the return type when it is a
+    # bare top-level union/intersection. A bare `|` in return position is
+    # parsed as an overload separator (`def x: () -> A | (Int) -> B`), so
+    # `def x: () -> bool | false` is a SYNTAX ERROR — RBS rejects it, Steep
+    # can't read the file back, and the stabilization loop never converges
+    # because the broken RBS re-derives every pass (felixefelip/rbs_infer#9).
+    #
+    # Every inference path is supposed to wrap via `parenthesize_compound`
+    # already, but this is the single chokepoint where `def`/`def self.`
+    # lines become text, so enforcing the invariant here covers any path
+    # that forgets (e.g. delegate methods) — current and future.
+    #
+    # Depth-aware: the return arrow is the LAST top-level `->` (depth 0
+    # over `()[]{}`), so proc-typed params (`(^() -> void) -> X`) and block
+    # types (`{ () -> void } -> X`) aren't mistaken for it. Type args that
+    # merely contain `|` (`Array[A | B]`), already-parenthesized unions, and
+    # nilable unions (`(A | B)?`) are left untouched by `parenthesize_compound`.
+    def parenthesize_return_type(method_sig)
+      arrow = last_top_level_arrow_index(method_sig)
+      return method_sig unless arrow
+
+      ret = method_sig[(arrow + 2)..].strip
+      wrapped = parenthesize_compound(ret)
+      return method_sig if wrapped == ret
+
+      "#{method_sig[0...arrow].rstrip} -> #{wrapped}"
+    end
+
+    # Index of the last `->` sitting at bracket depth 0, or nil. Used to
+    # locate the real return arrow past nested proc/block arrows.
+    def last_top_level_arrow_index(str)
+      return nil unless str
+
+      openers = { "(" => ")", "[" => "]", "{" => "}" }
+      closers = openers.values.to_set
+      depth = 0
+      found = nil
+      i = 0
+      while i < str.length
+        char = str[i]
+        if openers.key?(char)
+          depth += 1
+        elsif closers.include?(char)
+          depth -= 1 if depth > 0
+        elsif depth.zero? && char == "-" && str[i + 1] == ">"
+          found = i
+          i += 1
+        end
+        i += 1
+      end
+      found
+    end
+
     # Appends `?` to a type, parenthesizing compounds first — a bare
     # `A & B?` binds the `?` to the LAST component only (semantically
     # wrong) and is a syntax error in return position. No-op when the

--- a/spec/lib/rbs_infer/signatures/rbs_parser_util_spec.rb
+++ b/spec/lib/rbs_infer/signatures/rbs_parser_util_spec.rb
@@ -285,6 +285,36 @@ RSpec.describe RbsInfer::Signatures::RbsParserUtil do
     end
   end
 
+  describe ".parenthesize_return_type" do
+    it "wraps a bare union in return position (overload-separator ambiguity)" do
+      # `def f: () -> bool | false` is parsed as two overloads → syntax error;
+      # the parenthesized form is the only valid emission (rbs_infer#9).
+      expect(described_class.parenthesize_return_type("accessible_to?: () -> bool | false"))
+        .to eq("accessible_to?: () -> (bool | false)")
+    end
+
+    it "wraps regardless of params, including proc-typed params and blocks" do
+      expect(described_class.parenthesize_return_type("f: (untyped user) -> bool | false"))
+        .to eq("f: (untyped user) -> (bool | false)")
+      expect(described_class.parenthesize_return_type("f: (^() -> void) -> String | Integer"))
+        .to eq("f: (^() -> void) -> (String | Integer)")
+      expect(described_class.parenthesize_return_type("f: () { () -> void } -> A | B"))
+        .to eq("f: () { () -> void } -> (A | B)")
+    end
+
+    it "leaves already-valid return types untouched" do
+      [
+        "f: () -> bool",
+        "f: () -> bool?",
+        "f: () -> (bool | false)",
+        "f: () -> (A | B)?",
+        "f: () -> Array[String | Integer]",
+        "f: () -> (^() -> void)",
+        "x: untyped",
+      ].each { |sig| expect(described_class.parenthesize_return_type(sig)).to eq(sig) }
+    end
+  end
+
   describe ".nilablize" do
     it "parenthesizes compounds before appending ? (bare A & B? binds to the last component)" do
       expect(described_class.nilablize("Caderneta & Caderneta::Validated"))


### PR DESCRIPTION
## Problema

Métodos cujo tipo de retorno inferido era uma union/intersection *bare* de topo — ex. `def accessible_to?: () -> bool | false` — geravam **RBS inválido**. Em posição de retorno o `|` é o separador de *overloads* (`def f: () -> A | (Int) -> B`), então `false` é lido como início de uma segunda assinatura e o RBS rejeita o membro inteiro:

```
Syntax error: unexpected token for method type, token=`false` (kFALSE)
```

Isso também **quebrava o loop de estabilização**. Com `--output`, cada passo grava o `.rbs` e `SteepBridge.reset!` o relê, então o passo seguinte infere a classe em parte a partir da própria saída anterior. RBS inválido não parseia na releitura → o tipo é re-derivado todo passo → o arquivo nunca atinge ponto-fixo, aparecendo como `types did not converge after N stabilization passes`. Mesma classe do crescimento `Array[Array[...]]` corrigido em `9ad17c2`.

## Correção

`parenthesize_compound` (documentado em `rbs_parser_util.rb:177`) é o guard correto e quase todos os caminhos de inferência o aplicam — mas alguns caminhos de emissão (ex.: métodos delegados) interpolam o retorno cru. Em vez de remendar um caminho só, aplico o invariante no **ponto de emissão**, onde toda linha `def`/`def self.` vira texto:

- novo `RbsParserUtil.parenthesize_return_type`, que localiza a seta de retorno real (último `->` em profundidade 0 de `()[]{}`, então params com proc `(^() -> void) -> X` e blocos `{ () -> void } -> X` não confundem) e parentiza o retorno bare via o `parenthesize_compound` existente;
- ligado nos 4 sites de emissão do `RbsBuilder` (instância, `def self.`, mailer, módulos aninhados).

Formas já válidas (`bool?`, `(A | B)?`, `Array[A | B]`, unions já parentizadas, retornos proc) ficam intactas.

## Diagnóstico (segundo commit)

`RBS_INFER_DEBUG_CONVERGENCE=1` faz o loop imprimir um diff linha-a-linha a cada vez que o RBS muda entre passos — o aviso de convergência só dá a *contagem* de arquivos, nunca *o que* oscila.

## Verificação

- 535 specs unitários + 51 de integração passando, incluindo o baseline de `steep check` no dummy.
- **Nenhum snapshot mudou** → saída já correta não é afetada; é puro safety-net.
- Testes novos cobrindo `accessible_to?`, proc-params, blocos e os no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)