### PR TITLE
perf: share RBS sig file/glob caches across the run

### DIFF
--- a/bin/rbs_infer
+++ b/bin/rbs_infer
@@ -155,6 +155,10 @@ if output
 
   reset_caches = lambda do
     RbsInfer::Signatures::SteepBridge.reset!
+    # Run-wide RBS file/glob caches: clear so a freshly-written sig file (new
+    # path or changed content) is re-globbed/re-parsed on the next level/pass
+    # (felixefelip/rbs_infer#47).
+    RbsInfer::Signatures::RbsTypeLookup.reset!
     # ErbCallerResolver caches controller-ivar lookups per (class, action).
     # Without this reset, pass 2 would return the empty result that pass 1
     # computed when ApplicationHelper had no RBS, losing the inferred types

--- a/lib/rbs_infer/signatures/method_type_resolver.rb
+++ b/lib/rbs_infer/signatures/method_type_resolver.rb
@@ -317,10 +317,9 @@ module RbsInfer::Signatures
       types = {}
       normalized = class_name.sub(/\A::/, "")
 
-      Dir["sig/**/*.rbs"].each do |rbs_file|
-        content = File.read(rbs_file)
-        next unless content.include?(normalized.split("::").last)
-        info = @rbs_type_lookup.parse_rbs_class_block(content, normalized)
+      RbsTypeLookup.glob("sig/**/*.rbs").each do |rbs_file|
+        next unless @rbs_type_lookup.cached_content_for(rbs_file).include?(normalized.split("::").last)
+        info = @rbs_type_lookup.class_info_from_file(rbs_file, normalized)
         info.class_method_types.each { |name, type| types[name] ||= type }
       end
 

--- a/lib/rbs_infer/signatures/rbs_type_lookup.rb
+++ b/lib/rbs_infer/signatures/rbs_type_lookup.rb
@@ -9,12 +9,71 @@ module RbsInfer::Signatures
   RbsClassInfo = Data.define(:superclass, :types, :includes, :class_method_types)
 
   class RbsTypeLookup
+    # Run-wide caches shared across every instance. A fresh RbsTypeLookup is
+    # built per Analyzer (one per file, per stabilization pass), so the old
+    # per-instance caches re-globbed and re-parsed the whole `sig/` tree (768
+    # .rbs in a real app) for each of ~hundreds of analyses — the dominant cost
+    # once `type_check` was memoized: `RBS::Parser.parse_signature` (~10%, 94%
+    # of it from here) plus `Dir.[]` (~7%), and the AST allocations driving
+    # ~half the run's GC. Hoisting these to the class collapses that to ~once
+    # per generation (felixefelip/rbs_infer#47).
+    #
+    # Only the *file-derived* data is shared (content/AST is immutable once
+    # parsed); class-name-keyed inference results stay per-instance.
+    class << self
+      # Per-file content + parsed declarations + declaration index, keyed by
+      # path and invalidated by mtime — so a sig file rewritten between
+      # dependency levels is re-parsed, while unchanged files are parsed once.
+      def file_entry(rbs_file)
+        cache = caches[:files]
+        mtime = File.mtime(rbs_file)
+        entry = cache[rbs_file]
+        return entry if entry && entry[:mtime] == mtime
+
+        content = File.read(rbs_file)
+        declarations = RbsParserUtil.parse_declarations(content)
+        cache[rbs_file] = {
+          mtime: mtime,
+          content: content,
+          declarations: declarations,
+          index: RbsParserUtil.build_declaration_index(declarations),
+        }
+      rescue Errno::ENOENT, Errno::EACCES
+        { mtime: nil, content: "", declarations: [], index: {} }
+      end
+
+      # Cached `Dir[...]` over `sig/`. New .rbs files appear between dependency
+      # levels, so (unlike file_entry) this can't be mtime-keyed; the CLI clears
+      # it via `reset!` between levels/passes. Gem-collection globs are static
+      # within a run, so caching them is likewise safe.
+      def glob(pattern)
+        caches[:globs][pattern] ||= Dir[pattern]
+      end
+
+      # Clears the run-wide caches. Called alongside `SteepBridge.reset!`
+      # between dependency levels so freshly-written sig is picked up.
+      def reset!
+        @caches = nil
+      end
+
+      private
+
+      # The caches are scoped to the working directory: the sig globs and the
+      # relative paths they yield only mean anything under a fixed `Dir.pwd`, so
+      # a `chdir` (the CLI never does mid-run, but tests do) starts fresh —
+      # mirroring `SteepBridge.definition_builder`'s dir guard.
+      def caches
+        dir = Dir.pwd
+        if @caches.nil? || @caches[:dir] != dir
+          @caches = { dir: dir, files: {}, globs: {} }
+        end
+        @caches
+      end
+    end
+
     def initialize
       @inherited_cache = {}
       @rbs_collection_cache = {}
