### PR TITLE
perf: memoize SteepBridge#type_check per source

### DIFF
--- a/lib/rbs_infer/signatures/steep_bridge.rb
+++ b/lib/rbs_infer/signatures/steep_bridge.rb
@@ -706,7 +706,26 @@ module RbsInfer::Signatures
       end
     end
 
+    # Type-checks a source string and returns Steep's `typing` (or nil). This
+    # is the single most expensive operation in the pipeline (a full Steep
+    # synthesize), and the ~7 oracle methods above each call it — so one
+    # analysis type-checks the same target source ~5x and each caller source
+    # ~2x. Memoize per source for the instance's lifetime.
+    #
+    # Safe to cache: the bridge is per-Analyzer, the result depends only on
+    # (source, env, sidecar stores), the env (`definition_builder`) only
+    # changes via the class-level `reset!` — called *between* analyses, never
+    # during one — and the stores are load-once read-only inputs. The returned
+    # `typing` is only ever read by callers, never mutated. A new analysis
+    # gets a fresh instance (and a freshly-reset env), so no cross-analysis
+    # staleness. (felixefelip/rbs_infer#47)
     def type_check(source_code)
+      (@type_check_cache ||= {}).fetch(source_code) do
+        @type_check_cache[source_code] = type_check_uncached(source_code)
+      end
+    end
+
+    private def type_check_uncached(source_code)
       ensure_initialized
       return nil unless @subtyping
 


### PR DESCRIPTION
Implementa a **oportunidade 1** de #47.

## Problema

`SteepBridge#type_check` (um *synthesize* completo do Steep) é a operação mais cara do pipeline. Os ~7 métodos-oráculo do `SteepBridge` (`method_return_types_by_kind`, `constant_types`, `local_var_types_per_method`, `ivar_write_types`, `postcondition_inferred_entries`, ...) cada um chama `type_check` — então **uma análise checa a mesma source-alvo ~5×** e cada caller ~2×.

## Mudança

Memoiza o resultado por source pelo tempo de vida da instância (`@type_check_cache`).

**Seguro:** o bridge é por-Analyzer; o `typing` depende só de (source, env, stores); o env (`definition_builder`) só muda no `reset!` class-level — chamado **entre** análises, nunca durante uma; os stores são `||=` read-only; o `typing` retornado é só lido, nunca mutado. Cada análise nova recebe instância nova + env recém-resetado → sem staleness entre análises.

## Benchmark

6 alvos do dummy × 3 iterações, env quente (`spec/dummy`):

| | synthesize execs | wall-clock | por alvo |
|---|---|---|---|
| **antes** | 369 | 11.75s | 0.653s |
| **depois** | 69 | ~5.5s | ~0.30s |

**−81% de chamadas ao Steep, ~2.1× mais rápido.** A contagem de synthesize é determinística (369→69); o wall-clock foi confirmado estável em 2 runs (5.34s / 5.67s).

## Correção

Saída **idêntica** (byte a byte): 542 specs unitários + 52 de integração passam (os testes de snapshot comparam o RBS exato), e o baseline do `steep check` no dummy continua limpo.

Refs #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)