### PR TITLE
fix: resolve constant default of optional params to its value type (#46)

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -251,6 +251,12 @@ module RbsInfer
     # (felixefelip/rbs_infer#37).
     resolve_constant_types(target_members)
 
+    # Resolver tipos dos params opcionais cujo default é uma constante
+    # (`def f(x = Webhook::ACTIONS)`). O collector deferiu (emitiu
+    # `?untyped x`) porque o tipo é o do VALOR da constante e precisa do
+    # SteepBridge/env (felixefelip/rbs_infer#46).
+    resolve_constant_default_param_types(target_members, method_param_types)
+
     # Identificar parâmetros opcionais do initialize
     optional_params = extract_optional_init_params
 
@@ -460,6 +466,36 @@ module RbsInfer
     keep.each_value do |member|
       type = resolver.resolve(member.value_node, steep_type: steep_types[member.name])
       member.signature = "#{member.name}: #{type}"
+    end
+  end
+
+  # Preenche os params opcionais com default constante que o collector deferiu
+  # (`?untyped x`). Resolve via o mesmo ConstantArgTypeResolver usado para args
+  # em call-sites (#46): constante-valor → tipo do valor, classe/módulo → o
+  # nome (tipo válido), não resolvida → fica `untyped`. A inferência por
+  # call-site, quando existe, já venceu e é preservada. Injeta em
+  # `method_param_types` para o RbsBuilder substituir o `untyped`.
+  def resolve_constant_default_param_types(target_members, method_param_types)
+    members = target_members.select do |m|
+      [:method, :class_method].include?(m.kind) && m.param_constant_defaults && !m.param_constant_defaults.empty?
+    end
+    return if members.empty?
+
+    resolver = RbsInfer::Inference::ConstantArgTypeResolver.new(
+      steep_bridge: steep_bridge,
+      caller_constant_types: @parsed_target&.source ? steep_bridge.constant_types(@parsed_target.source) : {}
+    )
+
+    members.each do |member|
+      member.param_constant_defaults.each do |param_name, node|
+        inferred = method_param_types.dig(member.name, param_name)
+        next if inferred && inferred != "untyped"
+
+        type = resolver.resolve(name: RbsInfer::Analyzer.extract_constant_path(node), namespace: @target_class)
+        next unless type
+
+        (method_param_types[member.name] ||= {})[param_name] = type
+      end
     end
   end
 

--- a/lib/rbs_infer/inference/class_member_collector.rb
+++ b/lib/rbs_infer/inference/class_member_collector.rb
@@ -6,7 +6,10 @@ module RbsInfer::Inference
   # `value_node` = nó Prism do RHS, preenchido só para membros `:constant`
   # (felixefelip/rbs_infer#37); o tipo é resolvido depois no Analyzer, que
   # tem acesso ao SteepBridge/resolvers, e gravado em `signature`.
-  Member = Struct.new(:kind, :name, :signature, :visibility, :owner, :value_node, keyword_init: true)
+  # `param_constant_defaults` = para membros `:method`/`:class_method`, mapa
+  # `param => nó Prism` dos params opcionais cujo default é uma constante; o
+  # tipo (valor da constante) também é resolvido depois no Analyzer (#46).
+  Member = Struct.new(:kind, :name, :signature, :visibility, :owner, :value_node, :param_constant_defaults, keyword_init: true)
 
   # Metadata extraída de uma chamada `delegate` — tipos são resolvidos depois no Analyzer
   DelegateInfo = Struct.new(:methods, :target, :prefix, :allow_nil, keyword_init: true)
@@ -102,7 +105,8 @@ module RbsInfer::Inference
       name = node.name.to_s
       sig = find_rbs_signature(@comments, @lines, node.location.start_line)
 
-      params_sig = ExtractParamsSignature.new(node.parameters).call
+      extractor = ExtractParamsSignature.new(node.parameters)
+      params_sig = extractor.call
 
       signature = if sig
                     "#{name}: #{sig}"
@@ -120,7 +124,10 @@ module RbsInfer::Inference
         name: name,
         signature: signature,
         visibility: @current_visibility,
-        owner: current_owner
+        owner: current_owner,
+        # Only when we synthesized the signature — an explicit `#:`/`@rbs`
+        # annotation is authoritative and must not be overridden.
+        param_constant_defaults: sig ? nil : extractor.constant_default_params
       )
       super
     end

