### PR TITLE
fix: unify value-position constant typing at the root (#56)

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -461,7 +461,7 @@ module RbsInfer
     target_members.reject! { |m| m.kind == :constant && !keep[[m.owner, m.name]].equal?(m) }
 
     steep_types = @parsed_target&.source ? steep_bridge.constant_types(@parsed_target.source) : {}
-    resolver = RbsInfer::Inference::ConstantTypeResolver.new(target_class: @target_class)
+    resolver = RbsInfer::Inference::ConstantTypeResolver.new(target_class: @target_class, constant_resolver: constant_arg_resolver)
 
     keep.each_value do |member|
       type = resolver.resolve(member.value_node, steep_type: steep_types[member.name])
@@ -475,16 +475,32 @@ module RbsInfer
   # nome (tipo válido), não resolvida → fica `untyped`. A inferência por
   # call-site, quando existe, já venceu e é preservada. Injeta em
   # `method_param_types` para o RbsBuilder substituir o `untyped`.
+  # Env-aware resolver for constants-in-value-position over the TARGET source:
+  # env tier (stdlib/gems/generated sig) + same-file tier (the target's own
+  # constants, type-checked once). Threaded into every value-typing analyzer so
+  # a constant becomes its VALUE type, never its bare name (felixefelip/rbs_infer#56).
+  def constant_arg_resolver
+    @constant_arg_resolver ||= RbsInfer::Inference::ConstantArgTypeResolver.new(
+      steep_bridge: steep_bridge,
+      caller_constant_types: @parsed_target&.source ? steep_bridge.constant_types(@parsed_target.source) : {}
+    )
+  end
+
+  # Env-only variant (no same-file tier) for analyzing OTHER classes, where the
+  # target's constants don't apply; their own constants resolve via generated RBS.
+  def env_only_constant_resolver
+    @env_only_constant_resolver ||= RbsInfer::Inference::ConstantArgTypeResolver.new(
+      steep_bridge: steep_bridge, caller_constant_types: {}
+    )
+  end
+
   def resolve_constant_default_param_types(target_members, method_param_types)
     members = target_members.select do |m|
       [:method, :class_method].include?(m.kind) && m.param_constant_defaults && !m.param_constant_defaults.empty?
     end
     return if members.empty?
 
-    resolver = RbsInfer::Inference::ConstantArgTypeResolver.new(
-      steep_bridge: steep_bridge,
-      caller_constant_types: @parsed_target&.source ? steep_bridge.constant_types(@parsed_target.source) : {}
-    )
+    resolver = constant_arg_resolver
 
     members.each do |member|
       member.param_constant_defaults.each do |param_name, node|
@@ -594,7 +610,7 @@ module RbsInfer
   def infer_attr_types_from_initialize(init_arg_types)
     return {} unless @parsed_target
 
-    visitor = RbsInfer::Inference::InitializeBodyAnalyzer.new
+    visitor = RbsInfer::Inference::InitializeBodyAnalyzer.new(constant_resolver: constant_arg_resolver)
     @parsed_target.tree.accept(visitor)
 
     attr_types = {}
@@ -660,7 +676,7 @@ module RbsInfer
                         .to_set
     return [{}, {}] if attr_names.empty?
 
-    visitor = RbsInfer::Inference::ClassBodyAttrAnalyzer.new(attr_names: attr_names, method_type_resolver: method_type_resolver)
+    visitor = RbsInfer::Inference::ClassBodyAttrAnalyzer.new(attr_names: attr_names, method_type_resolver: method_type_resolver, constant_resolver: constant_arg_resolver)
     @parsed_target.tree.accept(visitor)
 
     [visitor.attr_types, visitor.collection_element_types]
@@ -783,17 +799,17 @@ module RbsInfer
   def extract_nil_default_param_names
     return Set.new unless @parsed_target
 
-    visitor = RbsInfer::Inference::InitializeBodyAnalyzer.new
+    visitor = RbsInfer::Inference::InitializeBodyAnalyzer.new(constant_resolver: constant_arg_resolver)
     @parsed_target.tree.accept(visitor)
     visitor.nil_default_params
   end
 
   def method_type_resolver
-    @method_type_resolver ||= RbsInfer::Signatures::MethodTypeResolver.new(@source_files, source_index: @source_index, parse_cache: @parse_cache, file_index: @file_index, caller_file_cache: @caller_file_cache)
+    @method_type_resolver ||= RbsInfer::Signatures::MethodTypeResolver.new(@source_files, source_index: @source_index, parse_cache: @parse_cache, file_index: @file_index, caller_file_cache: @caller_file_cache, constant_resolver: env_only_constant_resolver)
   end
 
   def type_merger
-    @type_merger ||= RbsInfer::Inference::TypeMerger.new(target_file: @target_file, target_class: @target_class, instance_types: @instance_types || [])
+    @type_merger ||= RbsInfer::Inference::TypeMerger.new(target_file: @target_file, target_class: @target_class, instance_types: @instance_types || [], constant_resolver: constant_arg_resolver)
   end
 
   def return_type_resolver
@@ -801,6 +817,7 @@ module RbsInfer
       target_file: @target_file,
       target_class: @target_class,
       method_type_resolver: method_type_resolver,
+      constant_resolver: constant_arg_resolver,
       instance_types: @instance_types || [],
       steep_bridge: steep_bridge
     )