-      @rbs_declarations_cache = {}
-      @rbs_content_cache = {}
-      @rbs_index_cache = {}
     end
 
     # Busca tipos em arquivos .rbs gerados (ex: rbs_rails para AR models)
@@ -27,7 +86,7 @@ module RbsInfer::Signatures
 
       # 1. Tentar match por nome de arquivo (caso simples: uma classe por arquivo)
       class_path = RbsInfer.class_name_to_path(normalized)
-      Dir["sig/**/*.rbs"].each do |rbs_file|
+      self.class.glob("sig/**/*.rbs").each do |rbs_file|
         next unless rbs_file.end_with?("#{class_path}.rbs")
         info = class_info_from_file(rbs_file, normalized)
         superclass ||= info.superclass
@@ -38,7 +97,7 @@ module RbsInfer::Signatures
       # 2. Buscar inner classes dentro de todos os rbs files
       if types.empty? && superclass.nil?
         short_name = normalized.split("::").last
-        Dir["sig/**/*.rbs"].each do |rbs_file|
+        self.class.glob("sig/**/*.rbs").each do |rbs_file|
           next unless cached_content_for(rbs_file).include?(short_name)
           info = class_info_from_file(rbs_file, normalized)
           next if info.types.empty? && info.superclass.nil? && info.includes.empty?
@@ -57,31 +116,19 @@ module RbsInfer::Signatures
       RbsParserUtil.class_info_from_rbs(content, class_name)
     end
 
-    # Retorna as declarations RBS cacheadas para um arquivo.
-    # Cada arquivo é lido e parseado pelo RBS::Parser no máximo uma vez por instância.
+    # Declarations RBS cacheadas para um arquivo (run-wide, ver `.file_entry`).
     def cached_declarations_for(rbs_file)
-      @rbs_declarations_cache[rbs_file] ||= begin
-        content = File.read(rbs_file)
-        @rbs_content_cache[rbs_file] = content
-        RbsParserUtil.parse_declarations(content)
-      rescue Errno::ENOENT, Errno::EACCES
-        []
-      end
+      self.class.file_entry(rbs_file)[:declarations]
     end
 
-    # Retorna o conteúdo cacheado de um arquivo RBS (lido no máximo uma vez).
+    # Conteúdo cacheado de um arquivo RBS (run-wide).
     def cached_content_for(rbs_file)
-      @rbs_content_cache[rbs_file] ||= begin
-        cached_declarations_for(rbs_file) # popula ambos os caches
-        @rbs_content_cache[rbs_file] || ""
-      end
+      self.class.file_entry(rbs_file)[:content]
     end
 
-    # Retorna RbsClassInfo para um arquivo e classe usando índice cacheado (O(1) lookup).
+    # RbsClassInfo para um arquivo e classe usando o índice cacheado (O(1)).
     def class_info_from_file(rbs_file, class_name)
-      index = @rbs_index_cache[rbs_file] ||=
-        RbsParserUtil.build_declaration_index(cached_declarations_for(rbs_file))
-      RbsParserUtil.class_info_from_index(index, class_name)
+      RbsParserUtil.class_info_from_index(self.class.file_entry(rbs_file)[:index], class_name)
     end
 
     # Resolve tipos herdados percorrendo a cadeia de superclasses via RBS
