### PR TITLE
fix: scope ivar-write inference to the target class

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -303,7 +303,7 @@ module RbsInfer
   end
 
   def synthesize_setter_markers(target_members, attr_types)
-    per_method = steep_bridge.ivar_write_types_per_method(@parsed_target.source)
+    per_method = steep_bridge.ivar_write_types_per_method(@parsed_target.source, target_class: @target_class)
     return [] if per_method.empty?
 
     declared_ivar_types = collect_declared_attr_types(target_members, attr_types)

--- a/lib/rbs_infer/extensions/rails/erb_convention_generator/controller_analyzer.rb
+++ b/lib/rbs_infer/extensions/rails/erb_convention_generator/controller_analyzer.rb
@@ -194,7 +194,7 @@ module RbsInfer
 
             source = File.read(controller_file)
             bridge = controller_steep_bridge
-            @controller_per_method_ivar_cache[controller_class] = bridge.ivar_write_types_per_method(source)
+            @controller_per_method_ivar_cache[controller_class] = bridge.ivar_write_types_per_method(source, target_class: controller_class)
           end
 
           def controller_steep_bridge

--- a/lib/rbs_infer/inference/return_type_resolver.rb
+++ b/lib/rbs_infer/inference/return_type_resolver.rb
@@ -161,7 +161,7 @@ module RbsInfer::Inference
       # nilability and the fallback adds the call-sites' nominal types.
       steep_nil_only = Set.new
       if @steep_bridge && parsed_target.source
-        steep_ivars = @steep_bridge.ivar_write_types(parsed_target.source)
+        steep_ivars = @steep_bridge.ivar_write_types(parsed_target.source, target_class: @target_class)
         steep_ivars.each do |name, type|
           next if attr_names.include?(name)
           if type == "nil"

--- a/lib/rbs_infer/signatures/steep_bridge.rb
+++ b/lib/rbs_infer/signatures/steep_bridge.rb
@@ -339,8 +339,16 @@ module RbsInfer::Signatures
       resolved == type_str ? nil : resolved
     end
 
-    # Returns { "var_name" => "Type" } for all instance variable writes
-    # observed in the source. The var name is without the leading `@`.
+    # Returns { "var_name" => "Type" } for instance variable writes
+    # observed in the source, scoped to `target_class`. The var name is
+    # without the leading `@`.
+    #
+    # `target_class` matters when a single file defines several classes
+    # (initializers, `lib/*_ext.rb`, fixtures): only writes lexically
+    # inside `target_class` (or a module nested-and-included under it,
+    # e.g. an expander's `GeneratedAttributeMethods`) count, so a sibling
+    # class's `@x` never bleeds in (felixefelip/rbs_infer#38). Pass `nil`
+    # to opt out of scoping (whole-file behavior).
     #
     # Writes counted:
     #
@@ -351,10 +359,10 @@ module RbsInfer::Signatures
     #   of `@x` (felixefelip/rbs_infer#4 + steep#18 mapping).
     #
     # When no write is observed inside `def initialize` (nor at class-body
-    # scope), the emitted type gets `| nil` (definite-initialization rule).
-    # The narrowing is then reabsorbed by steep#16 within methods that
-    # explicitly assign before reading.
-    def ivar_write_types(source_code)
+    # scope) of `target_class`, the emitted type gets `| nil`
+    # (definite-initialization rule). The narrowing is then reabsorbed by
+    # steep#16 within methods that explicitly assign before reading.
+    def ivar_write_types(source_code, target_class:)
       typing = type_check(source_code)
       return {} unless typing
 
@@ -362,10 +370,18 @@ module RbsInfer::Signatures
       return {} unless source_node
 
       type_sets = Hash.new { |h, k| h[k] = RbsInfer::Inference::IvarTypeSet.new }
-      initialized = collect_initialized_ivars(source_node)
+      initialized = collect_initialized_ivars(source_node, target_class: target_class)
       attr_writer_to_ivar = collect_attr_writers(source_node)
+      # Only writes lexically inside `target_class` count. A single file can
+      # define several classes (initializers, `lib/*_ext.rb`, the dummy-app
+      # fixtures), and without scoping their ivars — and same-named methods
+      # like `initialize` — pool into each other (felixefelip/rbs_infer#38).
+      # `each_typing` enumerates the whole file, so we filter it by node
+      # identity against the set of writes that belong to `target_class`.
+      in_scope = collect_scoped_write_node_ids(source_node, attr_writer_to_ivar, target_class)
 
       typing.each_typing do |node, type|
