### PR TITLE
refactor: unify Prism node→type dispatch into one literal typer (#58)

### DIFF
--- a/lib/rbs_infer/ast/node_type_inferrer.rb
+++ b/lib/rbs_infer/ast/node_type_inferrer.rb
@@ -63,7 +63,7 @@ module RbsInfer::AST
       constant_resolver.resolve(name: RbsInfer::Analyzer.extract_constant_path(node), namespace: namespace)
     end
 
-    def self.infer_hash_type(node, known_types: {}, context_class: nil, constant_resolver: nil)
+    def self.infer_hash_type(node, constant_resolver:, known_types: {}, context_class: nil)
       elements = node.elements
       return "Hash[untyped, untyped]" if elements.empty?
 
@@ -96,7 +96,7 @@ module RbsInfer::AST
       end
     end
 
-    def self.infer_value_type(node, known_types: {}, context_class: nil, constant_resolver: nil)
+    def self.infer_value_type(node, constant_resolver:, known_types: {}, context_class: nil)
       case node
       when Prism::StringNode, Prism::InterpolatedStringNode then "String"
       when Prism::IntegerNode then "Integer"

--- a/lib/rbs_infer/ast/node_type_inferrer.rb
+++ b/lib/rbs_infer/ast/node_type_inferrer.rb
@@ -7,13 +7,17 @@ module RbsInfer::AST
   # method resolution) incluem este módulo e adicionam sua própria
   # camada de resolução sobre o resultado de `infer_node_type`.
   module NodeTypeInferrer
-    # Includers that type constants in VALUE position (a constant as a return,
-    # ivar, hash value, default, …) provide a `ConstantArgTypeResolver` here so
-    # the type is the constant's VALUE type, not its bare name (invalid RBS for
-    # a value constant, and env-poisoning). Purely structural includers inherit
-    # nil and value-position constants defer to untyped (felixefelip/rbs_infer#56).
+    # Abstract: every includer must declare its resolver explicitly
+    # (felixefelip/rbs_infer#56). Includers that type constants in VALUE position
+    # (a constant as a return, ivar, hash value, default, …) provide a real
+    # `ConstantArgTypeResolver` so the type is the constant's VALUE type, not its
+    # bare name (invalid RBS for a value constant, and env-poisoning) — typically
+    # via `attr_reader :constant_resolver`. Purely structural includers that never
+    # type value-position constants override with an explicit `nil`. Not defaulted
+    # to nil: a future includer that types value constants but forgets to override
+    # would silently degrade them to untyped; raising forces a conscious choice.
     def constant_resolver
-      nil
+      raise NotImplementedError, "#{self.class} must declare #constant_resolver (a ConstantArgTypeResolver, or nil if it never types value-position constants)"
     end
 
     def infer_node_type(node, context_class: nil, known_types: {})

--- a/lib/rbs_infer/ast/node_type_inferrer.rb
+++ b/lib/rbs_infer/ast/node_type_inferrer.rb
@@ -21,16 +21,10 @@ module RbsInfer::AST
     end
 
     def infer_node_type(node, context_class: nil, known_types: {})
+      literal = NodeTypeInferrer.infer_literal_node_type(node, constant_resolver: constant_resolver, known_types: known_types, context_class: context_class)
+      return literal if literal
+
       case node
-      when Prism::StringNode, Prism::InterpolatedStringNode then "String"
-      when Prism::IntegerNode then "Integer"
-      when Prism::FloatNode then "Float"
-      when Prism::SymbolNode, Prism::InterpolatedSymbolNode then "Symbol"
-      when Prism::TrueNode, Prism::FalseNode then "bool"
-      when Prism::NilNode then "nil"
-      when Prism::ArrayNode then "Array[untyped]"
-      when Prism::HashNode then infer_hash_type(node, context_class: context_class, known_types: known_types)
-      when Prism::InterpolatedRegularExpressionNode, Prism::RegularExpressionNode then "Regexp"
       when Prism::SelfNode then context_class
       when Prism::ConstantReadNode, Prism::ConstantPathNode
         NodeTypeInferrer.resolve_constant_value_type(node, namespace: context_class, constant_resolver: constant_resolver)
@@ -51,16 +45,32 @@ module RbsInfer::AST
       end
     end
 
-    def infer_hash_type(node, context_class: nil, known_types: {})
-      NodeTypeInferrer.infer_hash_type(node, known_types: known_types, context_class: context_class, constant_resolver: constant_resolver)
-    end
-
     # Resolves a bare-constant node to its VALUE type via the resolver, or nil
     # when none/unresolved — never the bare name (#56). Shared by the instance
     # method and the module-level value/hash typers.
     def self.resolve_constant_value_type(node, namespace:, constant_resolver:)
       return nil unless constant_resolver
       constant_resolver.resolve(name: RbsInfer::Analyzer.extract_constant_path(node), namespace: namespace)
+    end
+
+    # The single source of truth for nodes whose RBS type is unambiguous from
+    # the node alone (literals, collections, regexps). Returns nil for
+    # context-dependent nodes (calls, constants, self, variable reads) so each
+    # caller layers its own resolution on top — replacing the literal-typing
+    # case table that used to be copy-pasted across the value typers
+    # (felixefelip/rbs_infer#58).
+    def self.infer_literal_node_type(node, constant_resolver:, known_types: {}, context_class: nil)
+      case node
+      when Prism::StringNode, Prism::InterpolatedStringNode then "String"
+      when Prism::IntegerNode then "Integer"
+      when Prism::FloatNode then "Float"
+      when Prism::SymbolNode, Prism::InterpolatedSymbolNode then "Symbol"
+      when Prism::TrueNode, Prism::FalseNode then "bool"
+      when Prism::NilNode then "nil"
+      when Prism::ArrayNode then "Array[untyped]"
+      when Prism::HashNode then infer_hash_type(node, known_types: known_types, context_class: context_class, constant_resolver: constant_resolver)
+      when Prism::InterpolatedRegularExpressionNode, Prism::RegularExpressionNode then "Regexp"
+      end
     end
 
     def self.infer_hash_type(node, constant_resolver:, known_types: {}, context_class: nil)
@@ -97,16 +107,10 @@ module RbsInfer::AST
     end
 
     def self.infer_value_type(node, constant_resolver:, known_types: {}, context_class: nil)
+      literal = infer_literal_node_type(node, constant_resolver: constant_resolver, known_types: known_types, context_class: context_class)
+      return literal if literal
+
       case node
-      when Prism::StringNode, Prism::InterpolatedStringNode then "String"
-      when Prism::IntegerNode then "Integer"
-      when Prism::FloatNode then "Float"
-      when Prism::SymbolNode, Prism::InterpolatedSymbolNode then "Symbol"
-      when Prism::TrueNode, Prism::FalseNode then "bool"
-      when Prism::NilNode then "nil"
-      when Prism::ArrayNode then "Array[untyped]"
-      when Prism::HashNode then infer_hash_type(node, known_types: known_types, context_class: context_class, constant_resolver: constant_resolver)
-      when Prism::InterpolatedRegularExpressionNode, Prism::RegularExpressionNode then "Regexp"
       when Prism::SelfNode then context_class || "untyped"
       when Prism::ConstantReadNode, Prism::ConstantPathNode
         resolve_constant_value_type(node, namespace: context_class, constant_resolver: constant_resolver) || "untyped"

--- a/lib/rbs_infer/inference/class_member_collector.rb
+++ b/lib/rbs_infer/inference/class_member_collector.rb
@@ -24,6 +24,11 @@ module RbsInfer::Inference
 
     attr_reader :members, :delegates, :superclass_name, :is_module
 
+    # Structural collector: constant value/hash defaults are peeled off before
+    # they reach the resolver path (bare constants → deferred to the Analyzer),
+    # so this never types a value-position constant itself (felixefelip/rbs_infer#56).
+    def constant_resolver = nil
+
     CONTROLLER_BASES = %w[ApplicationController ActionController::Base ActionController::API].freeze
 
     def initialize(comments:, lines:, target_class: nil)

--- a/lib/rbs_infer/inference/class_member_collector/extract_params_signature.rb
+++ b/lib/rbs_infer/inference/class_member_collector/extract_params_signature.rb
@@ -10,6 +10,11 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
     # mirroring how `:constant` members defer (felixefelip/rbs_infer#37, #46).
     attr_reader :constant_default_params
 
+    # Structural: constant defaults are captured into @constant_default_params and
+    # emitted as `?untyped` for the Analyzer to fill, so this never resolves a
+    # value-position constant itself (felixefelip/rbs_infer#56).
+    def constant_resolver = nil
+
     def initialize(params)
 			@params = params
       @parts = []

--- a/lib/rbs_infer/inference/intra_class_call_analyzer.rb
+++ b/lib/rbs_infer/inference/intra_class_call_analyzer.rb
@@ -182,6 +182,9 @@ module RbsInfer::Inference
     end
 
     def resolve_value_type(node)
+      literal = RbsInfer::AST::NodeTypeInferrer.infer_literal_node_type(node, constant_resolver: @constant_arg_resolver)
+      return literal if literal
+
       case node
       when Prism::LocalVariableReadNode
         @local_var_types[node.name.to_s] || "untyped"
@@ -209,14 +212,6 @@ module RbsInfer::Inference
         else
           "untyped"
         end
-      when Prism::StringNode, Prism::InterpolatedStringNode then "String"
-      when Prism::IntegerNode then "Integer"
-      when Prism::FloatNode then "Float"
-      when Prism::SymbolNode, Prism::InterpolatedSymbolNode then "Symbol"
-      when Prism::TrueNode, Prism::FalseNode then "bool"
-      when Prism::NilNode then "nil"
-      when Prism::ArrayNode then "Array[untyped]"
-      when Prism::HashNode then RbsInfer::AST::NodeTypeInferrer.infer_hash_type(node, constant_resolver: @constant_arg_resolver)
       when Prism::ConstantReadNode, Prism::ConstantPathNode
         name = RbsInfer::Analyzer.extract_constant_path(node)
         # No namespace tracked here; intra-class constants resolve via the

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -309,6 +309,9 @@ module RbsInfer::Inference
     end
 
     def resolve_value_type(node)
+      literal = RbsInfer::AST::NodeTypeInferrer.infer_literal_node_type(node, constant_resolver: @constant_arg_resolver)
+      return literal if literal
+
       case node
       when Prism::LocalVariableReadNode
         @local_var_types[node.name.to_s] || "untyped"
@@ -322,14 +325,6 @@ module RbsInfer::Inference
         else
           resolve_method_chain(node) || "untyped"
         end
-      when Prism::StringNode, Prism::InterpolatedStringNode then "String"
-      when Prism::IntegerNode then "Integer"
-      when Prism::FloatNode then "Float"
-      when Prism::SymbolNode then "Symbol"
-      when Prism::TrueNode, Prism::FalseNode then "bool"
-      when Prism::NilNode then "nil"
-      when Prism::ArrayNode then "Array[untyped]"
-      when Prism::HashNode then RbsInfer::AST::NodeTypeInferrer.infer_hash_type(node, constant_resolver: @constant_arg_resolver)
       when Prism::ConstantReadNode, Prism::ConstantPathNode
         resolve_constant_arg_type(node)
       when Prism::SelfNode

--- a/lib/rbs_infer/inference/param_type_inferrer.rb
+++ b/lib/rbs_infer/inference/param_type_inferrer.rb
@@ -228,6 +228,9 @@ module RbsInfer::Inference
 
     # Resolve o tipo de um valor de argumento
     def resolve_arg_value_type(node, local_var_types, method_return_types)
+      literal = RbsInfer::AST::NodeTypeInferrer.infer_literal_node_type(node, constant_resolver: @constant_arg_resolver, context_class: @constant_namespace)
+      return literal if literal
+
       case node
       when Prism::LocalVariableReadNode
         local_var_types[node.name.to_s] || "untyped"
@@ -245,12 +248,6 @@ module RbsInfer::Inference
             "untyped"
           end
         end
-      when Prism::StringNode then "String"
-      when Prism::IntegerNode then "Integer"
-      when Prism::FloatNode then "Float"
-      when Prism::SymbolNode then "Symbol"
-      when Prism::TrueNode, Prism::FalseNode then "bool"
-      when Prism::NilNode then "nil"
       when Prism::ConstantReadNode, Prism::ConstantPathNode
         name = RbsInfer::Analyzer.extract_constant_path(node)
         @constant_arg_resolver.resolve(name: name, namespace: @constant_namespace) || "untyped"

--- a/lib/rbs_infer/inference/return_type_resolver.rb
+++ b/lib/rbs_infer/inference/return_type_resolver.rb
@@ -294,15 +294,10 @@ module RbsInfer::Inference
     # Klass.new, and simple same-class method lookups.
     # Complex chain resolution is delegated to Steep.
     def basic_value_type(node, known_return_types)
+      literal = RbsInfer::AST::NodeTypeInferrer.infer_literal_node_type(node, known_types: known_return_types, context_class: @target_class, constant_resolver: @constant_resolver)
+      return literal if literal
+
       case node
-      when Prism::NilNode then "nil"
-      when Prism::StringNode, Prism::InterpolatedStringNode then "String"
-      when Prism::IntegerNode then "Integer"
-      when Prism::FloatNode then "Float"
-      when Prism::SymbolNode, Prism::InterpolatedSymbolNode then "Symbol"
-      when Prism::TrueNode, Prism::FalseNode then "bool"
-      when Prism::ArrayNode then "Array[untyped]"
-      when Prism::HashNode then RbsInfer::AST::NodeTypeInferrer.infer_hash_type(node, known_types: known_return_types, context_class: @target_class, constant_resolver: @constant_resolver)
       when Prism::SelfNode then @target_class
       when Prism::CallNode
         if node.name == :new && node.receiver

--- a/spec/lib/rbs_infer/ast/node_type_inferrer_spec.rb
+++ b/spec/lib/rbs_infer/ast/node_type_inferrer_spec.rb
@@ -17,6 +17,39 @@ RSpec.describe RbsInfer::AST::NodeTypeInferrer do
     nil
   end
 
+  describe ".infer_literal_node_type" do
+    def infer_literal(source, constant_resolver: fake_constant_resolver)
+      node = Prism.parse(source).value.statements.body.first
+      described_class.infer_literal_node_type(node, constant_resolver: constant_resolver)
+    end
+
+    # The single source of truth shared by every value typer (#58). Each literal
+    # kind must map identically regardless of caller — this is what the per-class
+    # copies used to drift on (e.g. some missed Array/Hash/InterpolatedSymbol).
+    it "maps every unambiguous literal node to its RBS type" do
+      expect(infer_literal('"x"')).to eq("String")
+      expect(infer_literal('"a#{b}c"')).to eq("String")          # InterpolatedString
+      expect(infer_literal("1")).to eq("Integer")
+      expect(infer_literal("1.5")).to eq("Float")
+      expect(infer_literal(":a")).to eq("Symbol")
+      expect(infer_literal(':"a#{b}"')).to eq("Symbol")          # InterpolatedSymbol
+      expect(infer_literal("true")).to eq("bool")
+      expect(infer_literal("false")).to eq("bool")
+      expect(infer_literal("nil")).to eq("nil")
+      expect(infer_literal("[1, 2]")).to eq("Array[untyped]")
+      expect(infer_literal("{ a: 1 }")).to eq("{ a: Integer }")
+      expect(infer_literal("/abc/")).to eq("Regexp")
+      expect(infer_literal('/a#{b}/')).to eq("Regexp")           # InterpolatedRegexp
+    end
+
+    it "returns nil for context-dependent nodes (caller layers its own resolution)" do
+      expect(infer_literal("foo")).to be_nil                     # CallNode / receiverless
+      expect(infer_literal("@x")).to be_nil                      # InstanceVariableRead
+      expect(infer_literal("self")).to be_nil                    # SelfNode
+      expect(infer_literal("SOME_CONST")).to be_nil              # ConstantRead
+    end
+  end
+
   describe ".infer_hash_type" do
     it "returns record type for all-Symbol keys" do
       expect(infer_hash("{ foo: 'bar', baz: 42 }")).to eq("{ foo: String, baz: Integer }")


### PR DESCRIPTION
Closes #58.

## Contexto

A tabela de dispatch "nó Prism → tipo RBS" (literais: `String`, `Integer`, `Float`, `Symbol`, `bool`, `nil`, `Array`, `Hash`, `Regexp`) estava reimplementada em **6 lugares** e já tinha **divergido**: `param_type_inferrer` não tipava `Array`/`Hash`/`InterpolatedString`; vários não cobriam `Regexp`/`InterpolatedSymbol`. Cada divergência é uma inconsistência silenciosa de inferência entre call-sites, params e returns — exatamente o que `docs/engineering/prefer-principled-over-shortcuts.md` alerta.

## Mudanças

Extrai `NodeTypeInferrer.infer_literal_node_type` como **fonte única de verdade** para nós cujo tipo é inequívoco a partir do nó (literais, coleções, regexp). Retorna `nil` para nós dependentes de contexto (call, constante, self, leitura de variável) — cada chamador empilha sua própria resolução por cima.

Roteei as 6 cópias por ele:

- `NodeTypeInferrer#infer_node_type`
- `NodeTypeInferrer.infer_value_type`
- `NewCallCollector#resolve_value_type`
- `IntraClassCallAnalyzer#resolve_value_type`
- `ReturnTypeResolver#basic_value_type`
- `ParamTypeInferrer#resolve_arg_value_type`

**Opção C — divergências unificadas, não só deduplicadas:** todos os typers passam a cobrir o conjunto completo de literais de forma idêntica (ex.: args de método agora tipam `Array`/`Hash`/literais interpolados). Também removi o wrapper de instância `infer_hash_type` que ficou sem uso, e adicionei spec travando o mapa de literais na fonte única.

## Nota sobre escopo

Esta branch também carrega **2 commits de endurecimento do `constant_resolver`** que ficaram de fora do #57 (mergeado): hook `constant_resolver` abstrato e os typers de hash/value com kwarg obrigatório. Eles tocam o mesmo arquivo e são pré-requisito conceitual da consolidação. Posso separá-los num PR próprio se preferir revisar isolado.

## Verificação

- `bundle exec rspec spec/lib/` → **566 examples, 0 failures**
- `bundle exec rspec spec/integration/` → **53 examples, 0 failures**
- **Nenhum snapshot mudou**: o dummy app não exercita as formas recém-cobertas, então a mudança de comportamento é latente lá (não precisou `UPDATE_EXPECTATIONS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