--- a/lib/rbs_infer/ast/node_type_inferrer.rb
+++ b/lib/rbs_infer/ast/node_type_inferrer.rb
@@ -7,6 +7,15 @@ module RbsInfer::AST
   # method resolution) incluem este módulo e adicionam sua própria
   # camada de resolução sobre o resultado de `infer_node_type`.
   module NodeTypeInferrer
+    # Includers that type constants in VALUE position (a constant as a return,
+    # ivar, hash value, default, …) provide a `ConstantArgTypeResolver` here so
+    # the type is the constant's VALUE type, not its bare name (invalid RBS for
+    # a value constant, and env-poisoning). Purely structural includers inherit
+    # nil and value-position constants defer to untyped (felixefelip/rbs_infer#56).
+    def constant_resolver
+      nil
+    end
+
     def infer_node_type(node, context_class: nil, known_types: {})
       case node
       when Prism::StringNode, Prism::InterpolatedStringNode then "String"
@@ -20,7 +29,7 @@ module RbsInfer::AST
       when Prism::InterpolatedRegularExpressionNode, Prism::RegularExpressionNode then "Regexp"
       when Prism::SelfNode then context_class
       when Prism::ConstantReadNode, Prism::ConstantPathNode
-        RbsInfer::Analyzer.extract_constant_path(node)
+        NodeTypeInferrer.resolve_constant_value_type(node, namespace: context_class, constant_resolver: constant_resolver)
       when Prism::CallNode
         if node.name == :new && node.receiver
           RbsInfer::Analyzer.extract_constant_path(node.receiver)
@@ -39,10 +48,18 @@ module RbsInfer::AST
     end
 
     def infer_hash_type(node, context_class: nil, known_types: {})
-      NodeTypeInferrer.infer_hash_type(node, known_types: known_types, context_class: context_class)
+      NodeTypeInferrer.infer_hash_type(node, known_types: known_types, context_class: context_class, constant_resolver: constant_resolver)
     end
 
-    def self.infer_hash_type(node, known_types: {}, context_class: nil)
+    # Resolves a bare-constant node to its VALUE type via the resolver, or nil
+    # when none/unresolved — never the bare name (#56). Shared by the instance
+    # method and the module-level value/hash typers.
+    def self.resolve_constant_value_type(node, namespace:, constant_resolver:)
+      return nil unless constant_resolver
+      constant_resolver.resolve(name: RbsInfer::Analyzer.extract_constant_path(node), namespace: namespace)
+    end
+
+    def self.infer_hash_type(node, known_types: {}, context_class: nil, constant_resolver: nil)
       elements = node.elements
       return "Hash[untyped, untyped]" if elements.empty?
 
@@ -58,7 +75,7 @@ module RbsInfer::AST
         # Record type: { key: Type, ... }
         pairs = assocs.map { |e|
           key_name = e.key.unescaped
-          value_type = infer_value_type(e.value, known_types: known_types, context_class: context_class)
+          value_type = infer_value_type(e.value, known_types: known_types, context_class: context_class, constant_resolver: constant_resolver)
           "#{key_name}: #{value_type}"
         }
         "{ #{pairs.join(", ")} }"
@@ -75,7 +92,7 @@ module RbsInfer::AST
       end
     end
 
-    def self.infer_value_type(node, known_types: {}, context_class: nil)
+    def self.infer_value_type(node, known_types: {}, context_class: nil, constant_resolver: nil)
       case node
       when Prism::StringNode, Prism::InterpolatedStringNode then "String"
       when Prism::IntegerNode then "Integer"
@@ -84,11 +101,11 @@ module RbsInfer::AST
       when Prism::TrueNode, Prism::FalseNode then "bool"
       when Prism::NilNode then "nil"
       when Prism::ArrayNode then "Array[untyped]"
-      when Prism::HashNode then infer_hash_type(node, known_types: known_types, context_class: context_class)
+      when Prism::HashNode then infer_hash_type(node, known_types: known_types, context_class: context_class, constant_resolver: constant_resolver)
       when Prism::InterpolatedRegularExpressionNode, Prism::RegularExpressionNode then "Regexp"
       when Prism::SelfNode then context_class || "untyped"
       when Prism::ConstantReadNode, Prism::ConstantPathNode
-        RbsInfer::Analyzer.extract_constant_path(node) || "untyped"
+        resolve_constant_value_type(node, namespace: context_class, constant_resolver: constant_resolver) || "untyped"
       when Prism::CallNode
         if node.name == :new && node.receiver
           RbsInfer::Analyzer.extract_constant_path(node.receiver) || "untyped"