+        next unless in_scope.include?(node.object_id)
         case node.type
         when :ivasgn
           rhs = node.children[1]
@@ -399,11 +415,16 @@ module RbsInfer::Signatures
     end
 
     # Returns `{ "method_name" => { "ivar_name" => "type" } }` for every
-    # method in the source that writes (directly or via attr_writer) an
-    # instance variable. The per-method shape is what enables consumers
+    # method of `target_class` that writes (directly or via attr_writer)
+    # an instance variable. The per-method shape is what enables consumers
     # (e.g., the ERB convention generator) to narrow an ivar's type to
     # the contribution of a specific writer — rather than always seeing
     # the wide union of all observed writes.
+    #
+    # Scoped to `target_class` so that same-named methods across classes
+    # in one file (`Foo#initialize` and `Bar#initialize`) don't pool into
+    # a single `"initialize"` bucket (felixefelip/rbs_infer#38). Pass
+    # `nil` to opt out of scoping.
     #
     # Coverage mirrors `ivar_write_types`:
     # - Direct `:ivasgn` (`@x = expr`) inside any method.
@@ -413,7 +434,7 @@ module RbsInfer::Signatures
     # Top-level `:ivasgn` outside any method (class-instance variable in
     # class body) is intentionally NOT recorded here — there's no method
     # to attribute it to. Use `collect_initialized_ivars` for that case.
-    def ivar_write_types_per_method(source_code)
+    def ivar_write_types_per_method(source_code, target_class:)
       typing = type_check(source_code)
       return {} unless typing
 
@@ -430,6 +451,8 @@ module RbsInfer::Signatures
         typing: typing,
         attr_writer_to_ivar: attr_writer_to_ivar,
         current_method: nil,
+        namespace: [],
+        target_class: target_class,
         result: per_method_sets
       )
 
@@ -474,12 +497,15 @@ module RbsInfer::Signatures
     end
 
     # Returns Set[String] of ivar names (without leading `@`) that are
-    # assigned inside `def initialize` of any class in the source, or at
+    # assigned inside `def initialize` of `target_class`, or at its
     # class-body scope. Used by the definite-initialization rule to
-    # decide whether `nil` is added to the union.
-    def collect_initialized_ivars(node)
+    # decide whether `nil` is added to the union — so it must be scoped to
+    # the same class the writes are, or an `@x` initialized in a *sibling*
+    # class in the same file would wrongly suppress the `| nil` here.
+    def collect_initialized_ivars(node, target_class:)
       result = Set.new
-      walk_ivar_init_targets(node, in_init: false, in_class_body: false, result: result)
+      walk_ivar_init_targets(node, in_init: false, in_class_body: false,
+                             namespace: [], target_class: target_class, result: result)
       result
     end
 
@@ -551,21 +577,111 @@ module RbsInfer::Signatures
 
     private
 