@@ -98,7 +145,7 @@ module RbsInfer::Signatures
       all_includes = []
 
       # 1. Buscar em sig/rbs_rails/
-      Dir["sig/rbs_rails/**/*.rbs"].each do |rbs_file|
+      self.class.glob("sig/rbs_rails/**/*.rbs").each do |rbs_file|
         info = class_info_from_file(rbs_file, normalized)
         parent_superclass ||= info.superclass
         info.types.each { |name, type| types[name] ||= type }
@@ -112,7 +159,7 @@ module RbsInfer::Signatures
       #     (felixefelip/rbs_infer#19 follow-up: current_user do Devise).
       if types.empty? && parent_superclass.nil?
         class_path = RbsInfer.class_name_to_path(normalized)
-        Dir["sig/**/*.rbs"].each do |rbs_file|
+        self.class.glob("sig/**/*.rbs").each do |rbs_file|
           next unless RbsInfer.file_matches_class_path?(rbs_file, class_path, ext: ".rbs")
           info = class_info_from_file(rbs_file, normalized)
           parent_superclass ||= info.superclass
@@ -177,7 +224,7 @@ module RbsInfer::Signatures
       end
       gem_hints.uniq!
 
-      rbs_files = gem_hints.flat_map { |hint| Dir[".gem_rbs_collection/#{hint}/**/*.rbs"] }.uniq
+      rbs_files = gem_hints.flat_map { |hint| self.class.glob(".gem_rbs_collection/#{hint}/**/*.rbs") }.uniq
       return RbsClassInfo.new(superclass: nil, types:, includes: [], class_method_types: {}) if rbs_files.empty?
 
       all_includes = []
@@ -231,7 +278,7 @@ module RbsInfer::Signatures
         first.gsub(/([a-z])([A-Z])/, '\1-\2').downcase,
       ].uniq
 
-      rbs_files = gem_hints.flat_map { |hint| Dir[".gem_rbs_collection/#{hint}/**/*.rbs"] }.uniq
+      rbs_files = gem_hints.flat_map { |hint| self.class.glob(".gem_rbs_collection/#{hint}/**/*.rbs") }.uniq
       return {} if rbs_files.empty?
 
       types = {}

--- a/spec/lib/rbs_infer/signatures/rbs_type_lookup_spec.rb
+++ b/spec/lib/rbs_infer/signatures/rbs_type_lookup_spec.rb
@@ -121,4 +121,79 @@ RSpec.describe RbsInfer::Signatures::RbsTypeLookup do
       # Não deve levantar exceção ao percorrer a cadeia
     end
   end