--- a/lib/rbs_infer/extensions/rails/current_attributes_callbacks_generator.rb
+++ b/lib/rbs_infer/extensions/rails/current_attributes_callbacks_generator.rb
@@ -131,7 +131,15 @@ module RbsInfer
         end
 
         def method_type_resolver
-          @method_type_resolver ||= RbsInfer::Signatures::MethodTypeResolver.new(source_files)
+          # Env-only constant resolver (no project SteepBridge here): the RBS env
+          # is process-global, so transitively-resolved types derived from a
+          # constant still get the constant's VALUE type, not its bare name (#56).
+          @method_type_resolver ||= RbsInfer::Signatures::MethodTypeResolver.new(
+            source_files,
+            constant_resolver: RbsInfer::Inference::ConstantArgTypeResolver.new(
+              steep_bridge: RbsInfer::Signatures::SteepBridge.new, caller_constant_types: {}
+            )
+          )
         end
 
         def markers_rbs(populated)

--- a/lib/rbs_infer/inference/class_body_attr_analyzer.rb
+++ b/lib/rbs_infer/inference/class_body_attr_analyzer.rb
@@ -2,10 +2,13 @@ module RbsInfer::Inference
   class ClassBodyAttrAnalyzer < Prism::Visitor
     include RbsInfer::AST::NodeTypeInferrer
 
-    attr_reader :attr_types, :collection_element_types
+    attr_reader :attr_types, :collection_element_types, :constant_resolver
 
-    def initialize(attr_names:, method_type_resolver: nil)
+    # constant_resolver: env-aware resolver so an attr assigned a constant is
+    # typed by the constant's VALUE, not its bare name (felixefelip/rbs_infer#56).
+    def initialize(attr_names:, constant_resolver:, method_type_resolver: nil)
       @attr_names = attr_names
+      @constant_resolver = constant_resolver
       @attr_types = {}
       @collection_element_types = {}
       @in_method = false

--- a/lib/rbs_infer/inference/constant_arg_type_resolver.rb
+++ b/lib/rbs_infer/inference/constant_arg_type_resolver.rb
@@ -14,7 +14,8 @@ module RbsInfer::Inference
     # referencing source (pass `{}` when there's no such source — the ERB path
     # and Steep-less collectors). Required so each call site states it rather
     # than inheriting a hidden default. steep_bridge nil disables the
-    # cross-file tier → bare-name fallback, as before.
+    # cross-file tier → only same-file constants resolve; anything else → nil
+    # (caller emits untyped), never a bare name (#56).
     def initialize(steep_bridge:, caller_constant_types:)
       @steep_bridge = steep_bridge
       @caller_constant_types = caller_constant_types
@@ -32,8 +33,10 @@ module RbsInfer::Inference
       same_file = @caller_constant_types[short] || @caller_constant_types[bare]
       return same_file if same_file
 
-      # No env to classify against → keep the bare name (legacy behavior).
-      return name unless @steep_bridge
+      # No env to classify against → nil (caller emits untyped). We must NEVER
+      # return the bare name unclassified: it's invalid RBS for a value
+      # constant and poisons the shared env (felixefelip/rbs_infer#56).
+      return nil unless @steep_bridge
 
       @steep_bridge.constant_type_from_env(bare, namespace: namespace) ||
         (@steep_bridge.class_or_module?(bare, namespace: namespace) ? name : nil)

--- a/lib/rbs_infer/inference/constant_type_resolver.rb
+++ b/lib/rbs_infer/inference/constant_type_resolver.rb
@@ -24,8 +24,14 @@ module RbsInfer::Inference
   class ConstantTypeResolver
     include RbsInfer::AST::NodeTypeInferrer
 
-    def initialize(target_class:)
+    attr_reader :constant_resolver
+
+    # constant_resolver: env-aware resolver so a constant aliasing another
+    # constant (`FOO = BAR`) resolves to BAR's VALUE type via the NodeTypeInferrer
+    # fallback, not BAR's bare name (felixefelip/rbs_infer#56).
+    def initialize(target_class:, constant_resolver:)
       @target_class = target_class
+      @constant_resolver = constant_resolver
       @constructor_inferrer = RbsInfer::AST::ConstructorTypeInferrer.new(target_class: target_class)
     end
 

--- a/lib/rbs_infer/inference/initialize_body_analyzer.rb
+++ b/lib/rbs_infer/inference/initialize_body_analyzer.rb
@@ -2,9 +2,15 @@ module RbsInfer::Inference
   class InitializeBodyAnalyzer < Prism::Visitor
     include RbsInfer::AST::NodeTypeInferrer
 
-    attr_reader :self_assignments, :keyword_defaults, :nil_default_params
+    attr_reader :self_assignments, :keyword_defaults, :nil_default_params, :constant_resolver
 