+    # Renders a whitequark `:const` node into a dotted class-path string:
+    # `(const nil :Foo)` → "Foo", `(const (const nil :Foo) :Bar)` →
+    # "Foo::Bar", `(const (cbase) :Foo)` → "Foo". Returns nil for shapes
+    # we can't name (dynamic constant paths), so the caller keeps the
+    # outer namespace rather than inventing a segment.
+    def const_node_to_name(node)
+      return nil unless node.is_a?(::Parser::AST::Node) && node.type == :const
+
+      scope, name = node.children
+      if scope.nil? || (scope.is_a?(::Parser::AST::Node) && scope.type == :cbase)
+        name.to_s
+      elsif scope.is_a?(::Parser::AST::Node) && scope.type == :const
+        prefix = const_node_to_name(scope)
+        prefix ? "#{prefix}::#{name}" : nil
+      end
+    end
+
+    # True when the lexical class path `namespace` (array of segments) is
+    # `target_class` *or* something nested under it. The nested case is
+    # required: an expander (e.g. CurrentAttributes) can emit a nested
+    # `module GeneratedAttributeMethods` that is `include`d into the class
+    # and writes the same ivars, so its writes belong to the target. The
+    # `::` boundary keeps a sibling like `BoardMember` from matching
+    # target `Board`. A nil `target_class` means "don't scope" (whole
+    # file), preserved for callers with no single target.
+    def class_scope_match?(namespace, target_class)
+      return true if target_class.nil?
+
+      target = target_class.to_s.sub(/\A::/, "")
+      current = namespace.join("::")
+      current == target || current.start_with?("#{target}::")
+    end
+
+    # Object-ids of the `:ivasgn` / attr-writer `:send` nodes that live
+    # lexically inside `target_class`. `ivar_write_types` filters the
+    # whole-file `each_typing` stream against this set so a sibling class
+    # in the same file can't contribute to the target's ivar types. Using
+    # object-ids (not the nodes) sidesteps `Parser::AST::Node`'s
+    # structural `==`, which would conflate two identical writes in
+    # different classes.
+    def collect_scoped_write_node_ids(node, attr_writer_to_ivar, target_class, namespace: [], result: Set.new)
+      return result unless node.is_a?(::Parser::AST::Node)
+
+      case node.type
+      when :class, :module
+        name = const_node_to_name(node.children[0])
+        body = node.type == :class ? node.children[2] : node.children[1]
+        collect_scoped_write_node_ids(body, attr_writer_to_ivar, target_class,
+                                      namespace: name ? namespace + [name] : namespace,
+                                      result: result) if body
+      when :sclass
+        collect_scoped_write_node_ids(node.children[1], attr_writer_to_ivar, target_class,
+                                      namespace: namespace, result: result) if node.children[1]
+      when :ivasgn
+        result << node.object_id if class_scope_match?(namespace, target_class)
+        node.children.each do |c|
+          collect_scoped_write_node_ids(c, attr_writer_to_ivar, target_class, namespace: namespace, result: result)
+        end
+      when :send
+        receiver, method_name = node.children[0], node.children[1]
+        if attr_writer_to_ivar.key?(method_name) &&
+           (receiver.nil? || (receiver.respond_to?(:type) && receiver.type == :self)) &&
+           class_scope_match?(namespace, target_class)
+          result << node.object_id
+        end
+        node.children.each do |c|
+          collect_scoped_write_node_ids(c, attr_writer_to_ivar, target_class, namespace: namespace, result: result)
+        end
+      else
+        node.children.each do |c|
+          collect_scoped_write_node_ids(c, attr_writer_to_ivar, target_class, namespace: namespace, result: result)
+        end
+      end
+
+      result
+    end
+
     # Walks `node` accumulating ivar writes attributed to the enclosing
     # `def`. Propagates `current_method` through descent; only records
     # writes that happen inside a `:def` (writes in class body are
     # ignored here since they don't belong to any callable). Mirrors the
     # filter logic of `ivar_write_types` for both `:ivasgn` and
     # attr_writer-style `:send`.
-    def collect_ivar_writes_per_method(node, typing:, attr_writer_to_ivar:, current_method:, result:)
+    def collect_ivar_writes_per_method(node, typing:, attr_writer_to_ivar:, current_method:, namespace:, target_class:, result:)
       return unless node.is_a?(::Parser::AST::Node)
 
       case node.type
-      when :class, :module, :sclass
+      when :class, :module
+        name = const_node_to_name(node.children[0])
         body = node.type == :class ? node.children[2] : node.children[1]
         collect_ivar_writes_per_method(body, typing: typing,
                                        attr_writer_to_ivar: attr_writer_to_ivar,
                                        current_method: nil,
+                                       namespace: name ? namespace + [name] : namespace,
+                                       target_class: target_class,
+                                       result: result) if body
+      when :sclass
+        # `class << self` — same lexical class, singleton scope; keep the
+        # namespace so writes inside still attribute to the enclosing class.
+        body = node.children[1]
+        collect_ivar_writes_per_method(body, typing: typing,
+                                       attr_writer_to_ivar: attr_writer_to_ivar,
+                                       current_method: nil,
+                                       namespace: namespace,
+                                       target_class: target_class,
                                        result: result) if body
       when :def
         method_name = node.children[0].to_s
@@ -573,13 +689,15 @@ module RbsInfer::Signatures
         collect_ivar_writes_per_method(body, typing: typing,
                                        attr_writer_to_ivar: attr_writer_to_ivar,
                                        current_method: method_name,
+                                       namespace: namespace,
+                                       target_class: target_class,
                                        result: result) if body
       when :defs
         # Singleton `def self.X` — class-instance variable scope, not
         # relevant for the per-action narrowing this method serves.
       when :ivasgn
         rhs = node.children[1]
