### PR TITLE
fix: defer constant return types to their value type (#46)

### DIFF
--- a/lib/rbs_infer/inference/class_member_collector.rb
+++ b/lib/rbs_infer/inference/class_member_collector.rb
@@ -397,6 +397,14 @@ module RbsInfer::Inference
 
       return nil unless last_stmt
 
+      # A bare constant as the last expression is a VALUE — a value constant
+      # (`CONTINUE`, an `Integer`) or a class object (`User`, typed
+      # `singleton(User)`) — never the bare name `infer_node_type` would yield,
+      # which is invalid RBS for the former and wrong for the latter. Defer to
+      # the Analyzer's Steep-backed return pass, which types both correctly
+      # (felixefelip/rbs_infer#46).
+      return nil if last_stmt.is_a?(Prism::ConstantReadNode) || last_stmt.is_a?(Prism::ConstantPathNode)
+
       type = infer_node_type(last_stmt)
       return nil unless type
 

--- a/lib/rbs_infer/inference/type_merger.rb
+++ b/lib/rbs_infer/inference/type_merger.rb
@@ -333,6 +333,14 @@ module RbsInfer::Inference
     end
 
     def infer_literal_type(node)
+      # A constant reference is not a literal: its type is the constant's VALUE
+      # type (a value constant like `CONTINUE` → `Integer`) or `singleton(K)`
+      # for a class/module — never the bare name `infer_node_type` yields, which
+      # is invalid RBS for the former and wrong for the latter. Defer to the
+      # Steep-backed return pass in `improve_method_return_types`, leaving the
+      # method `-> untyped` for now (felixefelip/rbs_infer#46).
+      return nil if node.is_a?(Prism::ConstantReadNode) || node.is_a?(Prism::ConstantPathNode)
+
       infer_node_type(node)
     end
 

--- a/lib/rbs_infer/signatures/method_type_resolver.rb
+++ b/lib/rbs_infer/signatures/method_type_resolver.rb
@@ -406,6 +406,13 @@ module RbsInfer::Signatures
 
     # Inferir return type a partir de literais ou Klass.new na última expressão
     def infer_literal_return_type(node, class_name = nil)
+      # A bare constant as the return expression is a VALUE (value constant →
+      # its value type) or a class object (→ `singleton(K)`), never the bare
+      # name `infer_node_type` yields — invalid RBS for the former, wrong for
+      # the latter. Leave it unresolved so the method stays `untyped` and the
+      # Steep-backed return pass types it (felixefelip/rbs_infer#46).
+      return nil if node.is_a?(Prism::ConstantReadNode) || node.is_a?(Prism::ConstantPathNode)
+
       basic = infer_node_type(node, context_class: class_name)
       return basic if basic
 

--- a/spec/dummy/app/models/palette.rb
+++ b/spec/dummy/app/models/palette.rb
@@ -11,6 +11,13 @@ class Palette
     @value = value
   end
 
+  # Return is a bare value constant (#46): the type is the constant's VALUE
+  # type (`Integer`), resolved by Steep — not the bare name `MAX`, which is
+  # invalid RBS.
+  def max_weight
+    MAX
+  end
+
   COLORS = {
     "Blue" => "var(--color-1)",
     "Gray" => "var(--color-2)"

--- a/spec/dummy/sig/rbs_infer/app/models/palette.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/palette.rbs
@@ -5,4 +5,5 @@ class Palette
   COLORS: Array[Palette]
 
   def initialize: (untyped name, untyped value) -> untyped
+  def max_weight: () -> Integer
 end

--- a/spec/expectations/models/palette.rbs
+++ b/spec/expectations/models/palette.rbs
@@ -5,4 +5,5 @@ class Palette
   COLORS: Array[Palette]
 
   def initialize: (untyped name, untyped value) -> untyped
+  def max_weight: () -> Integer
 end

--- a/spec/lib/rbs_infer/inference/class_member_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/class_member_collector_spec.rb
@@ -127,6 +127,27 @@ RSpec.describe RbsInfer::Inference::ClassMemberCollector do
     expect(collector.members.find { |m| m.name == "build_count" }.signature).to include("-> Integer")
   end
 
+  it "defere o return type quando a última expressão é uma constante (felixefelip/rbs_infer#46)" do
+    source = <<~RUBY
+      class Foo
+        def status
+          ACTIVE
+        end
+
+        def continue
+          Loofah::Scrubber::CONTINUE
+        end
+      end
+    RUBY
+
+    collector = collect(source)
+    # O nome cru não é tipo RBS válido para uma constante-valor (nem o tipo
+    # certo para classe/módulo: seria singleton). Fica untyped; o Analyzer
+    # resolve via Steep.
+    expect(collector.members.find { |m| m.name == "status" }.signature).to eq("status: () -> untyped")
+    expect(collector.members.find { |m| m.name == "continue" }.signature).to eq("continue: () -> untyped")
+  end
+
   describe "class << self (métodos singleton)" do
     it "classifica métodos definidos em `class << self` como class_method" do
       source = <<~RUBY


### PR DESCRIPTION
## Problema

Um método cuja última expressão é uma constante crua tinha o **nome da constante** como return type:

```ruby
# lib/auto_link_scrubber.rb
def scrub(node)
  return Loofah::Scrubber::STOP if ...
  ...
  Loofah::Scrubber::CONTINUE
end
```
```rbs
# antes (inválido)
def scrub: (untyped node) -> Loofah::Scrubber::CONTINUE
# depois
def scrub: (untyped node) -> Object
```

Um nome cru só é tipo RBS válido para classe/módulo. Para constante-valor é **inválido** e envenena o env; e mesmo para classe deveria ser `singleton(K)`, não o nome.

## Causa raiz

A mesma raiz da #54 (nome cru de constante usado como tipo), mas no caminho de **return type**, replicada em **três** pontos independentes de "inferir o return pela última expressão", todos via `infer_node_type`/`extract_constant_path`:

1. `ClassMemberCollector#infer_return_type`
2. `TypeMerger#infer_literal_type` (passo "literal na última expressão")
3. `MethodTypeResolver#infer_literal_return_type` (alcançado por `resolve_all` → `improve_method_return_types`)

O collector deferia, mas (2) e (3) repreenchiam com o nome cru — por isso era whack-a-mole até cobrir os três.

## Correção

Os três pontos agora deixam uma constante na última expressão **sem resolver**, então o método fica `-> untyped` e o passo já existente baseado em **Steep** (`improve_method_return_types`) o tipa corretamente:

- constante-valor → tipo do valor (`Integer`, `Object`, …)
- classe/módulo → `singleton(K)`
- sem RBS pra resolver → permanece `untyped` (em vez do nome inválido)

Uma constante como **receiver** de chain (`Foo::Bar.baz`) continua resolvendo para a classe — esse caminho é outro método (`resolve_receiver_type`) e não foi tocado.

## Testes

- Spec unitário novo em `class_member_collector_spec` (return de constante → `untyped`).
- Fixture de integração `Palette#max_weight` retornando a constante-valor `MAX` → `() -> Integer` (exercita os três guards + resolução por Steep).
- Suite completa: `629 examples, 0 failures` (expectations e sig do dummy regenerados).

Complementa #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)