### PR TITLE
feat(rails): emit module self-types sidecar (drop Steep path heuristic)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ rbs_generators_all:
 	make rbs_rails_custom
 	make rbs_infer_enumerize
 	make rbs_infer_carrierwave
-	make rbs_infer_erb
 	make rbs_infer_module_self_types
+	make rbs_infer_erb
 
 ## Gerar RBS apenas para arquivo específico passado como argumento
 

--- a/Makefile
+++ b/Makefile
@@ -39,12 +39,16 @@ rbs_rails_generator:
 rbs_infer_erb:
 	cd $(DUMMY_DIR) && bundle exec ruby -I$(ROOT_DIR)/lib -e "require 'rbs_infer/extensions/rails/erb_convention_generator'; RbsInfer::Extensions::Rails::ErbConventionGenerator.new(app_dir: '.', output_dir: 'sig/rbs_infer_erb', source_files: Dir['app/**/*.rb']).generate_all"
 
+rbs_infer_module_self_types:
+	cd $(DUMMY_DIR) && bundle exec ruby -I$(ROOT_DIR)/lib -e "require 'rbs_infer/extensions/rails/module_self_type_generator'; RbsInfer::Extensions::Rails::ModuleSelfTypeGenerator.new(app_dir: '.').generate"
+
 rbs_generators_all:
 	make rbs_rails_generator
 	make rbs_rails_custom
 	make rbs_infer_enumerize
 	make rbs_infer_carrierwave
 	make rbs_infer_erb
+	make rbs_infer_module_self_types
 
 ## Gerar RBS apenas para arquivo específico passado como argumento
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Loaded automatically when running inside a Rails app via [`RbsInfer::Railtie`](l
 | `rake rbs_infer:enumerize:all` | `RbsInfer::Extensions::Enumerize::Generator` | `sig/rbs_enumerize/` |
 | `rake rbs_infer:rails_custom:all` | `RbsInfer::Extensions::Rails::CustomGenerator` | `sig/rbs_rails_custom/` |
 | `rake rbs_infer:erb:all` | `RbsInfer::Extensions::Rails::ErbConventionGenerator` | `sig/rbs_infer_erb/` |
+| `rake rbs_infer:module_self_types:all` | `RbsInfer::Extensions::Rails::ModuleSelfTypeGenerator` | `sig/generated/.steep_module_self_types.yml` |
 
 **Enumerize generator** — walks `app/models/**/*.rb`, captures `enumerize :attr, in: [...]`, and emits per-attribute `Value` / `Attribute` classes plus instance/class accessors, predicate methods, and scope methods (shallow/deep).
 

--- a/bin/rbs_infer
+++ b/bin/rbs_infer
@@ -76,6 +76,13 @@ if rails_project
     app_dir: Dir.pwd,
     source_files: source_files
   )
+
+  # Emit the module/concern self-type sidecar up front so that every Steep
+  # type-check during this run (target *and* caller files) sees the
+  # `@type self:`/`@type instance:` annotations (felixefelip/rbs_infer#52).
+  require "rbs_infer/extensions/rails/module_self_type_generator"
+  RbsInfer::Extensions::Rails::ModuleSelfTypeGenerator.new(app_dir: Dir.pwd).generate
+  Steep::Source::ModuleSelfTypes.reset!
 end
 
 generate = lambda do |inputs_to_process, silent: false|

--- a/lib/rbs_infer.rb
+++ b/lib/rbs_infer.rb
@@ -49,5 +49,9 @@ require_relative "rbs_infer/extensions/rails/current_attributes_expander"
 # into a plain class reopening (felixefelip/rbs_infer#38) — pure Prism,
 # self-gates on the `on_load` substring, so it is always safe to load.
 require_relative "rbs_infer/extensions/rails/on_load_expander"
+# Computes module/concern self-type annotations from the AST (correct
+# acronym casing) + Rails path conventions, for Steep's generic injector
+# (felixefelip/rbs_infer#52). Pure Prism/string logic, safe to always load.
+require_relative "rbs_infer/extensions/rails/module_self_type_annotator"
 
 require_relative "rbs_infer/railtie" if defined?(Rails::Railtie)

--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -1,5 +1,5 @@
 require "prism"
-require "steep/source/module_self_type_resolver"
+require "steep/source/module_self_types"
 
 # Analisador que gera assinaturas RBS completas a partir de código Ruby puro,
 # sem exigir anotações de tipo, comentários especiais ou arquivos extras.
@@ -91,7 +91,18 @@ module RbsInfer
     @expanded_source = RbsInfer::Project::SourceExpanders.apply(source)
     source = @expanded_source if @expanded_source
 
