### PR TITLE
fix: union method param types across call-sites (#64)

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -220,10 +220,10 @@ module RbsInfer
     # Inferir tipos de parâmetros de métodos via chamadas intra-classe
     method_param_types = param_type_inferrer.infer_method_param_types(attr_types, parsed_target: @parsed_target)
 
-    # Inferir tipos de parâmetros de métodos via chamadas cross-class.
-    # Une (não sobrescreve) com os tipos intra-classe: um método chamado com
-    # `String` num arquivo e `:Symbol` noutro deve inferir `(String | Symbol)`,
-    # não o primeiro tipo visto (felixefelip/rbs_infer#64).
+    # Infer method param types from cross-class call-sites. Union (don't
+    # overwrite) with the intra-class types: a method called with `String` in
+    # one file and `:Symbol` in another should infer `(String | Symbol)`, not
+    # the first type seen (felixefelip/rbs_infer#64).
     cross_class_param_types = infer_method_param_types_from_callers
     cross_class_param_types.each do |method_name, param_types|
       method_param_types[method_name] ||= {}

--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -745,7 +745,16 @@ module RbsInfer
       target_methods: target_methods,
       steep_bridge: steep_bridge
     )
-    @source_index.files_referencing(@target_class).each { |file| analyzer.analyze(file) }
+    referencing = @source_index.files_referencing(@target_class)
+
+    # A concern's instance methods are called *bare* by includer hosts and by
+    # the host's sibling concerns — files that never name the concern, so the
+    # constant-reference index misses them. For a module target, fold in the
+    # mixin graph and force bare-call matching on those files (#64).
+    reaching = @is_module ? mixin_index.files_reaching(@target_class).to_set : Set.new
+    (referencing.to_set | reaching).each do |file|
+      analyzer.analyze(file, force_bare: reaching.include?(file))
+    end
 
     @extra_caller_sources&.call(analyzer, @target_class, @source_files)
 
@@ -853,6 +862,10 @@ module RbsInfer
     @steep_bridge ||= RbsInfer::Signatures::SteepBridge.new
   end
 
+  def mixin_index
+    @mixin_index ||= RbsInfer::Project::MixinIndex.new(@source_files, parse_cache: @parse_cache)
+  end
+
   # ─── Resolver quais namespaces da classe-alvo são class (não module) ──
 
   def resolve_namespace_classes(class_name = @target_class)
@@ -910,6 +923,7 @@ require_relative "inference/ivar_type_set"
 require_relative "inference/return_type_resolver"
 require_relative "inference/param_type_inferrer"
 require_relative "project/source_index"
+require_relative "project/mixin_index"
 require_relative "signatures/steep_bridge"
 require_relative "project/source_expanders"
 require_relative "project/self_type_annotators"

--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -218,12 +218,21 @@ module RbsInfer
     # Inferir tipos de parâmetros de métodos via chamadas intra-classe
     method_param_types = param_type_inferrer.infer_method_param_types(attr_types, parsed_target: @parsed_target)
 
-    # Inferir tipos de parâmetros de métodos via chamadas cross-class
+    # Inferir tipos de parâmetros de métodos via chamadas cross-class.
+    # Une (não sobrescreve) com os tipos intra-classe: um método chamado com
+    # `String` num arquivo e `:Symbol` noutro deve inferir `(String | Symbol)`,
+    # não o primeiro tipo visto (felixefelip/rbs_infer#64).
     cross_class_param_types = infer_method_param_types_from_callers
     cross_class_param_types.each do |method_name, param_types|
       method_param_types[method_name] ||= {}
       param_types.each do |param_name, type|
-        method_param_types[method_name][param_name] ||= type
+        existing = method_param_types[method_name][param_name]
+        method_param_types[method_name][param_name] =
+          if existing && existing != "untyped"
+            RbsInfer::Inference::TypeMerger.union_types([existing, type])
+          else
+            type
+          end
       end
     end
 

--- a/lib/rbs_infer/inference/caller_file_analyzer.rb
+++ b/lib/rbs_infer/inference/caller_file_analyzer.rb
@@ -13,7 +13,7 @@ module RbsInfer::Inference
       @method_call_usages = Hash.new { |h, k| h[k] = [] }
     end
 
-    def analyze(file)
+    def analyze(file, force_bare: false)
       source = File.read(file)
       result = Prism.parse(source)
       comments = result.comments
@@ -53,8 +53,12 @@ module RbsInfer::Inference
       # Enable bare call matching when the file includes the target module/concern.
       # e.g. PostsController includes FilterConfiguration → configure_filter("posts")
       # is a bare call that would otherwise be invisible to cross-class analysis.
+      #
+      # `force_bare` is set by the caller for files the mixin graph already
+      # proved can reach the target's methods (the host and its sibling
+      # concerns), which never name the concern themselves (#64).
       short_name = @target_class.split("::").last
