### PR TITLE
fix(rails): carry per-def `self` in the class_methods sidecar entry

### DIFF
--- a/lib/rbs_infer/extensions/rails/class_methods_implements.rb
+++ b/lib/rbs_infer/extensions/rails/class_methods_implements.rb
@@ -2,6 +2,7 @@
 
 require "prism"
 require_relative "class_methods_expander"
+require_relative "module_self_type_annotator"
 
 module RbsInfer
   module Extensions
@@ -12,26 +13,36 @@ module RbsInfer
       #
       # `ClassMethodsExpander` desugars such a block into a nested
       # `module ClassMethods` for RBS *generation*. For *source checking*, Steep
-      # needs the block body annotated `# @implements <Concern>::ClassMethods` —
-      # the symmetric counterpart. This emits, per file, the resolved target so
-      # Steep's `ModuleSelfTypes` injector can place that annotation, without
-      # Steep ever learning the `class_methods` DSL.
+      # needs the block body annotated `# @implements <Concern>::ClassMethods`
+      # (so the defs attach to ClassMethods) AND, on each method, a `self` that
+      # a `class_methods` method actually runs with: the including class's
+      # singleton intersected with ClassMethods (felixefelip/steep#47). At
+      # runtime self is the includer's singleton, where the includer's
+      # scopes/class methods live; the `& ClassMethods` term keeps calls
+      # between the block's own methods resolving even when the includer's RBS
+      # doesn't `extend ...::ClassMethods`. This emits, per file, both resolved
+      # values so Steep's `ModuleSelfTypes` injector can place the annotations,
+      # without Steep ever learning the `class_methods` DSL.
       #
       # Detection reuses `ClassMethodsExpander.class_methods_block?` so the
       # sidecar and the RBS desugar agree on exactly what a `class_methods`
-      # block is.
+      # block is. The including class is derived by the same rule
+      # `ModuleSelfTypeAnnotator` uses for the concern self-type.
       module ClassMethodsImplements
         CALL = "class_methods"
 
         module_function
 
+        # @param path [String] source path (for the including-class rule)
         # @param module_name [String] the concern's FQN from the AST (e.g.
         #   "Post::Taggable")
         # @param source [String] the file's source
         # @return [Array<Hash>] `[{ "call" => "class_methods", "implements" =>
-        #   "::<FQN>::ClassMethods" }]` when `source` has at least one
-        #   receiverless `class_methods do` block, else `[]`.
-        def blocks_for(module_name:, source:)
+        #   "::<FQN>::ClassMethods"[, "self" => "singleton(::<Includer>) &
+        #   ::<FQN>::ClassMethods"] }]` when `source` has at least one
+        #   receiverless `class_methods do` block, else `[]`. `self` is omitted
+        #   when no including class can be derived (e.g. a top-level concern).
+        def blocks_for(path:, module_name:, source:)
           return [] if module_name.nil? || module_name.empty?
           return [] unless source.include?(CALL)
 
@@ -43,7 +54,12 @@ module RbsInfer
                       .any?
           return [] unless has_block
 
-          [{ "call" => CALL, "implements" => "::#{module_name}::ClassMethods" }]
+          class_methods = "::#{module_name}::ClassMethods"
+          entry = { "call" => CALL, "implements" => class_methods }
+          if (including = ModuleSelfTypeAnnotator.including_class_for(path, module_name))
+            entry["self"] = "singleton(::#{including}) & #{class_methods}"
+          end
+          [entry]
         end
       end
     end

--- a/lib/rbs_infer/extensions/rails/module_self_type_generator.rb
+++ b/lib/rbs_infer/extensions/rails/module_self_type_generator.rb
@@ -70,7 +70,7 @@ module RbsInfer
           return nil unless module_name
 
           entry = ModuleSelfTypeAnnotator.entry_for(path: rel, module_name: module_name, source: source) || {}
-          blocks = ClassMethodsImplements.blocks_for(module_name: module_name, source: source)
+          blocks = ClassMethodsImplements.blocks_for(path: rel, module_name: module_name, source: source)
           entry["blocks"] = blocks unless blocks.empty?
 
           entry.empty? ? nil : entry

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -21,6 +21,7 @@ app/models/post/taggable.rb:
   blocks:
   - call: class_methods
     implements: "::Post::Taggable::ClassMethods"
+    self: singleton(::Post) & ::Post::Taggable::ClassMethods
 app/models/user/displayable.rb:
   anchor: Displayable
   annotations:

--- a/spec/lib/rbs_infer/extensions/rails/class_methods_implements_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/class_methods_implements_spec.rb
@@ -5,11 +5,11 @@ require "rbs_infer"
 require "rbs_infer/extensions/rails/class_methods_implements"
 
 RSpec.describe RbsInfer::Extensions::Rails::ClassMethodsImplements do
-  def blocks(source, module_name: "Post::Taggable")
-    described_class.blocks_for(module_name: module_name, source: source)
+  def blocks(source, path: "app/models/post/taggable.rb", module_name: "Post::Taggable")
+    described_class.blocks_for(path: path, module_name: module_name, source: source)
   end
 
-  it "emits an @implements target for a `class_methods do` block" do
+  it "emits @implements and the includer-singleton self for a `class_methods do` block" do
     result = blocks(<<~RUBY)
       module Post::Taggable
         extend ActiveSupport::Concern
@@ -23,7 +23,27 @@ RSpec.describe RbsInfer::Extensions::Rails::ClassMethodsImplements do
     RUBY
 
     expect(result).to eq(
-      [{ "call" => "class_methods", "implements" => "::Post::Taggable::ClassMethods" }]
+      [{
+        "call" => "class_methods",
+        "implements" => "::Post::Taggable::ClassMethods",
+        "self" => "singleton(::Post) & ::Post::Taggable::ClassMethods"
+      }]
+    )
+  end
+
+  it "omits `self` when no including class can be derived (top-level concern)" do
+    result = blocks(<<~RUBY, path: "app/models/concerns/greetable.rb", module_name: "Greetable")
+      module Greetable
+        extend ActiveSupport::Concern
+
+        class_methods do
+          def banner; "hi"; end
+        end
+      end
+    RUBY
+
+    expect(result).to eq(
+      [{ "call" => "class_methods", "implements" => "::Greetable::ClassMethods" }]
     )
   end
 

--- a/spec/lib/rbs_infer/extensions/rails/module_self_type_generator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/module_self_type_generator_spec.rb
@@ -71,7 +71,11 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeGenerator do
       # self-type annotations and the block @implements coexist in one entry.
       expect(entry["anchor"]).to eq("Taggable")
       expect(entry["blocks"]).to eq(
-        [{ "call" => "class_methods", "implements" => "::Post::Taggable::ClassMethods" }]
+        [{
+          "call" => "class_methods",
+          "implements" => "::Post::Taggable::ClassMethods",
+          "self" => "singleton(::Post) & ::Post::Taggable::ClassMethods"
+        }]
       )
     end
   end


### PR DESCRIPTION
Generator side of the `class_methods do` self-widening fix. Pairs with felixefelip/steep#50 (the injector that places `# @type self:` on each method-def line).

## Problem

A concern's `class_methods do` method that calls one of the **includer's** scopes/class methods still failed:

```ruby
module Card::Entropic
  included do
    scope :due_to_be_postponed, -> { ... }
  end
  class_methods do
    def auto_postpone_all_due
      due_to_be_postponed.find_each { ... }   # Type `::Card::Entropic::ClassMethods` does not have method `due_to_be_postponed`
    end
  end
end
```

`@implements ClassMethods` types each method body's self as a `ClassMethods` instance. But a `class_methods` method runs with the **including class's singleton** as self (that's where the scopes live). A block-level self can't fix this — a method body's self comes from its owner — so Steep needs `# @type self:` on each def (steep#50).

## Change

`ClassMethodsImplements.blocks_for` now also emits a `self` in the `blocks` entry:

```yaml
blocks:
  - call: class_methods
    implements: "::Card::Entropic::ClassMethods"
    self: "singleton(::Card) & ::Card::Entropic::ClassMethods"
```

- `singleton(::<Includer>)` resolves the includer's scopes / class methods.
- `& ::<Concern>::ClassMethods` keeps calls **between the block's own methods** resolving even when the includer's RBS doesn't `extend ...::ClassMethods` (as the dummy's `Post` doesn't).
- The including class is derived by the same rule `ModuleSelfTypeAnnotator` uses for the concern self-type; `self` is omitted when none can be derived (top-level concern).

## Verification

The dummy's `Post::Taggable` `class_methods` block — whose `known_tag?` calls the sibling `default_tag_names` — now genuinely exercises this end-to-end: `make steep` stays **baseline-clean (18 → 18, no diff)** only with the per-def self (without it, `default_tag_names` doesn't resolve from `known_tag?`).

Isolated checks confirm both a scope call and a sibling class-method call resolve, even with an includer that does **not** `extend ...::ClassMethods`.

Unit specs updated for the `self` value and the top-level-concern omission. Full suite: **645 examples, 0 failures**.