-    source = Steep::Source::ModuleSelfTypeResolver.annotate(@target_file, source)
+    # Inject `@type self:`/`@type instance:` for concerns/modules so the
+    # pipeline (and Steep) sees the right self-type. rbs_infer owns the
+    # Rails conventions + the real (AST-cased) name; Steep just places the
+    # comment (felixefelip/rbs_infer#52).
+    if @target_class &&
+       (entry = RbsInfer::Extensions::Rails::ModuleSelfTypeAnnotator.entry_for(
+         path: @target_file, module_name: @target_class, source: source))
+      source = Steep::Source::ModuleSelfTypes.inject(
+        source, annotations: entry["annotations"], anchor: entry["anchor"]
+      )
+    end
+
     result = Prism.parse(source)
     @parsed_target = RbsInfer::ParsedFile.new(
       result: result,

--- a/lib/rbs_infer/extensions/rails/module_self_type_annotator.rb
+++ b/lib/rbs_infer/extensions/rails/module_self_type_annotator.rb
@@ -1,0 +1,65 @@
+module RbsInfer
+  module Extensions
+    module Rails
+      # Computes the `# @type self:` / `# @type instance:` annotation for a
+      # concern/module, to be injected by Steep's generic
+      # `Steep::Source::ModuleSelfTypes.inject` (felixefelip/rbs_infer#52).
+      #
+      # This is the Rails-aware half that used to live inside Steep: it knows
+      # the path conventions (models / helpers / controller concerns), the
+      # including-class rule, and concern detection. Unlike the old Steep code
+      # it does NOT camelize the file path to get the module name — the caller
+      # passes the real name from the AST (`Analyzer#target_class`), so acronyms
+      # (`SQLite`, `OAuth`) keep their declared casing.
+      module ModuleSelfTypeAnnotator
+        MODELS_PREFIX = "app/models/"
+        HELPERS_PREFIX = "app/helpers/"
+        CONTROLLER_CONCERNS_PREFIX = "app/controllers/concerns/"
+
+        module_function
+
+        # @param path [String] source path (e.g. "app/models/search/record/sqlite.rb")
+        # @param module_name [String] the real FQN from the AST (e.g. "Search::Record::SQLite")
+        # @param source [String] the file's source (for concern detection)
+        # @return [Hash, nil] `{ "anchor" => leaf, "annotations" => [lines] }`, or
+        #   nil when the file isn't a covered module/concern.
+        def entry_for(path:, module_name:, source:)
+          return nil if module_name.nil? || module_name.empty?
+
+          including_class = including_class_for(path, module_name)
+          return nil unless including_class
+
+          anchor = module_name.split("::").last
+          is_concern = source.include?("extend ActiveSupport::Concern")
+
+          { "anchor" => anchor, "annotations" => annotations(module_name, including_class, is_concern) }
+        end
+
+        # The class a concern/module is mixed into. Helpers and controller
+        # concerns mix into ApplicationController by Rails convention; a model
+        # concern mixes into its enclosing namespace (`Post::Taggable` → `Post`).
+        # Returns nil when the file isn't under a covered root, or a model
+        # concern has no namespace to derive the host from.
+        def including_class_for(path, module_name)
+          path = path.to_s
+          return "ApplicationController" if path.include?(HELPERS_PREFIX)
+          return "ApplicationController" if path.include?(CONTROLLER_CONCERNS_PREFIX)
+          return nil unless path.include?(MODELS_PREFIX)
+
+          parts = module_name.split("::")
+          return nil if parts.size < 2
+
+          parts[0..-2].join("::")
+        end
+
+        def annotations(module_name, including_class, is_concern)
+          instance = "# @type instance: #{including_class} & #{module_name}"
+          return [instance] unless is_concern
+
+          self_line = "# @type self: singleton(#{including_class}) & singleton(#{module_name})"
+          [self_line, instance]
+        end
+      end
+    end
+  end
+end

--- a/lib/rbs_infer/extensions/rails/module_self_type_generator.rb
+++ b/lib/rbs_infer/extensions/rails/module_self_type_generator.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "prism"
+require "yaml"
+require "fileutils"
+
+module RbsInfer
+  module Extensions
+    module Rails
+      # Emits `sig/generated/.steep_module_self_types.yml` — the sidecar that
+      # Steep's `Steep::Source::ModuleSelfTypes` reads to inject
+      # `@type self:`/`@type instance:` into concerns/modules during parsing
+      # (felixefelip/rbs_infer#52).
+      #
+      # For each module/concern under the covered roots it records, keyed by the
+      # project-relative path, the leaf-name anchor and the annotation lines —
+      # computed by `ModuleSelfTypeAnnotator` from the AST-derived FQN (correct
+      # acronym casing) and Rails conventions. This replaces the path-based name
+      # derivation that used to live in Steep.
+      class ModuleSelfTypeGenerator
+        SIDECAR_PATH = "sig/generated/.steep_module_self_types.yml"
+        ROOTS = %w[app/models app/helpers app/controllers/concerns].freeze
+
+        def initialize(app_dir:)
+          @app_dir = app_dir
+        end
+
+        # Builds the path → entry table. Public so the CLI can write it without
+        # touching disk conventions twice.
+        def build_table
+          table = {}
+          ROOTS.each do |root|
+            Dir.glob(File.join(@app_dir, root, "**/*.rb")).sort.each do |abs|
+              rel = relative(abs)
+              entry = entry_for_file(abs, rel)
+              table[rel] = entry if entry
+            end
+          end
+          table
+        end
+
+        # Writes the sidecar (removing a stale one when nothing qualifies, so a
+        # deleted concern doesn't linger). Returns the absolute sidecar path.
+        def generate
+          table = build_table
+          out = File.join(@app_dir, SIDECAR_PATH)
+          if table.empty?
+            FileUtils.rm_f(out)
+          else
+            FileUtils.mkdir_p(File.dirname(out))
+            File.write(out, YAML.dump(table))
+          end
+          out
+        end
+
+        private
+
+        def entry_for_file(abs, rel)
+          source = File.read(abs)
+          extractor = RbsInfer::AST::ClassNameExtractor.new(file_path: abs)
+          Prism.parse(source).value.accept(extractor)
+          module_name = extractor.class_name
+          return nil unless module_name
+
+          ModuleSelfTypeAnnotator.entry_for(path: rel, module_name: module_name, source: source)
+        rescue StandardError
+          nil
+        end
+
+        def relative(abs)
+          prefix = "#{@app_dir.chomp('/')}/"
+          abs.start_with?(prefix) ? abs[prefix.length..] : abs
+        end
+      end
+    end
+  end
+end

--- a/lib/rbs_infer/extensions/rails/tasks/rbs_infer_module_self_types.rake
+++ b/lib/rbs_infer/extensions/rails/tasks/rbs_infer_module_self_types.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative "../module_self_type_generator"
+
+namespace :rbs_infer do
+  namespace :module_self_types do
+    desc "Generate the module/concern self-type sidecar for Steep (sig/generated/.steep_module_self_types.yml)"
+    task :all do
+      app_dir = defined?(Rails) ? Rails.root.to_s : Dir.pwd
+      out = RbsInfer::Extensions::Rails::ModuleSelfTypeGenerator.new(app_dir: app_dir).generate
+      puts "Generated module self-types sidecar: #{out}"
+    end
+  end
+end

--- a/lib/rbs_infer/railtie.rb
+++ b/lib/rbs_infer/railtie.rb
@@ -10,6 +10,7 @@ module RbsInfer
       load File.expand_path("extensions/devise/tasks/rbs_infer_devise.rake", __dir__)
       load File.expand_path("extensions/rails/tasks/rbs_infer_rails_custom.rake", __dir__)
       load File.expand_path("extensions/rails/tasks/rbs_infer_erb.rake", __dir__)
+      load File.expand_path("extensions/rails/tasks/rbs_infer_module_self_types.rake", __dir__)
     end
   end
 end

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -1,0 +1,43 @@
+---
+app/models/concerns/test/filtrable.rb:
+  anchor: Filtrable
+  annotations:
+  - "# @type self: singleton(Test) & singleton(Test::Filtrable)"
+  - "# @type instance: Test & Test::Filtrable"
+app/models/coupon/code.rb:
+  anchor: Code
+  annotations:
+  - "# @type instance: Coupon & Coupon::Code"
+app/models/post/notifiable.rb:
+  anchor: Notifiable
+  annotations:
+  - "# @type self: singleton(Post) & singleton(Post::Notifiable)"
+  - "# @type instance: Post & Post::Notifiable"
+app/models/post/taggable.rb:
+  anchor: Taggable
+  annotations:
+  - "# @type self: singleton(Post) & singleton(Post::Taggable)"
+  - "# @type instance: Post & Post::Taggable"
+app/models/user/displayable.rb:
+  anchor: Displayable
+  annotations:
+  - "# @type self: singleton(User) & singleton(User::Displayable)"
+  - "# @type instance: User & User::Displayable"
+app/models/user/recoverable.rb:
+  anchor: Recoverable
+  annotations:
+  - "# @type self: singleton(User) & singleton(User::Recoverable)"
+  - "# @type instance: User & User::Recoverable"
+app/helpers/application_helper.rb:
+  anchor: ApplicationHelper
+  annotations:
+  - "# @type instance: ApplicationController & ApplicationHelper"
+app/helpers/posts_helper.rb:
+  anchor: PostsHelper
+  annotations:
+  - "# @type instance: ApplicationController & PostsHelper"
+app/controllers/concerns/filter_configuration.rb:
+  anchor: FilterConfiguration
+  annotations:
+  - "# @type self: singleton(ApplicationController) & singleton(FilterConfiguration)"
+  - "# @type instance: ApplicationController & FilterConfiguration"

--- a/spec/integration/steep_dummy_spec.rb
+++ b/spec/integration/steep_dummy_spec.rb
@@ -40,6 +40,11 @@ RSpec.describe "Steep type check on dummy app", :dummy_app do
         # as a noisy DuplicateMethodDefinition.
         system("bundle", "exec", "rake", "rbs_infer:carrierwave:all",
                exception: true, out: File::NULL, err: File::NULL)
+        # Concern/module `@type self:`/`@type instance:` now come from this
+        # sidecar (felixefelip/rbs_infer#52); `steep check` reads it instead of
+        # deriving names from paths. Without it, concern self-types regress.
+        system("bundle", "exec", "rake", "rbs_infer:module_self_types:all",
+               exception: true, out: File::NULL, err: File::NULL)
       end
     end
   end

--- a/spec/lib/rbs_infer/extensions/rails/module_self_type_annotator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/module_self_type_annotator_spec.rb
@@ -1,0 +1,68 @@
+require "spec_helper"
+require "rbs_infer"
+
+RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeAnnotator do
+  CONCERN_SRC = "module X\n  extend ActiveSupport::Concern\nend\n"
+  PLAIN_SRC = "module X\nend\n"
+
+  describe ".entry_for" do
+    it "builds both annotations for a model concern, with the AST-cased name" do
+      entry = described_class.entry_for(
+        path: "app/models/search/record/sqlite.rb",
+        module_name: "Search::Record::SQLite",
+        source: CONCERN_SRC
+      )
+
+      expect(entry["anchor"]).to eq("SQLite")
+      expect(entry["annotations"]).to eq([
+        "# @type self: singleton(Search::Record) & singleton(Search::Record::SQLite)",
+        "# @type instance: Search::Record & Search::Record::SQLite"
+      ])
+    end
+
+    it "builds only the instance annotation for a plain model module" do
+      entry = described_class.entry_for(
+        path: "app/models/post/taggable.rb",
+        module_name: "Post::Taggable",
+        source: PLAIN_SRC
+      )
+
+      expect(entry["annotations"]).to eq(["# @type instance: Post & Post::Taggable"])
+    end
+
+    it "uses ApplicationController as the host for helpers" do
+      entry = described_class.entry_for(
+        path: "app/helpers/posts_helper.rb",
+        module_name: "PostsHelper",
+        source: PLAIN_SRC
+      )
+
+      expect(entry["annotations"]).to eq(["# @type instance: ApplicationController & PostsHelper"])
+    end
+
+    it "uses ApplicationController as the host for controller concerns" do
+      entry = described_class.entry_for(
+        path: "app/controllers/concerns/filter_configuration.rb",
+        module_name: "FilterConfiguration",
+        source: CONCERN_SRC
+      )
+
+      expect(entry["annotations"]).to include(
+        "# @type self: singleton(ApplicationController) & singleton(FilterConfiguration)",
+        "# @type instance: ApplicationController & FilterConfiguration"
+      )
+    end
+
+    it "returns nil for a file outside the covered roots" do
+      expect(described_class.entry_for(path: "lib/foo.rb", module_name: "Foo", source: PLAIN_SRC)).to be_nil
+    end
+
+    it "returns nil for a model module without a namespace (no host to derive)" do
+      expect(described_class.entry_for(path: "app/models/trashable.rb", module_name: "Trashable", source: PLAIN_SRC)).to be_nil
+    end
+
+    it "returns nil for a nil/empty module name" do
+      expect(described_class.entry_for(path: "app/models/x.rb", module_name: nil, source: PLAIN_SRC)).to be_nil
+    end
+  end
+end

--- a/spec/lib/rbs_infer/extensions/rails/module_self_type_generator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/module_self_type_generator_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+require "rbs_infer"
+require "rbs_infer/extensions/rails/module_self_type_generator"
+require "tmpdir"
+require "fileutils"
+require "yaml"
+
+RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeGenerator do
+  def in_app(files)
+    Dir.mktmpdir do |dir|
+      files.each do |rel, content|
+        path = File.join(dir, rel)
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, content)
+      end
+      yield dir
+    end
+  end
+
+  it "emits the sidecar with the declared (AST) casing, not path camelization" do
+    in_app(
+      "app/models/search/record/sqlite.rb" =>
+        "module Search::Record::SQLite\n  extend ActiveSupport::Concern\nend\n"
+    ) do |dir|
+      out = described_class.new(app_dir: dir).generate
+      table = YAML.safe_load(File.read(out))
+
+      entry = table.fetch("app/models/search/record/sqlite.rb")
+      expect(entry["anchor"]).to eq("SQLite")
+      expect(entry["annotations"]).to include(
+        "# @type instance: Search::Record & Search::Record::SQLite"
+      )
+      expect(entry["annotations"].join).not_to include("Sqlite")
+    end
+  end
+
+  it "covers models, helpers and controller concerns; skips uncovered files" do
+    in_app(
+      "app/models/post/taggable.rb"            => "module Post::Taggable\nend\n",
+      "app/helpers/posts_helper.rb"            => "module PostsHelper\nend\n",
+      "app/controllers/concerns/filterable.rb" => "module Filterable\n  extend ActiveSupport::Concern\nend\n",
+      "lib/ignored.rb"                         => "module Ignored\nend\n"
+    ) do |dir|
+      table = described_class.new(app_dir: dir).build_table
+
+      expect(table.keys).to contain_exactly(
+        "app/models/post/taggable.rb",
+        "app/helpers/posts_helper.rb",
+        "app/controllers/concerns/filterable.rb"
+      )
+      expect(table["app/helpers/posts_helper.rb"]["annotations"].first).to include("ApplicationController & PostsHelper")
+    end
+  end
+
+  it "removes a stale sidecar when nothing qualifies" do
+    in_app("lib/foo.rb" => "module Foo\nend\n") do |dir|
+      out = File.join(dir, described_class::SIDECAR_PATH)
+      FileUtils.mkdir_p(File.dirname(out))
+      File.write(out, "stale")
+
+      described_class.new(app_dir: dir).generate
+      expect(File.exist?(out)).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
Implementa felixefelip/rbs_infer#52. Par do Steep (felixefelip/steep#46). Design: `docs/guides/module_self_types_sidecar.md` (#51).