-        if current_method && rhs
+        if current_method && rhs && class_scope_match?(namespace, target_class)
           var_name = node.children[0].to_s.sub(/\A@/, "")
           # Use the RHS's INTRINSIC type, not what `typing` recorded.
           # When the ivar is already declared in RBS (e.g.,
@@ -599,12 +717,14 @@ module RbsInfer::Signatures
         collect_ivar_writes_per_method(rhs, typing: typing,
                                        attr_writer_to_ivar: attr_writer_to_ivar,
                                        current_method: current_method,
+                                       namespace: namespace,
+                                       target_class: target_class,
                                        result: result) if rhs
       when :send
         receiver, method_name, *args = node.children
         if current_method && attr_writer_to_ivar.key?(method_name) &&
            (receiver.nil? || (receiver.respond_to?(:type) && receiver.type == :self)) &&
-           !args.empty?
+           !args.empty? && class_scope_match?(namespace, target_class)
           arg = args[0]
           arg_type = intrinsic_type_of(arg, typing)
           if arg_type
@@ -616,6 +736,8 @@ module RbsInfer::Signatures
           collect_ivar_writes_per_method(c, typing: typing,
                                          attr_writer_to_ivar: attr_writer_to_ivar,
                                          current_method: current_method,
+                                         namespace: namespace,
+                                         target_class: target_class,
                                          result: result)
         end
       when :begin
@@ -623,6 +745,8 @@ module RbsInfer::Signatures
           collect_ivar_writes_per_method(c, typing: typing,
                                          attr_writer_to_ivar: attr_writer_to_ivar,
                                          current_method: current_method,
+                                         namespace: namespace,
+                                         target_class: target_class,
                                          result: result)
         end
       else
@@ -630,6 +754,8 @@ module RbsInfer::Signatures
           collect_ivar_writes_per_method(c, typing: typing,
                                          attr_writer_to_ivar: attr_writer_to_ivar,
                                          current_method: current_method,
+                                         namespace: namespace,
+                                         target_class: target_class,
                                          result: result)
         end
       end
@@ -638,33 +764,42 @@ module RbsInfer::Signatures
     # Walks `node` looking for `:ivasgn` targets that count as definite
     # initialization (inside `def initialize` or directly in a class body
     # outside any method). Does not descend into non-initialize defs.
-    def walk_ivar_init_targets(node, in_init:, in_class_body:, result:)
+    def walk_ivar_init_targets(node, in_init:, in_class_body:, namespace:, target_class:, result:)
       return unless node.is_a?(::Parser::AST::Node)
 
       case node.type
-      when :class, :module, :sclass
+      when :class, :module
+        name = const_node_to_name(node.children[0])
         body = node.type == :class ? node.children[2] : node.children[1]
-        walk_ivar_init_targets(body, in_init: false, in_class_body: true, result: result) if body
+        walk_ivar_init_targets(body, in_init: false, in_class_body: true,
+                               namespace: name ? namespace + [name] : namespace,
+                               target_class: target_class, result: result) if body
+      when :sclass
+        body = node.children[1]
+        walk_ivar_init_targets(body, in_init: false, in_class_body: true,
+                               namespace: namespace, target_class: target_class, result: result) if body
       when :def
         if node.children[0] == :initialize
           body = node.children[2]
-          walk_ivar_init_targets(body, in_init: true, in_class_body: false, result: result) if body
+          walk_ivar_init_targets(body, in_init: true, in_class_body: false,
+                                 namespace: namespace, target_class: target_class, result: result) if body
         end
       when :defs
         # def self.X — singleton method, skip; ivar there is class-instance
         # variable, not relevant for instance ivar initialization.
       when :ivasgn
-        if in_init || in_class_body
+        if (in_init || in_class_body) && class_scope_match?(namespace, target_class)
           var_name = node.children[0].to_s.sub(/\A@/, "")
           result << var_name
         end
         # also walk RHS for nested classes (`@x = Class.new { @y = ... }` is
         # exotic but harmless to descend)
         rhs = node.children[1]
-        walk_ivar_init_targets(rhs, in_init: in_init, in_class_body: in_class_body, result: result) if rhs
+        walk_ivar_init_targets(rhs, in_init: in_init, in_class_body: in_class_body,
+                               namespace: namespace, target_class: target_class, result: result) if rhs
       when :send
         receiver, method_name, *args = node.children
