### PR TITLE
fix: infer methods created by alias_method / alias keyword (#63)

### DIFF
--- a/lib/rbs_infer/inference/class_member_collector.rb
+++ b/lib/rbs_infer/inference/class_member_collector.rb
@@ -9,7 +9,10 @@ module RbsInfer::Inference
   # `param_constant_defaults` = para membros `:method`/`:class_method`, mapa
   # `param => nó Prism` dos params opcionais cujo default é uma constante; o
   # tipo (valor da constante) também é resolvido depois no Analyzer (#46).
-  Member = Struct.new(:kind, :name, :signature, :visibility, :owner, :value_node, :param_constant_defaults, keyword_init: true)
+  # `old_name` = para membros `:alias`/`:singleton_alias`, o método original
+  # apontado pelo alias; o RBS resolve o tipo nativamente via `alias`
+  # (felixefelip/rbs_infer#63).
+  Member = Struct.new(:kind, :name, :signature, :visibility, :owner, :value_node, :param_constant_defaults, :old_name, keyword_init: true)
 
   # Metadata extraída de uma chamada `delegate` — tipos são resolvidos depois no Analyzer
   DelegateInfo = Struct.new(:methods, :target, :prefix, :allow_nil, keyword_init: true)
@@ -160,8 +163,17 @@ module RbsInfer::Inference
         extract_extends(node)
       when :delegate
         extract_delegates(node)
+      when :alias_method
+        extract_alias_method(node)
       end
 
+      super
+    end
+
+    # `alias new old` keyword (Prism::AliasMethodNode). Plain Ruby — same
+    # native-`alias` emission path as `alias_method` (felixefelip/rbs_infer#63).
+    def visit_alias_method_node(node)
+      register_alias(node.new_name, node.old_name)
       super
     end
 
@@ -283,6 +295,44 @@ module RbsInfer::Inference
           visibility: :public,
           owner: current_owner
         )
+      end
+    end
+
+    # `alias_method :new, :old` (or string args). Registers an `:alias`
+    # member; a non-literal name (dynamic alias) is skipped — no static
+    # analysis can decide it (felixefelip/rbs_infer#63).
+    def extract_alias_method(node)
+      args = node.arguments&.arguments
+      return unless args && args.length >= 2
+
+      register_alias(args[0], args[1])
+    end
+
+    # Shared by `alias_method` and the `alias` keyword. Emits the alias into
+    # the scope that owns it (concern module, singleton) so the RBS carries a
+    # native `alias`, letting RBS/Steep resolve the original method's type.
+    def register_alias(new_node, old_node)
+      return unless inside_target?
+
+      new_name = literal_method_name(new_node)
+      old_name = literal_method_name(old_node)
+      return unless new_name && old_name
+
+      @members << Member.new(
+        kind: in_singleton_self? ? :singleton_alias : :alias,
+        name: new_name,
+        old_name: old_name,
+        signature: nil,
+        visibility: @current_visibility,
+        owner: current_owner
+      )
+    end
+
+    # The method name a SymbolNode/StringNode literal denotes, or nil for a
+    # dynamic (interpolated/computed) node.
+    def literal_method_name(node)
+      case node
+      when Prism::SymbolNode, Prism::StringNode then node.unescaped
       end
     end
 

--- a/lib/rbs_infer/signatures/rbs_builder.rb
+++ b/lib/rbs_infer/signatures/rbs_builder.rb
@@ -92,10 +92,20 @@ module RbsInfer::Signatures
         lines << "#{member_indent}def self.#{RbsInfer::Signatures::RbsParserUtil.parenthesize_return_type(sig)}"
       end
 