+
+  # Run-wide caches shared across instances (felixefelip/rbs_infer#47). Each
+  # example runs in its own tmpdir (a distinct Dir.pwd), so the pwd-scoped
+  # cache is naturally isolated; reset! is belt-and-suspenders.
+  describe "run-wide sig file/glob caches" do
+    around do |ex|
+      Dir.mktmpdir { |dir| Dir.chdir(dir) { ex.run } }
+    end
+    before { described_class.reset! }
+
+    def write_rbs(path, content, mtime: nil)
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, content)
+      File.utime(File.atime(path), mtime, path) if mtime
+    end
+
+    describe ".file_entry" do
+      it "parses a file once and serves the same entry from cache" do
+        write_rbs("sig/x.rbs", "class X\n  def a: () -> Integer\nend\n")
+
+        first = described_class.file_entry("sig/x.rbs")
+        second = described_class.file_entry("sig/x.rbs")
+
+        expect(second).to be(first) # cache hit → not re-parsed
+        expect(first[:index].keys).to include("X")
+        expect(first[:content]).to include("def a")
+      end
+
+      it "re-parses when the file's mtime changes (stabilization rewrite)" do
+        write_rbs("sig/x.rbs", "class X\nend\n", mtime: Time.at(1_000_000))
+        first = described_class.file_entry("sig/x.rbs")
+
+        write_rbs("sig/x.rbs", "class X\n  def a: () -> Integer\nend\n", mtime: Time.at(2_000_000))
+        second = described_class.file_entry("sig/x.rbs")
+
+        expect(second).not_to be(first)
+        expect(second[:content]).to include("def a")
+        expect(second[:index]["X"]).not_to be_nil
+      end
+
+      it "returns an empty entry for a missing file" do
+        entry = described_class.file_entry("sig/missing.rbs")
+
+        expect(entry[:declarations]).to eq([])
+        expect(entry[:content]).to eq("")
+        expect(entry[:index]).to eq({})
+      end
+    end
+
+    describe ".glob and .reset!" do
+      it "caches the glob and only sees new files after reset!" do
+        write_rbs("sig/a.rbs", "class A\nend\n")
+        expect(described_class.glob("sig/**/*.rbs")).to eq(["sig/a.rbs"])
+
+        write_rbs("sig/b.rbs", "class B\nend\n")
+        expect(described_class.glob("sig/**/*.rbs")).to eq(["sig/a.rbs"]) # still cached
+
+        described_class.reset!
+        expect(described_class.glob("sig/**/*.rbs")).to match_array(["sig/a.rbs", "sig/b.rbs"])
+      end
+    end
+
+    it "uses a fresh cache under a different working directory (no reset! needed)" do
+      write_rbs("sig/a.rbs", "class A\nend\n")
+      expect(described_class.glob("sig/**/*.rbs")).to eq(["sig/a.rbs"])
+
+      Dir.mktmpdir do |other|
+        Dir.chdir(other) do
+          FileUtils.mkdir_p("sig")
+          File.write("sig/c.rbs", "class C\nend\n")
+          expect(described_class.glob("sig/**/*.rbs")).to eq(["sig/c.rbs"])
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Continua o trabalho de #47. Depois do #48 (memoizar `type_check`), profilei o **app real (Fizzy)** e o gargalo migrou.

## Profiling (Fizzy, `app/models --output`, 768 .rbs em `sig/`)

| Custo | % | Origem |
|---|---|---|
| **GC** | ~50% | alocação de AST RBS (abaixo) |
| `RBS::Parser.parse_signature` | 10% | **94% via `RbsParserUtil.parse_declarations`** |
| `Dir.[]` | 7% | `Dir["sig/**/*.rbs"]` |

Becos descartados **com medição**: GC tuning (~1.5%, +RAM) e rebuild do env (só 5×, ~0.8s cada).

## Causa raiz

`RbsTypeLookup` tinha caches **por instância**, e é criado **por Analyzer** (um por arquivo, por pass de estabilização). Cada uma das ~centenas de análises **re-globava `Dir["sig/**/*.rbs"]` e re-lia+re-parseava** os arquivos que tocava. Reparsear os 768 `.rbs` repetidamente É o `parse_signature` (10%) e a fonte das alocações de AST que dirigem ~metade do GC.

## Correção

Sobe os caches **derivados de arquivo** (conteúdo / declarations / índice) e os globs do `sig/` para o **nível de classe**, compartilhados por todas as instâncias:

- `file_entry`: chave por path **+ mtime** → arquivo reescrito entre níveis é re-parseado; inalterado é parseado 1× por geração;
- `glob`: `Dir[...]` cacheado, limpo pelo `reset!` entre níveis/passes (arquivo novo não é detectável por mtime);
- ambos **escopados a `Dir.pwd`** (refazem no `chdir`, espelhando o `SteepBridge`) → testes que `chdir` em temp dirs continuam corretos.

Resultados de inferência keyed por nome de classe seguem por instância. O CLI agora chama `RbsTypeLookup.reset!` junto do `SteepBridge.reset!`; `lookup_class_methods` do `MethodTypeResolver` também passa a usar o cache compartilhado.

## Benchmark (Fizzy, back-to-back)

| | wall-clock | RSS |
|---|---|---|
| antes (main) | 2:55 (175s) | 636 MB |
| **depois** | **2:01 (121s)** | **554 MB** |

**~31% mais rápido, −13% de RAM** (a queda de memória é o sinal determinístico de menos alocação). Empilha sobre o #48.

## Correção verificada

Saída **idêntica**: 542 specs unitários + 52 de integração passam (snapshots comparam o RBS exato). Baseline do `steep check` no dummy intacto.

Refs #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)