-        if (in_init || in_class_body) &&
+        if (in_init || in_class_body) && class_scope_match?(namespace, target_class) &&
            (receiver.nil? || (receiver.respond_to?(:type) && receiver.type == :self)) &&
            method_name.to_s.end_with?("=") &&
            method_name != :==
@@ -682,17 +817,20 @@ module RbsInfer::Signatures
           result << ivar unless ivar.empty?
         end
         node.children.each do |c|
-          walk_ivar_init_targets(c, in_init: in_init, in_class_body: in_class_body, result: result)
+          walk_ivar_init_targets(c, in_init: in_init, in_class_body: in_class_body,
+                                 namespace: namespace, target_class: target_class, result: result)
         end
       when :begin
         node.children.each do |c|
-          walk_ivar_init_targets(c, in_init: in_init, in_class_body: in_class_body, result: result)
+          walk_ivar_init_targets(c, in_init: in_init, in_class_body: in_class_body,
+                                 namespace: namespace, target_class: target_class, result: result)
         end
       else
         # Descend through everything else (if/case/blocks/etc.) while
         # keeping the current scope flags.
         node.children.each do |c|
-          walk_ivar_init_targets(c, in_init: in_init, in_class_body: in_class_body, result: result)
+          walk_ivar_init_targets(c, in_init: in_init, in_class_body: in_class_body,
+                                 namespace: namespace, target_class: target_class, result: result)
         end
       end
     end

--- a/spec/dummy/app/models/example.rb
+++ b/spec/dummy/app/models/example.rb
@@ -1,0 +1,31 @@
+class Column
+  attr_accessor :board, :column_name, :user_name
+
+	def initialize(column_name:)
+		@column_name = column_name
+	end
+
+  def set_default_user_name
+		self.user_name = board.user_name
+  end
+end
+
+class Board
+  attr_reader :user_name
+
+	def initialize(user_name:)
+		@user_name = user_name
+	end
+end
+
+class Example
+  def self.run
+	  board = Board.new(user_name: 'John Doe')
+
+		column = Column.new(column_name: 'To Do') # user_name e board são nil neste ponto
+
+		column.board = board
+
+		column.set_default_user_name # como o board foi atribuído, agora o user_name será definido corretamente sem NoMethodError
+  end
+end

--- a/spec/dummy/app/models/example.rb
+++ b/spec/dummy/app/models/example.rb
@@ -1,31 +1,31 @@
 class Column
   attr_accessor :board, :column_name, :user_name
 
-	def initialize(column_name:)
-		@column_name = column_name
-	end
+  def initialize(column_name:)
+    @column_name = column_name
+  end
 
   def set_default_user_name
-		self.user_name = board.user_name
+    self.user_name = board.user_name
   end
 end
 
 class Board
   attr_reader :user_name
 
-	def initialize(user_name:)
-		@user_name = user_name
-	end
+  def initialize(user_name:)
+    @user_name = user_name
+  end
 end
 
 class Example
   def self.run
-	  board = Board.new(user_name: 'John Doe')
+    board = Board.new(user_name: 'John Doe')
 
-		column = Column.new(column_name: 'To Do') # user_name e board são nil neste ponto
+    column = Column.new(column_name: 'To Do') # user_name e board são nil neste ponto
 
-		column.board = board
+    column.board = board
 
-		column.set_default_user_name # como o board foi atribuído, agora o user_name será definido corretamente sem NoMethodError
+    column.set_default_user_name # como o board foi atribuído, agora o user_name será definido corretamente sem NoMethodError
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example.rbs
@@ -1,0 +1,20 @@
+class Column
+  attr_accessor board: Board
+  attr_accessor column_name: String
+  attr_accessor user_name: untyped
+  def initialize: (column_name: String) -> void
+  def set_default_user_name: () -> String
+
+  class AfterSetDefaultUserName
+    attr_reader user_name: String
+  end
+end
+
+class Board
+  attr_reader user_name: String
+  def initialize: (user_name: String) -> void
+end
+
+class Example
+  def self.run: () -> String
+end

--- a/spec/lib/rbs_infer/signatures/steep_bridge_spec.rb
+++ b/spec/lib/rbs_infer/signatures/steep_bridge_spec.rb
@@ -437,7 +437,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types(code)
+      result = bridge.ivar_write_types(code, target_class: "Foo")
       expect(result["x"]).to eq("String")
     end
 