-    def initialize
+    # constant_resolver: required (felixefelip/rbs_infer#56) so a keyword
+    # default or self-assignment from a constant (`max_depth: MAX_DEPTH`,
+    # `@x = SIZE`) is typed by the constant's VALUE, not its bare name. Pass an
+    # env-aware ConstantArgTypeResolver; an env-only one still resolves
+    # cross-file constants via generated RBS.
+    def initialize(constant_resolver:)
+      @constant_resolver = constant_resolver
       @self_assignments = {}
       @keyword_defaults = {}
       # Params com default literal `nil` (`def x(name: nil)`). Separados
@@ -101,12 +107,14 @@ module RbsInfer::Inference
           end
         end
       when Prism::ConstantReadNode, Prism::ConstantPathNode
-        { kind: :constant, type: RbsInfer::Analyzer.extract_constant_path(node) }
+        # Value of the constant, not its bare name (#56). nil when unresolved →
+        # consumer skips it (treats the attr as untyped), never emits the name.
+        { kind: :constant, type: RbsInfer::AST::NodeTypeInferrer.resolve_constant_value_type(node, namespace: nil, constant_resolver: @constant_resolver) }
       when Prism::ArrayNode
         element_type = infer_collection_element_type(node.elements)
         { kind: :literal, type: "Array[#{element_type}]" }
       when Prism::HashNode
-        { kind: :literal, type: RbsInfer::AST::NodeTypeInferrer.infer_hash_type(node) }
+        { kind: :literal, type: RbsInfer::AST::NodeTypeInferrer.infer_hash_type(node, constant_resolver: @constant_resolver) }
       else
         { kind: :unknown }
       end

--- a/lib/rbs_infer/inference/intra_class_call_analyzer.rb
+++ b/lib/rbs_infer/inference/intra_class_call_analyzer.rb
@@ -216,7 +216,7 @@ module RbsInfer::Inference
       when Prism::TrueNode, Prism::FalseNode then "bool"
       when Prism::NilNode then "nil"
       when Prism::ArrayNode then "Array[untyped]"
-      when Prism::HashNode then RbsInfer::AST::NodeTypeInferrer.infer_hash_type(node)
+      when Prism::HashNode then RbsInfer::AST::NodeTypeInferrer.infer_hash_type(node, constant_resolver: @constant_arg_resolver)
       when Prism::ConstantReadNode, Prism::ConstantPathNode
         name = RbsInfer::Analyzer.extract_constant_path(node)
         # No namespace tracked here; intra-class constants resolve via the

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -329,7 +329,7 @@ module RbsInfer::Inference
       when Prism::TrueNode, Prism::FalseNode then "bool"
       when Prism::NilNode then "nil"
       when Prism::ArrayNode then "Array[untyped]"
-      when Prism::HashNode then RbsInfer::AST::NodeTypeInferrer.infer_hash_type(node)
+      when Prism::HashNode then RbsInfer::AST::NodeTypeInferrer.infer_hash_type(node, constant_resolver: @constant_arg_resolver)
       when Prism::ConstantReadNode, Prism::ConstantPathNode
         resolve_constant_arg_type(node)
       when Prism::SelfNode

--- a/lib/rbs_infer/inference/return_type_resolver.rb
+++ b/lib/rbs_infer/inference/return_type_resolver.rb
@@ -9,10 +9,11 @@ module RbsInfer::Inference
   class ReturnTypeResolver
     include KnownReturnTypesBuilder
 
-    def initialize(target_file:, target_class:, method_type_resolver:, instance_types: [], steep_bridge: nil)
+    def initialize(target_file:, target_class:, method_type_resolver:, constant_resolver:, instance_types: [], steep_bridge: nil)
       @target_file = target_file
       @target_class = target_class
       @method_type_resolver = method_type_resolver
+      @constant_resolver = constant_resolver
       @instance_types = instance_types
       @steep_bridge = steep_bridge
     end
@@ -301,7 +302,7 @@ module RbsInfer::Inference
       when Prism::SymbolNode, Prism::InterpolatedSymbolNode then "Symbol"
       when Prism::TrueNode, Prism::FalseNode then "bool"
       when Prism::ArrayNode then "Array[untyped]"
-      when Prism::HashNode then RbsInfer::AST::NodeTypeInferrer.infer_hash_type(node, known_types: known_return_types, context_class: @target_class)
+      when Prism::HashNode then RbsInfer::AST::NodeTypeInferrer.infer_hash_type(node, known_types: known_return_types, context_class: @target_class, constant_resolver: @constant_resolver)
       when Prism::SelfNode then @target_class
       when Prism::CallNode
         if node.name == :new && node.receiver
@@ -310,7 +311,8 @@ module RbsInfer::Inference
           known_return_types[node.name.to_s]
         end
       when Prism::ConstantReadNode, Prism::ConstantPathNode
-        RbsInfer::Analyzer.extract_constant_path(node)
+        # Constant's VALUE type, not its bare name (#56).
+        RbsInfer::AST::NodeTypeInferrer.resolve_constant_value_type(node, namespace: @target_class, constant_resolver: @constant_resolver)
       end
     end
   end