--- a/lib/rbs_infer/inference/class_member_collector/extract_params_signature.rb
+++ b/lib/rbs_infer/inference/class_member_collector/extract_params_signature.rb
@@ -2,9 +2,18 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
   class ExtractParamsSignature
     include RbsInfer::AST::NodeTypeInferrer
 
+    # Optional positional params whose default is a constant reference, mapped
+    # `name => Prism node`. A constant's VALUE type (`Array[String]`, `Integer`,
+    # …) is not its bare name — a bare name is a valid type only for a
+    # class/module — so we can't resolve it here (no SteepBridge/env). We emit
+    # `?untyped name` and let the Analyzer fill it via ConstantArgTypeResolver,
+    # mirroring how `:constant` members defer (felixefelip/rbs_infer#37, #46).
+    attr_reader :constant_default_params
+
     def initialize(params)
 			@params = params
       @parts = []
+      @constant_default_params = {}
     end
 
     def call
@@ -29,6 +38,18 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
       end
     end
 
+    def optional_param_type(param)
+      value = param.value if param.respond_to?(:value)
+
+      case value
+      when Prism::ConstantReadNode, Prism::ConstantPathNode
+        @constant_default_params[param.name.to_s] = value
+        "untyped"
+      else
+        infer_node_type(value) || "untyped"
+      end
+    end
+
     def extract_positional_params_signature
       # Parâmetros posicionais obrigatórios
       @params.requireds.each do |p|
@@ -37,8 +58,7 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
 
       # Parâmetros opcionais
       @params.optionals.each do |p|
-        type = infer_node_type(p.value) if p.respond_to?(:value)
-        @parts << "?#{type || 'untyped'} #{p.name}"
+        @parts << "?#{optional_param_type(p)} #{p.name}"
       end if @params.respond_to?(:optionals)
 
       # Rest param

--- a/spec/dummy/app/helpers/posts_helper.rb
+++ b/spec/dummy/app/helpers/posts_helper.rb
@@ -15,6 +15,15 @@ module PostsHelper
     content_tag(:p, post.summary(length), class: "text-muted")
   end
 
+  # Regression fixture (#46): an optional param defaulting to a value
+  # constant must take the constant's VALUE type, not its bare name (which
+  # is invalid RBS for a value constant). `Palette::WEIGHTS` is `Array[Integer]`
+  # and `Coupon::CODE_LENGTH` is `Integer` — both resolved cross-file via the
+  # RBS env. A class/module default (`Palette`) keeps its name.
+  def post_weights(weights = Palette::WEIGHTS, length = Coupon::CODE_LENGTH, klass = Palette)
+    content_tag(:p, "#{weights.sum} #{length} #{klass}")
+  end
+
   # Helper called ONLY from `posts/index.html.erb` inside the
   # `@posts.each |post|` block. Regression fixture for the
   # ivar/local name-collision bug — the param `post` here must be

--- a/spec/dummy/sig/rbs_infer/app/helpers/posts_helper.rbs
+++ b/spec/dummy/sig/rbs_infer/app/helpers/posts_helper.rbs
@@ -1,5 +1,6 @@
 module PostsHelper
   def post_status_badge: ((Post & Post::Validated | Post | (Post & Post::Validated)) post) -> String
   def post_summary: ((Post & Post::Validated | Post | (Post & Post::Validated)) post, ?Integer length) -> String
+  def post_weights: (?Array[Integer] weights, ?Integer length, ?Palette klass) -> String
   def post_index_marker: (Post & Post::Validated post) -> String
 end

--- a/spec/expectations/helpers/posts_helper.rbs
+++ b/spec/expectations/helpers/posts_helper.rbs
@@ -1,5 +1,6 @@
 module PostsHelper
   def post_status_badge: ((Post & Post::Validated | Post | (Post & Post::Validated)) post) -> String
   def post_summary: ((Post & Post::Validated | Post | (Post & Post::Validated)) post, ?Integer length) -> String
+  def post_weights: (?Array[Integer] weights, ?Integer length, ?Palette klass) -> String
   def post_index_marker: (Post & Post::Validated post) -> String
 end