+      # Aliases (`alias new old`) — o RBS resolve nativamente o tipo do
+      # método original, sem duplicar a assinatura (felixefelip/rbs_infer#63).
+      # Singletons recebem o prefixo `self.` nos dois nomes.
+      members.select { |m| m.kind == :singleton_alias && m.owner.nil? }.each do |a|
+        lines << "#{member_indent}alias self.#{a.name} self.#{a.old_name}"
+      end
+      members.select { |m| m.kind == :alias && m.owner.nil? }.each do |a|
+        lines << "#{member_indent}alias #{a.name} #{a.old_name}"
+      end
+
       # Agrupar por visibilidade: public -> protected -> private
       # RBS não suporta `protected`, então tratamos como public
       [:public, :protected, :private].each do |vis|
-        vis_members = members.select { |m| m.visibility == vis && m.owner.nil? && ![:include, :extend, :class_method, :constant].include?(m.kind) }
+        vis_members = members.select { |m| m.visibility == vis && m.owner.nil? && ![:include, :extend, :class_method, :constant, :alias, :singleton_alias].include?(m.kind) }
         next if vis_members.empty?
 
         if vis == :private
@@ -189,6 +199,12 @@ module RbsInfer::Signatures
         end
         mod_members.select { |m| m.kind == :class_method }.each do |m|
           lines << "#{inner_indent}def self.#{RbsInfer::Signatures::RbsParserUtil.parenthesize_return_type(m.signature)}"
+        end
+        mod_members.select { |m| m.kind == :singleton_alias }.each do |a|
+          lines << "#{inner_indent}alias self.#{a.name} self.#{a.old_name}"
+        end
+        mod_members.select { |m| m.kind == :alias }.each do |a|
+          lines << "#{inner_indent}alias #{a.name} #{a.old_name}"
         end
         mod_members.each do |m|
           line = render_value_member(m, inner_indent, {}, attr_types, method_param_types, Set.new)

--- a/spec/dummy/app/models/widget/closeable.rb
+++ b/spec/dummy/app/models/widget/closeable.rb
@@ -7,4 +7,11 @@ module Widget::Closeable
   def close
     track_event(:closed)
   end
+
+  # felixefelip/rbs_infer#63: bare call to a method `Publishable` created via
+  # `alias_method`. Resolves only if that alias reached `Widget`'s RBS — here
+  # self is `(Widget & Widget::Closeable)`, the issue's failing shape.
+  def reopen
+    track_event(:reopened) if was_just_published?
+  end
 end

--- a/spec/dummy/app/models/widget/publishable.rb
+++ b/spec/dummy/app/models/widget/publishable.rb
@@ -8,4 +8,14 @@ module Widget::Publishable
   def publish
     track_event(:published)
   end
+
+  def published?
+    true
+  end
+
+  # felixefelip/rbs_infer#63: a method created via `alias_method` (and the
+  # `alias` keyword) must reach the host's RBS, so a *sibling* concern can
+  # call it bare where self is `(Widget & Widget::Closeable)`.
+  alias_method :was_just_published?, :published?
+  alias just_published? published?
 end

--- a/spec/dummy/sig/rbs_infer/app/models/widget/closeable.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/widget/closeable.rbs
@@ -1,6 +1,7 @@
 class Widget
   module Closeable
     extend ActiveSupport::Concern
-    def close: () -> { action: Symbol | String, particulars: untyped }
+    def close: () -> { action: (Symbol | String), particulars: untyped }
+    def reopen: () -> ({ action: (Symbol | String), particulars: untyped } | nil)
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/widget/publishable.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/widget/publishable.rbs
@@ -1,6 +1,9 @@
 class Widget
   module Publishable
     extend ActiveSupport::Concern
+    alias was_just_published? published?
+    alias just_published? published?
     def publish: () -> { action: Symbol | String, particulars: untyped }
+    def published?: () -> bool
   end
 end

--- a/spec/lib/rbs_infer/inference/class_member_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/class_member_collector_spec.rb
@@ -540,4 +540,71 @@ RSpec.describe RbsInfer::Inference::ClassMemberCollector do
 
     expect { RBS::Parser.parse_signature(rbs_content) }.not_to raise_error
   end