--- a/lib/rbs_infer/inference/type_merger.rb
+++ b/lib/rbs_infer/inference/type_merger.rb
@@ -6,8 +6,13 @@ module RbsInfer::Inference
     # Métodos de Array que retornam self (o próprio array)
     ARRAY_SELF_RETURN_METHODS = %i[<< push append unshift prepend insert concat].to_set
 
-    def initialize(target_file:, target_class: nil, instance_types: [])
+    attr_reader :constant_resolver
+
+    # constant_resolver: env-aware resolver so a constant in value position
+    # (e.g. a block body) is typed by its VALUE, not its bare name (#56).
+    def initialize(target_file:, constant_resolver:, target_class: nil, instance_types: [])
       @target_file = target_file
+      @constant_resolver = constant_resolver
       @target_class = target_class
       @instance_types = instance_types
     end

--- a/lib/rbs_infer/signatures/method_type_resolver.rb
+++ b/lib/rbs_infer/signatures/method_type_resolver.rb
@@ -9,11 +9,13 @@ module RbsInfer::Signatures
 
     attr_reader :constant_resolver
 
-    # constant_resolver: env-aware resolver for value-position constants in the
-    # classes this resolver analyzes (e.g. another class's init keyword default).
-    # Defaulted nil because some callers (Rails extension generators) legitimately
-    # have no env; there a value constant just defers to untyped (#56).
-    def initialize(source_files, source_index: nil, parse_cache: nil, file_index: nil, caller_file_cache: nil, constant_resolver: nil)
+    # constant_resolver: required (felixefelip/rbs_infer#56). Env-aware resolver
+    # for value-position constants in the classes this resolver analyzes (e.g.
+    # another class's init keyword default → its VALUE type, not its bare name).
+    # Required, not defaulted: a caller that forgets it silently degrades those
+    # types to untyped. Callers without a project SteepBridge can still pass an
+    # env-only ConstantArgTypeResolver (the RBS env is process-global).
+    def initialize(source_files, constant_resolver:, source_index: nil, parse_cache: nil, file_index: nil, caller_file_cache: nil)
       @source_files = source_files
       @source_index = source_index
       @constant_resolver = constant_resolver
@@ -182,8 +184,9 @@ module RbsInfer::Signatures
           local_var_types: local_var_types,
           method_type_resolver: self,
           caller_class_name: caller_class_name,
-          # No Steep env here → bare-name fallback; explicit, not a default (#46).
-          constant_arg_resolver: RbsInfer::Inference::ConstantArgTypeResolver.new(steep_bridge: nil, caller_constant_types: {})
+          # Env-aware resolver so constant call-site args resolve to their value
+          # type via the loaded RBS env, not a bare name (#46, #56).
+          constant_arg_resolver: @constant_resolver
         )
         entry.result.value.accept(visitor)
         all_usages.concat(visitor.usages)
@@ -385,8 +388,9 @@ module RbsInfer::Signatures
           local_var_types: local_var_types,
           method_type_resolver: self,
           caller_class_name: caller_class_name,
-          # No Steep env here → bare-name fallback; explicit, not a default (#46).
-          constant_arg_resolver: RbsInfer::Inference::ConstantArgTypeResolver.new(steep_bridge: nil, caller_constant_types: {})
+          # Env-aware resolver so constant call-site args resolve to their value
+          # type via the loaded RBS env, not a bare name (#46, #56).
+          constant_arg_resolver: @constant_resolver
         )
         entry.result.value.accept(visitor)
 

--- a/lib/rbs_infer/signatures/method_type_resolver.rb
+++ b/lib/rbs_infer/signatures/method_type_resolver.rb
@@ -7,9 +7,16 @@ module RbsInfer::Signatures
   class MethodTypeResolver
     include RbsInfer::AST::NodeTypeInferrer
 
-    def initialize(source_files, source_index: nil, parse_cache: nil, file_index: nil, caller_file_cache: nil)
+    attr_reader :constant_resolver
+
+    # constant_resolver: env-aware resolver for value-position constants in the
+    # classes this resolver analyzes (e.g. another class's init keyword default).
+    # Defaulted nil because some callers (Rails extension generators) legitimately
+    # have no env; there a value constant just defers to untyped (#56).
+    def initialize(source_files, source_index: nil, parse_cache: nil, file_index: nil, caller_file_cache: nil, constant_resolver: nil)
       @source_files = source_files
       @source_index = source_index
+      @constant_resolver = constant_resolver
       @parse_cache = parse_cache || RbsInfer::Project::ParseCache.new
       @file_index = file_index || RbsInfer::Project::FileIndex.new(source_files)
       @caller_file_cache = caller_file_cache || RbsInfer::Project::CallerFileCache.new(@parse_cache)
@@ -247,7 +254,7 @@ module RbsInfer::Signatures
           end
 
           # 2. Tipos inferidos via keyword defaults do initialize
-          init_visitor = RbsInfer::Inference::InitializeBodyAnalyzer.new
+          init_visitor = RbsInfer::Inference::InitializeBodyAnalyzer.new(constant_resolver: @constant_resolver)
           result.value.accept(init_visitor)
 
           init_visitor.keyword_defaults.each do |param_name, default_type|