-      match_bare = source.match?(/\binclude\b.*\b#{Regexp.escape(short_name)}\b/)
+      match_bare = force_bare || source.match?(/\binclude\b.*\b#{Regexp.escape(short_name)}\b/)
 
       # After-validation callback narrowing: inside e.g. an `after_create`
       # handler, `self` is the validated record, so `Foo.new(self)` should

--- a/lib/rbs_infer/inference/intra_class_call_analyzer.rb
+++ b/lib/rbs_infer/inference/intra_class_call_analyzer.rb
@@ -7,13 +7,11 @@ module RbsInfer::Inference
   #    `Telefone.new(ddd:, numero:)` → infere `ddd: String, numero: String`
   #    a partir da assinatura de Telefone#initialize
   class IntraClassCallAnalyzer < Prism::Visitor
-    # method_name → { param_name → type }
-    attr_reader :inferred_param_types
-
     def initialize(attr_types: {}, method_type_resolver: nil, method_positional_params: {}, steep_bridge: nil, source_code: nil)
       @attr_types = attr_types
       @method_type_resolver = method_type_resolver
-      @inferred_param_types = Hash.new { |h, k| h[k] = {} }
+      # method_name → param_name → [type, ...] candidatos de cada call-site
+      @param_type_candidates = Hash.new { |h, k| h[k] = Hash.new { |h2, k2| h2[k2] = [] } }
       @local_var_types = {}
       @current_method_name = nil
       @current_param_names = Set.new
@@ -58,8 +56,7 @@ module RbsInfer::Inference
         args = extract_keyword_arg_types(node)
         args.each do |param_name, type|
           next if type == "untyped"
-          existing = @inferred_param_types[method_name][param_name]
-          @inferred_param_types[method_name][param_name] = type unless existing
+          @param_type_candidates[method_name][param_name] << type
         end
 
         # Positional args: mapear por posição usando os nomes dos parâmetros do método-alvo
@@ -71,8 +68,7 @@ module RbsInfer::Inference
             next unless param_name
             type = resolve_value_type(arg)
             next if type == "untyped"
-            existing = @inferred_param_types[method_name][param_name]
-            @inferred_param_types[method_name][param_name] = type unless existing
+            @param_type_candidates[method_name][param_name] << type
           end
         end
       end
@@ -83,6 +79,18 @@ module RbsInfer::Inference
       end
 
       super
+    end
+
+    # method_name → { param_name → type }, unindo os candidatos de cada
+    # call-site num único tipo (`String` + `:Symbol` → `(String | Symbol)`).
+    def inferred_param_types
+      result = Hash.new { |h, k| h[k] = {} }
+      @param_type_candidates.each do |method_name, params|
+        params.each do |param_name, types|
+          result[method_name][param_name] = TypeMerger.union_types(types)
+        end
+      end
+      result
     end
 
     private
@@ -124,8 +132,7 @@ module RbsInfer::Inference
           expected_type = class_types[key]
           next unless expected_type && expected_type != "untyped"
 
-          existing = @inferred_param_types[@current_method_name][value_param]
-          @inferred_param_types[@current_method_name][value_param] = expected_type unless existing
+          @param_type_candidates[@current_method_name][value_param] << expected_type
         end
       end
     end

--- a/lib/rbs_infer/inference/intra_class_call_analyzer.rb
+++ b/lib/rbs_infer/inference/intra_class_call_analyzer.rb
@@ -10,7 +10,7 @@ module RbsInfer::Inference
     def initialize(attr_types: {}, method_type_resolver: nil, method_positional_params: {}, steep_bridge: nil, source_code: nil)
       @attr_types = attr_types
       @method_type_resolver = method_type_resolver
-      # method_name → param_name → [type, ...] candidatos de cada call-site
+      # method_name → param_name → [type, ...] candidates from each call-site
       @param_type_candidates = Hash.new { |h, k| h[k] = Hash.new { |h2, k2| h2[k2] = [] } }
       @local_var_types = {}
       @current_method_name = nil
@@ -81,8 +81,8 @@ module RbsInfer::Inference
       super
     end
 
-    # method_name → { param_name → type }, unindo os candidatos de cada
-    # call-site num único tipo (`String` + `:Symbol` → `(String | Symbol)`).
+    # method_name → { param_name → type }, unioning each call-site's
+    # candidates into a single type (`String` + `:Symbol` → `(String | Symbol)`).
     def inferred_param_types
       result = Hash.new { |h, k| h[k] = {} }
       @param_type_candidates.each do |method_name, params|

--- a/lib/rbs_infer/inference/type_merger.rb
+++ b/lib/rbs_infer/inference/type_merger.rb
@@ -19,6 +19,42 @@ module RbsInfer::Inference
 
     # ─── Unificar tipos de múltiplos call-sites ────────────────────────
 
+    # Une uma lista de tipos (de call-sites distintos) numa única string RBS.
+    # `untyped` é descartado quando há ao menos um tipo resolvido. Uniões já
+    # existentes (`(String | Symbol)`) são achatadas via parser RBS, de modo
+    # que combinar resultados parciais (intra-classe + cross-class) seja
+    # associativo e idempotente — sem aninhar parênteses nem duplicar membros.
+    def self.union_types(types)
+      flat = types.flat_map { |t| flatten_union(t) }
+
+      # Preferir tipos resolvidos sobre untyped
+      resolved = flat.reject { |t| t == "untyped" }
+      resolved = flat if resolved.empty?
+
+      # Deduplicar pela forma normalizada (sem `::` à esquerda), preservando
+      # a forma original da 1ª ocorrência — um único tipo é emitido verbatim,
+      # mantendo nomes absolutos (`::MyApp::Entity`) intactos.
+      seen = {}
+      unique = []
+      resolved.each do |type|
+        key = type.sub(/\A::/, "")
+        next if seen[key]
+        seen[key] = true
+        unique << type
+      end
+      unique.size == 1 ? unique.first : "(#{unique.join(" | ")})"
+    end
+
+    # Achata um tipo num conjunto de membros de união de nível superior.
+    # `(String | Symbol)` → `["String", "Symbol"]`; tipos não-união (incl.
+    # genéricos como `Array[A | B]`) ficam intactos.
+    def self.flatten_union(type_str)
+      parsed = RBS::Parser.parse_type(type_str)
+      parsed.is_a?(RBS::Types::Union) ? parsed.types.map(&:to_s) : [type_str]
+    rescue RBS::ParsingError, RBS::BaseError
+      [type_str]
+    end
+
     def merge_argument_types(usages)
       all_types = Hash.new { |h, k| h[k] = [] }
 
@@ -30,13 +66,10 @@ module RbsInfer::Inference
 
       merged = {}
       all_types.each do |arg_name, types|
-        # Preferir tipos resolvidos sobre untyped
-        resolved = types.reject { |t| t == "untyped" }
-        resolved = types if resolved.empty?
-
-        # Normalizar :: prefix e deduplicar
-        unique = resolved.map { |t| t.sub(/\A::/, "") }.uniq
-        merged[arg_name] = unique.size == 1 ? unique.first : "(#{unique.join(" | ")})"
+        # Convenção cross-class: emitir nomes sem o prefixo `::` absoluto,
+        # de modo que `::Shared::Cpf` e `Shared::Cpf` colapsem num só.
+        normalized = types.map { |t| t.sub(/\A::/, "") }
+        merged[arg_name] = self.class.union_types(normalized)
       end
 
       merged

--- a/lib/rbs_infer/inference/type_merger.rb
+++ b/lib/rbs_infer/inference/type_merger.rb
@@ -19,21 +19,21 @@ module RbsInfer::Inference
 
     # ─── Unificar tipos de múltiplos call-sites ────────────────────────
 
-    # Une uma lista de tipos (de call-sites distintos) numa única string RBS.
-    # `untyped` é descartado quando há ao menos um tipo resolvido. Uniões já
-    # existentes (`(String | Symbol)`) são achatadas via parser RBS, de modo
-    # que combinar resultados parciais (intra-classe + cross-class) seja
-    # associativo e idempotente — sem aninhar parênteses nem duplicar membros.
+    # Unions a list of types (from distinct call-sites) into a single RBS
+    # string. `untyped` is dropped when at least one resolved type exists.
+    # Pre-existing unions (`(String | Symbol)`) are flattened via the RBS
+    # parser, so combining partial results (intra-class + cross-class) is
+    # associative and idempotent — no nested parens, no duplicate members.
     def self.union_types(types)
       flat = types.flat_map { |t| flatten_union(t) }
 
-      # Preferir tipos resolvidos sobre untyped
+      # Prefer resolved types over untyped
       resolved = flat.reject { |t| t == "untyped" }
       resolved = flat if resolved.empty?
 
-      # Deduplicar pela forma normalizada (sem `::` à esquerda), preservando
-      # a forma original da 1ª ocorrência — um único tipo é emitido verbatim,
-      # mantendo nomes absolutos (`::MyApp::Entity`) intactos.
+      # Dedup by the normalized form (no leading `::`), keeping the original
+      # form of the first occurrence — a single type is emitted verbatim, so
+      # absolute names (`::MyApp::Entity`) stay intact.
       seen = {}
       unique = []
       resolved.each do |type|
@@ -45,9 +45,9 @@ module RbsInfer::Inference
       unique.size == 1 ? unique.first : "(#{unique.join(" | ")})"
     end
 
-    # Achata um tipo num conjunto de membros de união de nível superior.
-    # `(String | Symbol)` → `["String", "Symbol"]`; tipos não-união (incl.
-    # genéricos como `Array[A | B]`) ficam intactos.
+    # Flattens a type into its set of top-level union members.
+    # `(String | Symbol)` → `["String", "Symbol"]`; non-union types (incl.
+    # generics like `Array[A | B]`) are left intact.
     def self.flatten_union(type_str)
       parsed = RBS::Parser.parse_type(type_str)
       parsed.is_a?(RBS::Types::Union) ? parsed.types.map(&:to_s) : [type_str]
@@ -66,8 +66,8 @@ module RbsInfer::Inference
 
       merged = {}
       all_types.each do |arg_name, types|
-        # Convenção cross-class: emitir nomes sem o prefixo `::` absoluto,
-        # de modo que `::Shared::Cpf` e `Shared::Cpf` colapsem num só.
+        # Cross-class convention: emit names without the absolute `::` prefix,
+        # so `::Shared::Cpf` and `Shared::Cpf` collapse into one.
         normalized = types.map { |t| t.sub(/\A::/, "") }
         merged[arg_name] = self.class.union_types(normalized)
       end

--- a/lib/rbs_infer/project/mixin_index.rb
+++ b/lib/rbs_infer/project/mixin_index.rb
@@ -1,0 +1,80 @@
+module RbsInfer::Project
+  # Resolve, para um módulo-alvo (concern), os arquivos cujas chamadas
+  # *peladas* (sem receiver) podem alcançar os métodos de instância do módulo.
+  #
+  # Os métodos de um concern são mixados no host e chamados sem receiver — não
+  # só no arquivo do próprio host, mas também nos *outros* concerns do host:
+  # módulos irmãos compartilham o `self` do host, então um `track_event :x`
+  # pelado em `Card::Statuses` alcança `Eventable#track_event` porque `Card`
+  # inclui ambos. Esses arquivos irmãos nunca nomeiam o concern, então o índice
+  # por referência de constante (`SourceIndex`) não os encontra.
+  #
+  # Este índice parseia cada arquivo uma vez registrando, por arquivo: a
+  # classe/módulo que ele define e os short names que ele `include`/`prepend`.
+  # A partir disso responde `files_reaching(module_name)` = arquivos host (que
+  # incluem o módulo) ∪ os arquivos de cada módulo irmão que esses hosts também
+  # incluem.
+  class MixinIndex
+    def initialize(source_files, parse_cache: nil)
+      @parse_cache = parse_cache || ParseCache.new
+      @included_shorts = {}                            # file → Set[short name]
+      @files_defining = Hash.new { |h, k| h[k] = [] }  # short name → [file]
+      build(source_files)
+    end
+
+    # Arquivos cujas chamadas peladas podem alcançar métodos de instância de
+    # `module_name` (host + concerns irmãos do host).
+    def files_reaching(module_name)
+      short = module_name.split("::").last
+      result = Set.new
+      host_files(short).each do |host|
+        result << host
+        @included_shorts.fetch(host, EMPTY).each do |sibling_short|
+          next if sibling_short == short
+          @files_defining[sibling_short].each { |f| result << f }
+        end
+      end
+      result.to_a
+    end
+
+    private
+
+    EMPTY = Set.new.freeze
+    private_constant :EMPTY
+
+    # Arquivos cuja classe/módulo inclui `short`.
+    def host_files(short)
+      @included_shorts.filter_map { |file, shorts| file if shorts.include?(short) }
+    end
+
+    def build(source_files)
+      source_files.each do |file|
+        entry = @parse_cache.get(file)
+        next unless entry
+
+        extractor = RbsInfer::AST::ClassNameExtractor.new(file_path: file)
+        entry.result.value.accept(extractor)
+        class_name = extractor.class_name
+        next unless class_name
+
+        @files_defining[class_name.split("::").last] << file
+        @included_shorts[file] = include_short_names(entry.result.value)
+      end
+    end
+
+    # Short names dos argumentos de `include A, B::C` / `prepend A`.
+    def include_short_names(root)
+      shorts = Set.new
+      RbsInfer::Analyzer.find_all_nodes(root) do |n|
+        n.is_a?(Prism::CallNode) && n.receiver.nil? &&
+          (n.name == :include || n.name == :prepend) && n.arguments
+      end.each do |call|
+        call.arguments.arguments.each do |arg|
+          name = RbsInfer::Analyzer.extract_constant_path(arg)
+          shorts << name.split("::").last if name
+        end
+      end
+      shorts
+    end
+  end
+end

--- a/lib/rbs_infer/project/mixin_index.rb
+++ b/lib/rbs_infer/project/mixin_index.rb
@@ -1,19 +1,18 @@
 module RbsInfer::Project
-  # Resolve, para um módulo-alvo (concern), os arquivos cujas chamadas
-  # *peladas* (sem receiver) podem alcançar os métodos de instância do módulo.
+  # For a target module (concern), resolves the files whose *bare* calls (no
+  # receiver) can reach the module's instance methods.
   #
-  # Os métodos de um concern são mixados no host e chamados sem receiver — não
-  # só no arquivo do próprio host, mas também nos *outros* concerns do host:
-  # módulos irmãos compartilham o `self` do host, então um `track_event :x`
-  # pelado em `Card::Statuses` alcança `Eventable#track_event` porque `Card`
-  # inclui ambos. Esses arquivos irmãos nunca nomeiam o concern, então o índice
-  # por referência de constante (`SourceIndex`) não os encontra.
+  # A concern's methods are mixed into the host and called without a receiver —
+  # not only in the host's own file, but in the host's *other* concerns too:
+  # sibling modules share the host's `self`, so a bare `track_event :x` in
+  # `Card::Statuses` reaches `Eventable#track_event` because `Card` includes
+  # both. Those sibling files never name the concern, so the constant-reference
+  # index (`SourceIndex`) doesn't find them.
   #
-  # Este índice parseia cada arquivo uma vez registrando, por arquivo: a
-  # classe/módulo que ele define e os short names que ele `include`/`prepend`.
-  # A partir disso responde `files_reaching(module_name)` = arquivos host (que
-  # incluem o módulo) ∪ os arquivos de cada módulo irmão que esses hosts também
-  # incluem.
+  # This index parses each file once, recording per file: the class/module it
+  # defines and the short names it `include`s/`prepend`s. From that it answers
+  # `files_reaching(module_name)` = host files (that include the module) ∪ the
+  # files of every sibling module those hosts also include.
   class MixinIndex
     def initialize(source_files, parse_cache: nil)
       @parse_cache = parse_cache || ParseCache.new
@@ -22,8 +21,8 @@ module RbsInfer::Project
       build(source_files)
     end
 
-    # Arquivos cujas chamadas peladas podem alcançar métodos de instância de
-    # `module_name` (host + concerns irmãos do host).
+    # Files whose bare calls can reach instance methods of `module_name`
+    # (the host + the host's sibling concerns).
     def files_reaching(module_name)
       short = module_name.split("::").last
       result = Set.new
@@ -42,7 +41,7 @@ module RbsInfer::Project
     EMPTY = Set.new.freeze
     private_constant :EMPTY
 
-    # Arquivos cuja classe/módulo inclui `short`.
+    # Files whose class/module includes `short`.
     def host_files(short)
       @included_shorts.filter_map { |file, shorts| file if shorts.include?(short) }
     end
@@ -62,7 +61,7 @@ module RbsInfer::Project
       end
     end
 
-    # Short names dos argumentos de `include A, B::C` / `prepend A`.
+    # Short names from the arguments of `include A, B::C` / `prepend A`.
     def include_short_names(root)
       shorts = Set.new
       RbsInfer::Analyzer.find_all_nodes(root) do |n|

--- a/spec/dummy/app/models/eventable.rb
+++ b/spec/dummy/app/models/eventable.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-# felixefelip/rbs_infer#64: `track_event` é chamado *pelado* a partir de
-# concerns IRMÃOS do host (`Widget::Publishable`/`Widget::Closeable`), que
-# nunca nomeiam `Eventable` — com `String` num call-site e `Symbol` noutro.
-# `action` deve então inferir `(String | Symbol)`, não apenas o primeiro tipo.
+# felixefelip/rbs_infer#64: `track_event` is called *bare* from the host's
+# SIBLING concerns (`Widget::Publishable`/`Widget::Closeable`), which never
+# name `Eventable` — with `String` at one call-site and `Symbol` at another.
+# `action` must then infer `(String | Symbol)`, not just the first type.
 module Eventable
   extend ActiveSupport::Concern
 

--- a/spec/dummy/app/models/eventable.rb
+++ b/spec/dummy/app/models/eventable.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# felixefelip/rbs_infer#64: `track_event` é chamado *pelado* a partir de
+# concerns IRMÃOS do host (`Widget::Publishable`/`Widget::Closeable`), que
+# nunca nomeiam `Eventable` — com `String` num call-site e `Symbol` noutro.
+# `action` deve então inferir `(String | Symbol)`, não apenas o primeiro tipo.
+module Eventable
+  extend ActiveSupport::Concern
+
+  def track_event(action, **particulars)
+    { action: action, particulars: particulars }
+  end
+end

--- a/spec/dummy/app/models/widget.rb
+++ b/spec/dummy/app/models/widget.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-# Host plain-Ruby (não-AR) que mixa o concern Eventable e os concerns irmãos
-# que o chamam pelado. Espelha o padrão do Fizzy (Card include Eventable,
-# Statuses, Assignable, ...).
+# Plain-Ruby (non-AR) host that mixes in the Eventable concern and the sibling
+# concerns that call it bare. Mirrors the Fizzy pattern (Card includes
+# Eventable, Statuses, Assignable, ...).
 class Widget
   include Eventable
   include Widget::Publishable
   include Widget::Closeable
 
-  # Host call-site, com `String`.
+  # Host call-site, with `String`.
   def rename
     track_event("renamed")
   end

--- a/spec/dummy/app/models/widget.rb
+++ b/spec/dummy/app/models/widget.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Host plain-Ruby (não-AR) que mixa o concern Eventable e os concerns irmãos
+# que o chamam pelado. Espelha o padrão do Fizzy (Card include Eventable,
+# Statuses, Assignable, ...).
+class Widget
+  include Eventable
+  include Widget::Publishable
+  include Widget::Closeable
+
+  # Host call-site, com `String`.
+  def rename
+    track_event("renamed")
+  end
+end

--- a/spec/dummy/app/models/widget/closeable.rb
+++ b/spec/dummy/app/models/widget/closeable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Outro concern irmão; também chama `track_event` pelado com um `Symbol`.
+# Another sibling concern; also calls `track_event` bare with a `Symbol`.
 module Widget::Closeable
   extend ActiveSupport::Concern
 

--- a/spec/dummy/app/models/widget/closeable.rb
+++ b/spec/dummy/app/models/widget/closeable.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Outro concern irmão; também chama `track_event` pelado com um `Symbol`.
+module Widget::Closeable
+  extend ActiveSupport::Concern
+
+  def close
+    track_event(:closed)
+  end
+end

--- a/spec/dummy/app/models/widget/publishable.rb
+++ b/spec/dummy/app/models/widget/publishable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Concern irmão de Eventable no host Widget; chama `track_event` pelado com
+# um `Symbol`, sem nunca nomear `Eventable`.
+module Widget::Publishable
+  extend ActiveSupport::Concern
+
+  def publish
+    track_event(:published)
+  end
+end

--- a/spec/dummy/app/models/widget/publishable.rb
+++ b/spec/dummy/app/models/widget/publishable.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Concern irmão de Eventable no host Widget; chama `track_event` pelado com
-# um `Symbol`, sem nunca nomear `Eventable`.
+# Sibling concern of Eventable in the Widget host; calls `track_event` bare
+# with a `Symbol`, without ever naming `Eventable`.
 module Widget::Publishable
   extend ActiveSupport::Concern
 

--- a/spec/dummy/app/services/event_reporter.rb
+++ b/spec/dummy/app/services/event_reporter.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Call-site cross-class de `EventTracker#track_event`, passando um `Symbol`.
+# Combinado com o call-site `String` de `EventTracker`, força a inferência
+# `action: (String | Symbol)` (felixefelip/rbs_infer#64).
+class EventReporter
+  def report
+    EventTracker.new.track_event(action: :reported)
+  end
+end

--- a/spec/dummy/app/services/event_reporter.rb
+++ b/spec/dummy/app/services/event_reporter.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# Call-site cross-class de `EventTracker#track_event`, passando um `Symbol`.
-# Combinado com o call-site `String` de `EventTracker`, força a inferência
-# `action: (String | Symbol)` (felixefelip/rbs_infer#64).
+# Cross-class call-site of `EventTracker#track_event`, passing a `Symbol`.
+# Combined with `EventTracker`'s own `String` call-site, this forces the
+# inference `action: (String | Symbol)` (felixefelip/rbs_infer#64).
 class EventReporter
   def report
     EventTracker.new.track_event(action: :reported)

--- a/spec/dummy/app/services/event_tracker.rb
+++ b/spec/dummy/app/services/event_tracker.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Reproduz felixefelip/rbs_infer#64: `track_event` é chamado com `String` em
+# alguns call-sites (aqui, intra-classe) e com `Symbol` em outros (ver
+# `EventReporter`), então `action` deve inferir `(String | Symbol)` — não
+# apenas o primeiro tipo visto.
+class EventTracker
+  def track_event(action:)
+    { action: action }
+  end
+
+  # Call-site intra-classe com `String` literal.
+  def track_created
+    track_event(action: "created")
+  end
+end

--- a/spec/dummy/app/services/event_tracker.rb
+++ b/spec/dummy/app/services/event_tracker.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-# Reproduz felixefelip/rbs_infer#64: `track_event` é chamado com `String` em
-# alguns call-sites (aqui, intra-classe) e com `Symbol` em outros (ver
-# `EventReporter`), então `action` deve inferir `(String | Symbol)` — não
-# apenas o primeiro tipo visto.
+# Reproduces felixefelip/rbs_infer#64: `track_event` is called with `String` at
+# some call-sites (here, intra-class) and with `Symbol` at others (see
+# `EventReporter`), so `action` must infer `(String | Symbol)` — not just the
+# first type seen.
 class EventTracker
   def track_event(action:)
     { action: action }
   end
 
-  # Call-site intra-classe com `String` literal.
+  # Intra-class call-site with a `String` literal.
   def track_created
     track_event(action: "created")
   end

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -32,6 +32,16 @@ app/models/user/recoverable.rb:
   annotations:
   - "# @type self: singleton(User) & singleton(User::Recoverable)"
   - "# @type instance: User & User::Recoverable"
+app/models/widget/closeable.rb:
+  anchor: Closeable
+  annotations:
+  - "# @type self: singleton(Widget) & singleton(Widget::Closeable)"
+  - "# @type instance: Widget & Widget::Closeable"
+app/models/widget/publishable.rb:
+  anchor: Publishable
+  annotations:
+  - "# @type self: singleton(Widget) & singleton(Widget::Publishable)"
+  - "# @type instance: Widget & Widget::Publishable"
 app/helpers/application_helper.rb:
   anchor: ApplicationHelper
   annotations:

--- a/spec/dummy/sig/rbs_infer/app/helpers/posts_helper.rbs
+++ b/spec/dummy/sig/rbs_infer/app/helpers/posts_helper.rbs
@@ -1,6 +1,6 @@
 module PostsHelper
-  def post_status_badge: ((Post & Post::Validated | Post | (Post & Post::Validated)) post) -> String
-  def post_summary: ((Post & Post::Validated | Post | (Post & Post::Validated)) post, ?Integer length) -> String
+  def post_status_badge: ((Post & Post::Validated | Post) post) -> String
+  def post_summary: ((Post & Post::Validated | Post) post, ?Integer length) -> String
   def post_weights: (?Array[Integer] weights, ?Integer length, ?Palette klass) -> String
   def post_index_marker: (Post & Post::Validated post) -> String
 end

--- a/spec/dummy/sig/rbs_infer/app/models/eventable.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/eventable.rbs
@@ -1,0 +1,4 @@
+module Eventable
+  extend ActiveSupport::Concern
+  def track_event: ((Symbol | String) action, **untyped) -> { action: (Symbol | String), particulars: untyped }
+end

--- a/spec/dummy/sig/rbs_infer/app/models/widget.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/widget.rbs
@@ -1,0 +1,6 @@
+class Widget
+  include Eventable
+  include ::Widget::Publishable
+  include ::Widget::Closeable
+  def rename: () -> { action: Symbol | String, particulars: untyped }
+end

--- a/spec/dummy/sig/rbs_infer/app/models/widget/closeable.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/widget/closeable.rbs
@@ -1,0 +1,6 @@
+class Widget
+  module Closeable
+    extend ActiveSupport::Concern
+    def close: () -> { action: Symbol | String, particulars: untyped }
+  end
+end

--- a/spec/dummy/sig/rbs_infer/app/models/widget/publishable.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/widget/publishable.rbs
@@ -1,0 +1,6 @@
+class Widget
+  module Publishable
+    extend ActiveSupport::Concern
+    def publish: () -> { action: Symbol | String, particulars: untyped }
+  end
+end

--- a/spec/dummy/sig/rbs_infer/app/services/event_reporter.rbs
+++ b/spec/dummy/sig/rbs_infer/app/services/event_reporter.rbs
@@ -1,0 +1,3 @@
+class EventReporter
+  def report: () -> { action: String | Symbol }
+end

--- a/spec/dummy/sig/rbs_infer/app/services/event_tracker.rbs
+++ b/spec/dummy/sig/rbs_infer/app/services/event_tracker.rbs
@@ -1,0 +1,4 @@
+class EventTracker
+  def track_event: (action: (String | Symbol)) -> { action: (String | Symbol) }
+  def track_created: () -> { action: untyped }
+end

--- a/spec/expectations/helpers/posts_helper.rbs
+++ b/spec/expectations/helpers/posts_helper.rbs
@@ -1,6 +1,6 @@
 module PostsHelper
-  def post_status_badge: ((Post & Post::Validated | Post | (Post & Post::Validated)) post) -> String
-  def post_summary: ((Post & Post::Validated | Post | (Post & Post::Validated)) post, ?Integer length) -> String
+  def post_status_badge: ((Post & Post::Validated | Post) post) -> String
+  def post_summary: ((Post & Post::Validated | Post) post, ?Integer length) -> String
   def post_weights: (?Array[Integer] weights, ?Integer length, ?Palette klass) -> String
   def post_index_marker: (Post & Post::Validated post) -> String
 end

--- a/spec/expectations/models/eventable.rbs
+++ b/spec/expectations/models/eventable.rbs
@@ -1,0 +1,4 @@
+module Eventable
+  extend ActiveSupport::Concern
+  def track_event: ((Symbol | String) action, **untyped) -> { action: (Symbol | String), particulars: untyped }
+end

--- a/spec/expectations/services/event_tracker.rbs
+++ b/spec/expectations/services/event_tracker.rbs
@@ -1,0 +1,4 @@
+class EventTracker
+  def track_event: (action: (String | Symbol)) -> { action: (String | Symbol) }
+  def track_created: () -> { action: untyped }
+end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -258,6 +258,13 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     assert_snapshot("services/event_tracker", target_class: "EventTracker", target_file: "app/services/event_tracker.rb")
   end
 
+  # felixefelip/rbs_infer#64: `track_event` (num concern) é chamado *pelado* a
+  # partir de concerns irmãos do host (Widget::Publishable/Closeable, que não
+  # nomeiam Eventable), com `String` e `Symbol` → `action: (String | Symbol)`.
+  it "Eventable concern unions bare-call param types from sibling concerns" do
+    assert_snapshot("models/eventable", target_class: "Eventable", target_file: "app/models/eventable.rb")
+  end
+
   it "Post::Taggable concern matches expected RBS" do
     assert_snapshot("models/post/taggable", target_class: "Post::Taggable", target_file: "app/models/post/taggable.rb")
   end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -252,15 +252,15 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     assert_snapshot("services/parse_xml", target_class: "ParseXml", target_file: "app/services/parse_xml.rb")
   end
 
-  # felixefelip/rbs_infer#64: `action` é chamado com `String` (intra-classe)
-  # e `Symbol` (via EventReporter), então deve inferir `(String | Symbol)`.
+  # felixefelip/rbs_infer#64: `action` is called with `String` (intra-class)
+  # and `Symbol` (via EventReporter), so it should infer `(String | Symbol)`.
   it "EventTracker service unions param types across call-sites" do
     assert_snapshot("services/event_tracker", target_class: "EventTracker", target_file: "app/services/event_tracker.rb")
   end
 
-  # felixefelip/rbs_infer#64: `track_event` (num concern) é chamado *pelado* a
-  # partir de concerns irmãos do host (Widget::Publishable/Closeable, que não
-  # nomeiam Eventable), com `String` e `Symbol` → `action: (String | Symbol)`.
+  # felixefelip/rbs_infer#64: `track_event` (in a concern) is called *bare*
+  # from the host's sibling concerns (Widget::Publishable/Closeable, which
+  # don't name Eventable), with `String` and `Symbol` → `action: (String | Symbol)`.
   it "Eventable concern unions bare-call param types from sibling concerns" do
     assert_snapshot("models/eventable", target_class: "Eventable", target_file: "app/models/eventable.rb")
   end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -252,6 +252,12 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     assert_snapshot("services/parse_xml", target_class: "ParseXml", target_file: "app/services/parse_xml.rb")
   end
 
+  # felixefelip/rbs_infer#64: `action` é chamado com `String` (intra-classe)
+  # e `Symbol` (via EventReporter), então deve inferir `(String | Symbol)`.
+  it "EventTracker service unions param types across call-sites" do
+    assert_snapshot("services/event_tracker", target_class: "EventTracker", target_file: "app/services/event_tracker.rb")
+  end
+
   it "Post::Taggable concern matches expected RBS" do
     assert_snapshot("models/post/taggable", target_class: "Post::Taggable", target_file: "app/models/post/taggable.rb")
   end

--- a/spec/lib/rbs_infer/inference/intra_class_call_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/inference/intra_class_call_analyzer_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe RbsInfer::Inference::IntraClassCallAnalyzer do
     expect(visitor.inferred_param_types["publicar"]["aluno"]).to eq("Entity")
   end
 
-  it "une tipos de kwargs de call-sites distintos (felixefelip/rbs_infer#64)" do
+  it "unions kwarg types from distinct call-sites (felixefelip/rbs_infer#64)" do
     source = <<~RUBY
       class Foo
         def track_event(action:)

--- a/spec/lib/rbs_infer/inference/intra_class_call_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/inference/intra_class_call_analyzer_spec.rb
@@ -26,6 +26,26 @@ RSpec.describe RbsInfer::Inference::IntraClassCallAnalyzer do
     expect(visitor.inferred_param_types["publicar"]["aluno"]).to eq("Entity")
   end
 
+  it "une tipos de kwargs de call-sites distintos (felixefelip/rbs_infer#64)" do
+    source = <<~RUBY
+      class Foo
+        def track_event(action:)
+        end
+
+        def track_created
+          track_event(action: "created")
+        end
+
+        def track_updated
+          track_event(action: :updated)
+        end
+      end
+    RUBY
+
+    visitor = analyze(source)
+    expect(visitor.inferred_param_types["track_event"]["action"]).to eq("(String | Symbol)")
+  end
+
   it "infere tipo via ImplicitNode (shorthand keyword: publicar(aluno:))" do
     source = <<~RUBY
       class Foo

--- a/spec/lib/rbs_infer/inference/type_merger_spec.rb
+++ b/spec/lib/rbs_infer/inference/type_merger_spec.rb
@@ -36,26 +36,26 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
   end
 
   describe ".union_types" do
-    it "une tipos distintos preservando a forma original" do
+    it "unions distinct types preserving the original form" do
       expect(described_class.union_types(["String", "::MyApp::Entity"]))
         .to eq("(String | ::MyApp::Entity)")
     end
 
-    it "emite um único tipo verbatim (mantém `::` absoluto)" do
+    it "emits a single type verbatim (keeps the absolute `::`)" do
       expect(described_class.union_types(["::MyApp::Entity"])).to eq("::MyApp::Entity")
     end
 
-    it "achata uniões já existentes em vez de aninhar parênteses" do
+    it "flattens pre-existing unions instead of nesting parens" do
       expect(described_class.union_types(["(String | Symbol)", "Symbol"]))
         .to eq("(String | Symbol)")
     end
 
-    it "não achata `|` aninhado dentro de genéricos" do
+    it "does not flatten a `|` nested inside generics" do
       expect(described_class.union_types(["Array[String | Symbol]"]))
         .to eq("Array[String | Symbol]")
     end
 
-    it "descarta untyped quando há ao menos um tipo resolvido" do
+    it "drops untyped when at least one resolved type exists" do
       expect(described_class.union_types(["untyped", "String"])).to eq("String")
     end
   end

--- a/spec/lib/rbs_infer/inference/type_merger_spec.rb
+++ b/spec/lib/rbs_infer/inference/type_merger_spec.rb
@@ -35,6 +35,31 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
     expect(result["cpf"]).to eq("Shared::Cpf")
   end
 
+  describe ".union_types" do
+    it "une tipos distintos preservando a forma original" do
+      expect(described_class.union_types(["String", "::MyApp::Entity"]))
+        .to eq("(String | ::MyApp::Entity)")
+    end
+
+    it "emite um único tipo verbatim (mantém `::` absoluto)" do
+      expect(described_class.union_types(["::MyApp::Entity"])).to eq("::MyApp::Entity")
+    end
+
+    it "achata uniões já existentes em vez de aninhar parênteses" do
+      expect(described_class.union_types(["(String | Symbol)", "Symbol"]))
+        .to eq("(String | Symbol)")
+    end
+
+    it "não achata `|` aninhado dentro de genéricos" do
+      expect(described_class.union_types(["Array[String | Symbol]"]))
+        .to eq("Array[String | Symbol]")
+    end
+
+    it "descarta untyped quando há ao menos um tipo resolvido" do
+      expect(described_class.union_types(["untyped", "String"])).to eq("String")
+    end
+  end
+
   describe "#resolve_method_return_types_from_attrs" do
     it "não corrompe assinatura de método com bloco ao resolver return type" do
       source = <<~RUBY

--- a/spec/lib/rbs_infer/project/mixin_index_spec.rb
+++ b/spec/lib/rbs_infer/project/mixin_index_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RbsInfer::Project::MixinIndex do
     path
   end
 
-  it "alcança o host e os concerns irmãos do módulo-alvo" do
+  it "reaches the host and the target module's sibling concerns" do
     eventable = write_file("eventable.rb", <<~RUBY)
       module Eventable
         def track_event(action) = nil
@@ -43,12 +43,12 @@ RSpec.describe RbsInfer::Project::MixinIndex do
 
     index = described_class.new([eventable, host, publishable, closeable])
 
-    # host + ambos os irmãos (que nunca nomeiam Eventable)
+    # host + both siblings (which never name Eventable)
     expect(index.files_reaching("Eventable"))
       .to contain_exactly(host, publishable, closeable)
   end
 
-  it "resolve includes multi-linha e com namespace" do
+  it "resolves multi-line and namespaced includes" do
     host = write_file("card.rb", <<~RUBY)
       class Card
         include Accessible, Eventable,
@@ -65,7 +65,7 @@ RSpec.describe RbsInfer::Project::MixinIndex do
       .to contain_exactly(host, statuses, accessible)
   end
 
-  it "retorna vazio para um módulo que ninguém inclui" do
+  it "returns empty for a module no one includes" do
     lonely = write_file("lonely.rb", "module Lonely\nend\n")
 
     index = described_class.new([lonely])

--- a/spec/lib/rbs_infer/project/mixin_index_spec.rb
+++ b/spec/lib/rbs_infer/project/mixin_index_spec.rb
@@ -1,0 +1,75 @@
+require "spec_helper"
+require "rbs_infer"
+require "tmpdir"
+
+RSpec.describe RbsInfer::Project::MixinIndex do
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @dir = dir
+      example.run
+    end
+  end
+
+  def write_file(name, content)
+    path = File.join(@dir, name)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+    path
+  end
+
+  it "alcança o host e os concerns irmãos do módulo-alvo" do
+    eventable = write_file("eventable.rb", <<~RUBY)
+      module Eventable
+        def track_event(action) = nil
+      end
+    RUBY
+    host = write_file("widget.rb", <<~RUBY)
+      class Widget
+        include Eventable
+        include Widget::Publishable
+        include Widget::Closeable
+      end
+    RUBY
+    publishable = write_file("widget/publishable.rb", <<~RUBY)
+      module Widget::Publishable
+        def publish = track_event(:published)
+      end
+    RUBY
+    closeable = write_file("widget/closeable.rb", <<~RUBY)
+      module Widget::Closeable
+        def close = track_event(:closed)
+      end
+    RUBY
+
+    index = described_class.new([eventable, host, publishable, closeable])
+
+    # host + ambos os irmãos (que nunca nomeiam Eventable)
+    expect(index.files_reaching("Eventable"))
+      .to contain_exactly(host, publishable, closeable)
+  end
+
+  it "resolve includes multi-linha e com namespace" do
+    host = write_file("card.rb", <<~RUBY)
+      class Card
+        include Accessible, Eventable,
+          Statuses
+      end
+    RUBY
+    eventable = write_file("eventable.rb", "module Eventable\nend\n")
+    statuses = write_file("card/statuses.rb", "module Card::Statuses\nend\n")
+    accessible = write_file("accessible.rb", "module Accessible\nend\n")
+
+    index = described_class.new([host, eventable, statuses, accessible])
+
+    expect(index.files_reaching("Eventable"))
+      .to contain_exactly(host, statuses, accessible)
+  end
+
+  it "retorna vazio para um módulo que ninguém inclui" do
+    lonely = write_file("lonely.rb", "module Lonely\nend\n")
+
+    index = described_class.new([lonely])
+
+    expect(index.files_reaching("Lonely")).to be_empty
+  end
+end


### PR DESCRIPTION
Closes #64.

## Problema

`track_event` (e qualquer método) inferia o parâmetro `action` como `String` mesmo quando havia call-sites passando `Symbol`, então o Steep acusava `Cannot pass a value of type ::Symbol as an argument of type ::String`. O tipo deveria ser `(String | Symbol)`.

A inferência de tipo de parâmetro por call-site **descartava** tipos divergentes em vez de uni-los, por dois pontos:

1. **First-wins intra-classe** — `IntraClassCallAnalyzer` gravava o primeiro tipo resolvido com `unless existing` e ignorava os demais.
2. **Shadowing cross-class** — `Analyzer` unia os resultados intra-classe e cross-class com `||=`, então o tipo único intra-classe sombreava a união cross-class (que já era calculada corretamente).

## Correção

- **`TypeMerger.union_types`** (novo, reutilizável): une uma lista de tipos achatando uniões já existentes via `RBS::Parser` — associativo e idempotente (sem parênteses aninhados nem membros duplicados), descarta `untyped` quando há tipo resolvido e preserva a forma original (mantém `::` absoluto). `merge_argument_types` passou a delegar a ele.
- **`IntraClassCallAnalyzer`**: acumula candidatos por `(método, param)` e os une, em vez de first-wins.
- **`Analyzer`**: o merge intra+cross agora **une** via `union_types` em vez de `||=`.

## Testes

- Fixtures no dummy: `EventTracker` (call-site `String` intra-classe) + `EventReporter` (call-site `:Symbol` cross-class) → expectation `track_event: (action: (String | Symbol))`.
- Specs unitários para `union_types` (flatten / dedup / verbatim / genéricos) e para a união intra-classe.
- Suíte completa verde (unit + integração + steep check sem novos erros).
- **Bônus**: o flatten colapsou um union redundante pré-existente no snapshot do `PostsHelper` (`A | B | (A)` → `A | B`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)