## Contexto

O Steep injetava `@type self:`/`@type instance:` em concerns derivando o nome do **path** (`ModuleSelfTypeResolver`), o que erra siglas (`sqlite` → `Sqlite`) e embute Rails num type checker agnóstico. Esta PR move o "o que injetar" pra cá (rbs_infer já tem o FQN correto do AST) e deixa o Steep só fazer placement.

## Mudança

- **`ModuleSelfTypeAnnotator`** — computa anchor + linhas de anotação a partir do nome real (AST) + convenções Rails (models → host = namespace; helpers/controller-concerns → `ApplicationController`; concern vs módulo plano).
- **`ModuleSelfTypeGenerator`** + task `rbs_infer:module_self_types:all` — varre `app/models`, `app/helpers`, `app/controllers/concerns` e escreve `sig/generated/.steep_module_self_types.yml`.
- **`analyzer.rb`** — injeta via o novo `Steep::Source::ModuleSelfTypes.inject` com a entrada que computa (no lugar do `annotate` removido).
- **`bin/rbs_infer`** — emite o sidecar no início (sob Rails), pra todo `type_check` da run ver as anotações.
- **`steep_dummy_spec`** — gera o sidecar antes do `steep check`; baseline limpo.

## O bug de casing

Cai de graça: o nome vem do `@target_class` (AST), já correto. `Search::Record::SQLite` (concern com sigla) gera a anotação correta — sem `Sqlite`.

## Verificação

- **559 specs unitários + 52 de integração, 0 falhas.** Snapshots idênticos (saída do Analyzer inalterada); baseline do `steep check` no dummy limpo.
- Specs novos do annotator (casing, models/helpers/controller-concerns, fallbacks) e do generator (sidecar com casing do AST, roots cobertas, remoção de sidecar stale).

## Ordem de merge

Mergear **esta** PR antes do Steep #46 (o Steep antigo ignora o sidecar e segue pelo path; depois o #46 passa a lê-lo) — evita janela de regressão. Ver doc.

Closes #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)