--- a/spec/dummy/app/models/cbor_like.rb
+++ b/spec/dummy/app/models/cbor_like.rb
@@ -1,0 +1,19 @@
+# Exercises value-position constant typing (felixefelip/rbs_infer#56): a value
+# constant used as a keyword default and assigned to an ivar both resolve to the
+# constant's VALUE type (Integer), never its bare name — which is invalid RBS and
+# poisons the shared env. Mirrors the real ActionPack::WebAuthn::CborDecoder.
+class CborLike
+  MAX_DEPTH = 16
+
+  def initialize(max_depth: MAX_DEPTH)
+    @max_depth = max_depth
+    @limit = MAX_DEPTH
+    @depth = 0
+  end
+
+  # Reads the ivars so they're emitted; an array literal keeps the return type
+  # deterministic (no Steep-convergence dependence in the snapshot).
+  def levels
+    [@max_depth, @limit, @depth]
+  end
+end

--- a/spec/dummy/sig/rbs_infer/app/models/cbor_like.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/cbor_like.rbs
@@ -1,0 +1,9 @@
+class CborLike
+  @max_depth: Integer
+  @limit: Integer
+  @depth: Integer
+  MAX_DEPTH: Integer
+
+  def initialize: (?max_depth: Integer) -> Integer
+  def levels: () -> Array[untyped]
+end

--- a/spec/expectations/models/cbor_like.rbs
+++ b/spec/expectations/models/cbor_like.rbs
@@ -1,0 +1,9 @@
+class CborLike
+  @max_depth: Integer
+  @limit: Integer
+  @depth: Integer
+  MAX_DEPTH: Integer
+
+  def initialize: (?max_depth: Integer) -> Integer
+  def levels: () -> Array[untyped]
+end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -75,6 +75,10 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     assert_snapshot("models/coupon/code", target_class: "Coupon::Code", target_file: "app/models/coupon/code.rb")
   end
 
+  it "CborLike (value constant in value position) matches expected RBS" do
+    assert_snapshot("models/cbor_like", target_class: "CborLike", target_file: "app/models/cbor_like.rb")
+  end
+
   it "Current expansion (pseudo-code) matches expected source" do
     # Snapshot of the desugar itself, separate from the RBS snapshot: a
     # new bug points straight to the right layer — expansion changes →

--- a/spec/lib/rbs_infer/ast/node_type_inferrer_spec.rb
+++ b/spec/lib/rbs_infer/ast/node_type_inferrer_spec.rb
@@ -2,10 +2,10 @@ require "spec_helper"
 require "rbs_infer"
 
 RSpec.describe RbsInfer::AST::NodeTypeInferrer do
-  def infer_hash(source, known_types: {}, context_class: nil)
+  def infer_hash(source, known_types: {}, context_class: nil, constant_resolver: fake_constant_resolver)
     result = Prism.parse(source)
     hash_node = find_hash_node(result.value)
-    described_class.infer_hash_type(hash_node, known_types: known_types, context_class: context_class)
+    described_class.infer_hash_type(hash_node, known_types: known_types, context_class: context_class, constant_resolver: constant_resolver)
   end
 
   def find_hash_node(node)
@@ -38,8 +38,13 @@ RSpec.describe RbsInfer::AST::NodeTypeInferrer do
       expect(infer_hash("{ comment: Comment.new }")).to eq("{ comment: Comment }")
     end
 
-    it "returns record type with constant values" do
-      expect(infer_hash("{ klass: MyModule::MyClass }")).to eq("{ klass: MyModule::MyClass }")
+    it "types a constant value via the resolver (its VALUE type, not the bare name) (#56)" do
+      resolver = fake_constant_resolver("MyModule::MyClass" => "Integer")
+      expect(infer_hash("{ klass: MyModule::MyClass }", constant_resolver: resolver)).to eq("{ klass: Integer }")
+    end
+
+    it "uses untyped for a constant value the resolver can't classify (never the bare name) (#56)" do
+      expect(infer_hash("{ klass: MyModule::MyClass }")).to eq("{ klass: untyped }")
     end
 
     it "uses untyped for complex expressions in values" do

--- a/spec/lib/rbs_infer/inference/class_body_attr_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/inference/class_body_attr_analyzer_spec.rb
@@ -2,9 +2,9 @@ require "spec_helper"
 require "rbs_infer"
 
 RSpec.describe RbsInfer::Inference::ClassBodyAttrAnalyzer do
-  def analyze(source, attr_names)
+  def analyze(source, attr_names, constant_resolver: fake_constant_resolver)
     result = Prism.parse(source)
-    visitor = described_class.new(attr_names: attr_names.to_set)
+    visitor = described_class.new(attr_names: attr_names.to_set, constant_resolver: constant_resolver)
     result.value.accept(visitor)
     visitor
   end