--- a/spec/lib/rbs_infer/inference/class_member_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/class_member_collector_spec.rb
@@ -292,6 +292,39 @@ RSpec.describe RbsInfer::Inference::ClassMemberCollector do
     expect(member.signature).to include("?senha: untyped")
   end
 
+  describe "default de param opcional que é constante (felixefelip/rbs_infer#46)" do
+    it "defere a resolução: emite ?untyped e registra o nó da constante" do
+      source = <<~RUBY
+        class Foo
+          def bar(actions = Webhook::PERMITTED_ACTIONS)
+          end
+        end
+      RUBY
+
+      collector = collect(source)
+      member = collector.members.find { |m| m.name == "bar" }
+      # O nome cru da constante não é um tipo RBS válido para uma
+      # constante-valor; o tipo é resolvido depois no Analyzer.
+      expect(member.signature).to eq("bar: (?untyped actions) -> untyped")
+      expect(member.param_constant_defaults.keys).to eq(["actions"])
+      expect(member.param_constant_defaults["actions"]).to be_a(Prism::ConstantPathNode)
+    end
+
+    it "mantém a inferência inline para defaults literais" do
+      source = <<~RUBY
+        class Foo
+          def bar(length = 150, name = "x")
+          end
+        end
+      RUBY
+
+      collector = collect(source)
+      member = collector.members.find { |m| m.name == "bar" }
+      expect(member.signature).to eq("bar: (?Integer length, ?String name) -> untyped")
+      expect(member.param_constant_defaults).to be_empty
+    end
+  end
+
   it "coloca bloco após parênteses na assinatura RBS" do
     source = <<~RUBY
       class Foo


### PR DESCRIPTION
## Problema

Um parâmetro posicional opcional cujo default é uma constante era gerado com o **nome cru da constante** como tipo:

```ruby
# app/helpers/webhooks_helper.rb
def webhook_action_options(actions = Webhook::PERMITTED_ACTIONS)
```
```rbs
# antes (inválido)
def webhook_action_options: (?Webhook::PERMITTED_ACTIONS actions) -> untyped
# depois
def webhook_action_options: (?Array[String] actions) -> untyped
```

Um nome cru só é um tipo RBS válido para uma **classe/módulo**. Para uma constante de **valor** (`PERMITTED_ACTIONS = %w[...]`) o tipo correto é o do valor (`Array[String]`) — o nome cru é inválido e ainda "envenena" o env compartilhado.

## Causa raiz

`ExtractParamsSignature` inferia o tipo do param opcional direto do nó do default via `infer_node_type`, que para um nó de constante devolve `extract_constant_path` (o nome). Como ele roda sem `SteepBridge`, não consegue distinguir constante-valor de classe/módulo.

Esse mesmo problema já era resolvido para args em call-sites (#46, via `ConstantArgTypeResolver`) e para constantes-membro (#37, deferindo ao `Analyzer`), mas **não** no caminho do default de param opcional.

## Correção

Seguindo o padrão de deferral da #37:

1. `ExtractParamsSignature`: para default que é constante, emite `?untyped name` e registra o nó (`constant_default_params`).
2. `Member`: novo campo `param_constant_defaults` carrega esses nós.
3. `Analyzer#resolve_constant_default_param_types`: resolve via o mesmo `ConstantArgTypeResolver` dos call-sites (tem `SteepBridge`/env) e injeta em `method_param_types` para o `RbsBuilder` substituir o `untyped`.

Comportamento por caso:
- constante-valor → tipo do valor (`Array[String]`, `Integer`, …)
- classe/módulo → mantém o nome (tipo válido)
- não resolvida → `untyped` (em vez de poluir o env)
- tipo já inferido por call-site → preservado

## Testes

- Specs unitários novos em `class_member_collector_spec` (deferral de constante + literais permanecem inline).
- Fixture cross-file em `PostsHelper` (`Palette::WEIGHTS` → `?Array[Integer]`, `Coupon::CODE_LENGTH` → `?Integer`, `Palette` → `?Palette`), exercendo a resolução via env.
- Suite completa: `626 examples, 0 failures` (incl. snapshot e steep baseline, expectations/sig do dummy regenerados).

🤖 Generated with [Claude Code](https://claude.com/claude-code)