+
+  describe "aliases (felixefelip/rbs_infer#63)" do
+    it "coleta alias_method com argumentos symbol" do
+      source = <<~RUBY
+        class Foo
+          def published?; true; end
+          alias_method :was_just_published?, :published?
+        end
+      RUBY
+
+      member = collect(source).members.find { |m| m.kind == :alias }
+      expect(member.name).to eq("was_just_published?")
+      expect(member.old_name).to eq("published?")
+    end
+
+    it "coleta alias_method com argumentos string" do
+      source = <<~RUBY
+        class Foo
+          def published?; true; end
+          alias_method "was_just_published?", "published?"
+        end
+      RUBY
+
+      member = collect(source).members.find { |m| m.kind == :alias }
+      expect(member.name).to eq("was_just_published?")
+      expect(member.old_name).to eq("published?")
+    end
+
+    it "coleta a keyword alias" do
+      source = <<~RUBY
+        class Foo
+          def published?; true; end
+          alias just_published? published?
+        end
+      RUBY
+
+      member = collect(source).members.find { |m| m.kind == :alias }
+      expect(member.name).to eq("just_published?")
+      expect(member.old_name).to eq("published?")
+    end
+
+    it "classifica alias dentro de `class << self` como singleton" do
+      source = <<~RUBY
+        class Foo
+          class << self
+            def build; new; end
+            alias_method :make, :build
+          end
+        end
+      RUBY
+
+      member = collect(source).members.find { |m| m.name == "make" }
+      expect(member.kind).to eq(:singleton_alias)
+      expect(member.old_name).to eq("build")
+    end
+
+    it "ignora alias_method com nome dinâmico (não-literal)" do
+      source = <<~RUBY
+        class Foo
+          def published?; true; end
+          alias_method :"\#{prefix}_published?", :published?
+        end
+      RUBY
+
+      expect(collect(source).members.any? { |m| m.kind == :alias }).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
Closes #63.

## Problem

`alias_method :new, :old` (and the `alias new old` keyword) created methods the analyzer **never emitted into RBS**. There was no handling of either form anywhere in `lib/`. Steep then failed with, e.g.:

```
Type `(::Card & ::Card::Eventable)` does not have method `was_just_published?`
```

when a *sibling* concern called the aliased method bare — exactly the issue's failing shape (`was_just_published?` is created via `alias_method` in `Card::Statuses`).

## Fix

Emit a **native RBS `alias new old`** (`alias self.new self.old` for singleton aliases) instead of duplicating the original method's signature. RBS/Steep resolve the aliased type natively — including when the original comes from a mixin or changes later. This follows `prefer-principled-over-shortcuts` (leverage existing semantics, don't pattern-copy).

`alias`/`alias_method` are plain Ruby, not framework DSL, so per `keep-core-framework-agnostic` this lives in the **core**:

- **`ClassMemberCollector`** — `when :alias_method` in `visit_call_node` + a `visit_alias_method_node` for the keyword. Both register an `:alias` member (`:singleton_alias` inside `class << self`), respecting `inside_target?`, `current_owner` (nested concern) and visibility. Non-literal names (dynamic aliases) are skipped — no static analysis can decide them.
- **`RbsBuilder`** — emits aliases in the class body and inside nested-module concerns (`emit_parsed_nested_modules`).

## Validation

- **Dummy fixture** reproduces the issue: `Widget::Publishable` defines a method via `alias_method`/`alias`, and `Widget::Closeable#reopen` calls it bare where self is `(Widget & Widget::Closeable)`. Without the fix, steep produced the exact issue error.
- `make steep` / integration suite: **55 examples, 0 failures** (regression gone).
- New unit specs cover `alias_method` (symbol & string args), the `alias` keyword, singleton classification, and dynamic-name skipping.
- Full unit suite: **605 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)