--- a/spec/lib/rbs_infer/inference/constant_arg_type_resolver_spec.rb
+++ b/spec/lib/rbs_infer/inference/constant_arg_type_resolver_spec.rb
@@ -45,9 +45,14 @@ RSpec.describe RbsInfer::Inference::ConstantArgTypeResolver do
       expect(resolver.resolve(name: "UNDEFINED_CONST", namespace: nil)).to be_nil
     end
 
-    it "without a Steep env, preserves the legacy bare-name behavior" do
+    it "without a Steep env, still resolves a same-file constant" do
+      resolver = described_class.new(steep_bridge: nil, caller_constant_types: { "CODE_LENGTH" => "Integer" })
+      expect(resolver.resolve(name: "CODE_LENGTH", namespace: nil)).to eq("Integer")
+    end
+
+    it "without a Steep env, returns nil for an unclassifiable constant (never a bare name, #56)" do
       resolver = described_class.new(steep_bridge: nil, caller_constant_types: {})
-      expect(resolver.resolve(name: "User", namespace: nil)).to eq("User")
+      expect(resolver.resolve(name: "User", namespace: nil)).to be_nil
     end
 
     it "returns nil for a nil node name" do

--- a/spec/lib/rbs_infer/inference/constant_type_resolver_spec.rb
+++ b/spec/lib/rbs_infer/inference/constant_type_resolver_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "rbs_infer"
 
 RSpec.describe RbsInfer::Inference::ConstantTypeResolver do
-  subject(:resolver) { described_class.new(target_class: "Color") }
+  subject(:resolver) { described_class.new(target_class: "Color", constant_resolver: fake_constant_resolver) }
 
   # RHS node of a `NAME = <expr>` statement.
   def rhs(code)

--- a/spec/lib/rbs_infer/inference/initialize_body_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/inference/initialize_body_analyzer_spec.rb
@@ -2,9 +2,9 @@ require "spec_helper"
 require "rbs_infer"
 
 RSpec.describe RbsInfer::Inference::InitializeBodyAnalyzer do
-  def analyze(source)
+  def analyze(source, constant_resolver: fake_constant_resolver)
     result = Prism.parse(source)
-    visitor = described_class.new
+    visitor = described_class.new(constant_resolver: constant_resolver)
     result.value.accept(visitor)
     visitor
   end

--- a/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
 
     with_temp_files(files) do |dir, paths|
       Dir.chdir(dir) do
-        resolver = RbsInfer::Signatures::MethodTypeResolver.new(paths)
+        resolver = RbsInfer::Signatures::MethodTypeResolver.new(paths, constant_resolver: fake_constant_resolver)
         source = File.read(paths.last)
         result = Prism.parse(source)
         visitor = described_class.new(
@@ -375,7 +375,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
 
       with_temp_files(files) do |dir, paths|
         Dir.chdir(dir) do
-          resolver = RbsInfer::Signatures::MethodTypeResolver.new(paths)
+          resolver = RbsInfer::Signatures::MethodTypeResolver.new(paths, constant_resolver: fake_constant_resolver)
           source = File.read(File.join(dir, "caller.rb"))
           result = Prism.parse(source)
           visitor = described_class.new(

--- a/spec/lib/rbs_infer/inference/type_merger_spec.rb
+++ b/spec/lib/rbs_infer/inference/type_merger_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "rbs_infer"
 
 RSpec.describe RbsInfer::Inference::TypeMerger do
-  let(:merger) { described_class.new(target_file: nil) }
+  let(:merger) { described_class.new(target_file: nil, constant_resolver: fake_constant_resolver) }
 
   it "prioriza tipos resolvidos sobre untyped" do
     usages = [

--- a/spec/lib/rbs_infer/signatures/method_type_resolver_spec.rb
+++ b/spec/lib/rbs_infer/signatures/method_type_resolver_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     }
 
     with_temp_files(files) do |dir, paths|
-      resolver = described_class.new(paths)
+      resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
       expect(resolver.resolve("Foo", "name")).to eq("String")
     end
   end
@@ -35,7 +35,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     }
 
     with_temp_files(files) do |dir, paths|
-      resolver = described_class.new(paths)
+      resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
       expect(resolver.resolve("Foo", "count")).to eq("Integer")
     end
   end
@@ -54,7 +54,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     }
 
     with_temp_files(files) do |dir, paths|
-      resolver = described_class.new(paths)
+      resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
       expect(resolver.resolve("Foo", "repo")).to eq("DefaultRepo")
     end
   end
@@ -79,7 +79,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     }
 
     with_temp_files(files) do |dir, paths|
-      resolver = described_class.new(paths)
+      resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
       expect(resolver.resolve("MyApp::Foo", "widget")).to eq("Widget")
     end
   end
@@ -111,7 +111,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     RUBY
 
     with_temp_files("my_app/entity.rb" => entity_src, "my_app/service.rb" => service_src) do |dir, paths|
-      resolver = described_class.new(paths)
+      resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
       expect(resolver.resolve("MyApp::Entity", "nome")).to eq("String")
     end
   end