@@ -450,7 +450,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types(code)
+      result = bridge.ivar_write_types(code, target_class: "Foo")
       expect(result["x"]).to eq("String?")
     end
 
@@ -467,7 +467,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types(code)
+      result = bridge.ivar_write_types(code, target_class: "Foo")
       expect(result["x"]).to eq("((Comment & Comment::Validated) | Comment)?")
     end
 
@@ -484,7 +484,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types(code)
+      result = bridge.ivar_write_types(code, target_class: "Foo")
       expect(result["x"]).to eq("Comment | (Comment & Comment::Validated)")
     end
 
@@ -501,7 +501,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types(code)
+      result = bridge.ivar_write_types(code, target_class: "Foo")
       expect(result["x"]).to eq("(Comment & Comment::Validated)?")
     end
 
@@ -516,7 +516,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types(code)
+      result = bridge.ivar_write_types(code, target_class: "Foo")
       expect(result["x"]).to eq("String?")
     end
 
@@ -535,7 +535,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types(code)
+      result = bridge.ivar_write_types(code, target_class: "Foo")
       expect(result["x"]).to eq("Comment | (Comment & Comment::Validated)")
     end
 
@@ -550,7 +550,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types(code)
+      result = bridge.ivar_write_types(code, target_class: "Foo")
       expect(result["x"]).to eq("String")
     end
 
@@ -567,7 +567,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types(code)
+      result = bridge.ivar_write_types(code, target_class: "Foo")
       expect(result["x"]).to eq("String?")
     end
 
@@ -582,7 +582,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types(code)
+      result = bridge.ivar_write_types(code, target_class: "Foo")
       # class-body ivasgn is class-instance variable scope; method
       # ivasgn is instance scope. Per the issue, we treat the class-body
       # write as initialized for the same name (best-effort).
@@ -598,7 +598,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types(code)
+      result = bridge.ivar_write_types(code, target_class: "Foo")
       # Only `nil` was observed; nilable, no concrete type. The emitter
       # returns "nil" which is a valid RBS type.
       expect(result["x"]).to eq("nil")
@@ -624,7 +624,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types_per_method(code)
+      result = bridge.ivar_write_types_per_method(code, target_class: "Foo")
 
       expect(result["set_x"]["x"]).to eq("(Comment & Comment::Validated)")
       expect(result["make_x"]["x"]).to eq("Comment")
@@ -640,7 +640,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types_per_method(code)
+      result = bridge.ivar_write_types_per_method(code, target_class: "Foo")
 
       expect(result["set_x"]["x"]).to eq("Comment | (Comment & Comment::Validated)")
     end
@@ -656,7 +656,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types_per_method(code)
+      result = bridge.ivar_write_types_per_method(code, target_class: "Foo")
 
       expect(result["assign"]["x"]).to eq("String")
     end
@@ -674,7 +674,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types_per_method(code)
+      result = bridge.ivar_write_types_per_method(code, target_class: "Foo")
 
       expect(result.keys).to eq(["writes"])
     end
@@ -692,13 +692,13 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types_per_method(code)
+      result = bridge.ivar_write_types_per_method(code, target_class: "Foo")
 
       expect(result["set_x"]["x"]).to eq("String")
     end
 
     it "returns empty hash for source with no class body" do
-      result = bridge.ivar_write_types_per_method("# just a comment")
+      result = bridge.ivar_write_types_per_method("# just a comment", target_class: "Foo")
       expect(result).to eq({})
     end
 
@@ -713,7 +713,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types_per_method(code)
+      result = bridge.ivar_write_types_per_method(code, target_class: "Foo")
 
       # `@class_inst` at class body is class-instance variable, not
       # attributable to a method.
@@ -730,7 +730,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types_per_method(code)
+      result = bridge.ivar_write_types_per_method(code, target_class: "Foo")
 
       # `def self.X` operates on the singleton; ivars there are
       # class-instance variables, not relevant for the per-action
@@ -759,7 +759,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types_per_method(code)
+      result = bridge.ivar_write_types_per_method(code, target_class: "Foo")
 
       # `nil` literal isn't context-widened (it's already the bottom
       # of the union), so this test catches LHS-widening regressions
@@ -794,9 +794,60 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
         end
       RUBY
 
-      result = bridge.ivar_write_types_per_method(code)
+      result = bridge.ivar_write_types_per_method(code, target_class: "Foo")
 
       expect(result["set_default_name"]["name"]).to eq("String")
+    end
+  end
+
+  describe "ivar-write class scoping (felixefelip/rbs_infer#38)" do
+    # Two classes in one file that share a method name (`initialize`) and an
+    # ivar name (`@shared`). Before scoping, both `ivar_write_types` and
+    # `ivar_write_types_per_method` pooled writes across the classes.
+    let(:code) do
+      <<~RUBY
+        class Alpha
+          def initialize
+            @shared = "a"
+          end
+
+          def touch
+            @only_alpha = 1
+          end
+        end
+
+        class Beta
+          def configure
+            @shared = 2
+          end
+        end
+      RUBY
+    end
+
+    it "attributes per-method writes only to the requested class" do
+      alpha = bridge.ivar_write_types_per_method(code, target_class: "Alpha")
+      expect(alpha["initialize"]).to eq({ "shared" => "String" })
+      expect(alpha["touch"]).to eq({ "only_alpha" => "Integer" })
+      # Beta#configure must not appear under Alpha.
+      expect(alpha).not_to have_key("configure")
+
+      beta = bridge.ivar_write_types_per_method(code, target_class: "Beta")
+      expect(beta["configure"]).to eq({ "shared" => "Integer" })
+      # Alpha's `initialize`/`touch` must not merge into Beta.
+      expect(beta.keys).to eq(["configure"])
+    end
+
+    it "scopes flat writes and the definite-initialization rule per class" do
+      # `@shared` is initialized in Alpha#initialize (non-nil) but only
+      # assigned in Beta#configure outside init — so it is nilable *for
+      # Beta*. Without scoping, Alpha's initialize would suppress the `?`
+      # and Alpha's "String" would merge in.
+      alpha = bridge.ivar_write_types(code, target_class: "Alpha")
+      expect(alpha["shared"]).to eq("String")
+
+      beta = bridge.ivar_write_types(code, target_class: "Beta")
+      expect(beta["shared"]).to eq("Integer?")
+      expect(beta).not_to have_key("only_alpha")
     end
   end
 


### PR DESCRIPTION
## Problem

`SteepBridge#ivar_write_types` and `#ivar_write_types_per_method` walked the **whole parsed file** and attributed every instance-variable write to whatever class was being generated. In real Rails apps this is masked (one model per file), but any file with several classes — initializers, `lib/*_ext.rb`, or a multi-class fixture — pooled writes across them.

Reproduced with a plain-Ruby fixture (`Column` + `Board` + `Example` in one file):

- **same-named methods merged** — `Board#initialize`'s `@user_name` landed in `Column`'s `"initialize"` bucket, so `SetterMarkerSynthesizer` emitted a bogus `Column::AfterInitialize { user_name: String }` for an ivar `Column#initialize` never assigns;
- **flat writes leaked** — `Column`'s `@column_name` showed up as a spurious `@column_name: String` on `Board` and `Example`;
- **the definite-initialization rule crossed classes** — an `@x` initialized in a sibling's `initialize` wrongly suppressed the `| nil`.

## Fix

Both methods (and the `collect_initialized_ivars` that feeds the nilable rule) now take a **required** `target_class:` and count only writes lexically inside it.

- **Prefix matching, not exact** — a nested module that is `include`d into the target and shares its ivars (e.g. the CurrentAttributes expander's `GeneratedAttributeMethods`) still contributes. Exact matching regressed the `Current` snapshot; prefix matching restores it while still excluding siblings (the `::` boundary keeps `BoardMember` from matching `Board`).
- **Flat path keeps singleton writes** — `def self.x` `@ivar =` writes are still counted (matching the prior `each_typing` coverage that `Current.set`/`with` rely on); only the per-method marker walker skips singletons, as before.
- **Required, not defaulted** — every production caller (analyzer, return-type resolver, ERB controller analyzer) has a target class, so a forgotten wiring fails loudly instead of silently reverting to whole-file pooling (per `docs/engineering/required-threaded-deps.md`).

This is fix #1 of two for the belongs-to/nilability investigation; the separate `board` reverse-inference nilability fix follows.

## Tests

- New `steep_bridge_spec` block "ivar-write class scoping" with two classes sharing a method name (`initialize`) and an ivar (`@shared`), asserting per-method and flat writes (and the definite-init `?`) stay scoped.
- Full suite green: **607 unit + 55 integration**, including the `Current` (CurrentAttributes) snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)