@@ -143,7 +143,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     RUBY
 
     with_temp_files("my_app/entity.rb" => entity_src, "my_app/caller.rb" => caller_src) do |dir, paths|
-      resolver = described_class.new(paths)
+      resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
       expect(resolver.resolve("MyApp::Entity", "email")).to eq("Wrapper")
       expect(resolver.resolve_init_param_types("MyApp::Entity")["email"]).to eq("String")
     end
@@ -176,7 +176,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     }
 
     with_temp_files(files) do |dir, paths|
-      resolver = described_class.new(paths)
+      resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
       expect(resolver.resolve("Model & Model::Validated", "file")).to eq("Uploader")
       expect(resolver.resolve("(Model & Model::Validated)", "file")).to eq("Uploader")
     end
@@ -206,7 +206,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     }
 
     with_temp_files(files) do |dir, paths|
-      resolver = described_class.new(paths)
+      resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
       expect(resolver.resolve("(LeftClass & RightClass)", "shared")).to eq("Symbol")
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,26 @@ require "rbs_infer"
 
 DUMMY_APP_ROOT = File.expand_path("dummy", __dir__)
 
+# Test-only constant resolver (felixefelip/rbs_infer#56). Production code threads
+# a real env-aware ConstantArgTypeResolver into every value-typing class; the
+# dependency is required (not defaulted) so an un-wired production caller fails
+# loudly. Unit specs build this instead — a name→type map (empty resolves to
+# nil) — keeping the production API strict per docs/engineering/required-threaded-deps.
+module ConstantResolverHelper
+  FakeConstantResolver = Struct.new(:map) do
+    def resolve(name:, namespace:)
+      map[name]
+    end
+  end
+
+  def fake_constant_resolver(map = {})
+    FakeConstantResolver.new(map)
+  end
+end
+
 RSpec.configure do |config|
+  config.include ConstantResolverHelper
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end


### PR DESCRIPTION
Closes #56.

## Problema

Uma constante em **posição de valor** era emitida como o **nome cru**:

```ruby
# lib/action_pack/web_authn/cbor_decoder.rb
MAX_DEPTH = 16
def initialize(bytes, max_depth: MAX_DEPTH, ...)
  @max_depth = max_depth
```
```rbs
# antes (inválido / envenena o env)
@max_depth: MAX_DEPTH
def initialize: (untyped bytes, ?max_depth: MAX_DEPTH, ...) -> Integer
# depois
@max_depth: Integer
def initialize: (untyped bytes, ?max_depth: Integer, ...) -> Integer
```

Nome cru só é tipo RBS válido para classe/módulo. As PRs #54 (param defaults) e #55 (returns) corrigiram dois caminhos, mas a lógica "constante vira tipo" estava **duplicada** em vários sítios — whack-a-mole (#56).

## Correção (unificação na raiz)

Todo sítio de posição-de-valor passa a resolver a constante pelo `ConstantArgTypeResolver` (infra do #46) → tipo do **valor**, nunca o nome cru:

- **`NodeTypeInferrer`** (`infer_node_type` / `infer_value_type` / `infer_hash_type`): via um `resolve_constant_value_type` compartilhado + `constant_resolver` injetado. Includers puramente estruturais herdam `nil` → deferem para `untyped`, nunca nome cru.
- **`InitializeBodyAnalyzer`**: keyword defaults e self-assignments de constante (o caso reportado do `CborDecoder`).
- **`ReturnTypeResolver#basic_value_type`**: escrita de ivar a partir de constante.
- **`IntraClassCallAnalyzer` / `NewCallCollector`** (valores de hash): repassam o resolver `#46` que já possuem.

O resolver é construído uma vez no `Analyzer` (env + constantes do próprio target) e threadado como **dependência obrigatória** (princípio `required-threaded-deps`) por todas as classes de value-typing; variante env-only para outras classes. O `ConstantArgTypeResolver` foi endurecido: sem env Steep, retorna `nil` para constante não-classificável em vez do nome cru.

Usos **estruturais/receiver** de constante (`Foo.new`, `Foo::Bar.baz`) ficam intactos.

## Comportamento por caso

- constante-valor → tipo do valor (`Integer`, `Array[String]`, …)
- classe/módulo (param default, #46) → o nome (tipo válido)
- não resolvível / sem env → `untyped` (nunca o nome cru)
- return → continua deferindo ao Steep (#55), que dá `singleton(K)`/uniões

## Testes

- Specs unitários atualizados: resolver endurecido (sem env → nil), `NodeTypeInferrer` resolvendo valor de hash via resolver. Helper de teste `fake_constant_resolver` mantém a API de produção estrita (dep obrigatória).
- Fixture de integração `CborLike` (espelha o `CborDecoder`): `@limit: Integer`, `@max_depth: Integer`, `?max_depth: Integer`, `MAX_DEPTH: Integer` — nenhum nome cru.
- Suite completa: `632 examples, 0 failures` (snapshots e steep baseline incluídos; nenhum snapshot existente mudou → comportamento preservado onde já estava correto).

Relacionado: #54, #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)