### PR TITLE
feat: infer attr type from external setter call-sites (Board?)

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -224,7 +224,7 @@ module RbsInfer
     # overwrite) with the intra-class types: a method called with `String` in
     # one file and `:Symbol` in another should infer `(String | Symbol)`, not
     # the first type seen (felixefelip/rbs_infer#64).
-    cross_class_param_types = infer_method_param_types_from_callers
+    cross_class_param_types = infer_method_param_types_from_callers(extract_attr_writer_methods(target_members))
     cross_class_param_types.each do |method_name, param_types|
       method_param_types[method_name] ||= {}
       param_types.each do |param_name, type|
@@ -237,6 +237,14 @@ module RbsInfer
           end
       end
     end
+
+    # An attr set from outside via `receiver.attr = value` (receiver typed
+    # as this class) has no local write to infer from — but the setter is a
+    # method, so the cross-class call-site inference above already typed its
+    # parameter. Route that back to the attr's type, and — since the attr
+    # is never written in `initialize` — apply the definite-initialization
+    # `| nil` (felixefelip/rbs_infer#71).
+    apply_external_setter_attr_types(attr_types, method_param_types, target_members)
 
     # Inferir tipos de instance variables (@post, @posts, etc.)
     # method_param_types feeds `@x = param` when the param's type came
@@ -733,8 +741,8 @@ module RbsInfer
 
   # Inferir tipos de parâmetros de métodos via chamadas cross-class
   # Ex: PostPublisher chama notifier.notify(post.user, "msg") → user: User, message: String
-  def infer_method_param_types_from_callers
-    target_methods = extract_target_method_params
+  def infer_method_param_types_from_callers(extra_methods = {})
+    target_methods = extract_target_method_params.merge(extra_methods)
     return {} if target_methods.empty?
 
     positional_params = extract_init_positional_params
@@ -793,6 +801,46 @@ module RbsInfer
       methods[defn.name.to_s] = names unless names.empty?
     end
     methods
+  end
+
+  # `attr_accessor`/`attr_writer :x` defines an `x=` method, so an external
+  # `receiver.x = value` is just a call to it. Expose those writers as
+  # synthetic target methods (single param named after the attr) so the
+  # cross-class call-site inference types the assigned value exactly like
+  # any other method argument (felixefelip/rbs_infer#71).
+  def extract_attr_writer_methods(target_members)
+    target_members.each_with_object({}) do |m, acc|
+      next unless [:attr_accessor, :attr_writer].include?(m.kind)
+      acc["#{m.name}="] = [m.name]
+    end
+  end
+
+  # Fills `attr_types` for writable attrs whose type could only come from
+  # external `receiver.attr = value` call-sites (their `attr=` parameter,
+  # inferred by the cross-class pass). An `attr_accessor` whose backing
+  # ivar is never assigned in `initialize` is nilable — its getter can
+  # observe the pre-assignment `nil` — so the definite-initialization `?`
+  # is applied. A pure `attr_writer` has no getter, so it keeps the bare
+  # accepted-value type (felixefelip/rbs_infer#71).
+  def apply_external_setter_attr_types(attr_types, method_param_types, target_members)
+    writable = target_members.select { |m| [:attr_accessor, :attr_writer].include?(m.kind) }
+    return if writable.empty?
+
+    initialized = return_type_resolver.collect_prism_initialized_ivars(@parsed_target.tree)
+
+    writable.each do |m|
+      # Don't override a type already inferred from a local write.
+      next if attr_types[m.name] && attr_types[m.name] != "untyped"
+
+      setter_params = method_param_types["#{m.name}="]
+      inferred = setter_params&.values&.reject { |t| t.nil? || t == "untyped" }&.first
+      next unless inferred
+
+      if m.kind == :attr_accessor && !initialized.include?(m.name)
+        inferred = RbsInfer::Signatures::RbsParserUtil.nilablize(inferred)
+      end
+      attr_types[m.name] = inferred
+    end
   end
 
   # Extrai nomes dos parâmetros positional do initialize da classe-alvo

--- a/lib/rbs_infer/inference/return_type_resolver.rb
+++ b/lib/rbs_infer/inference/return_type_resolver.rb
@@ -200,6 +200,16 @@ module RbsInfer::Inference
       ivar_types
     end
 
+    # Returns Set[String] of ivar names (without `@`) assigned inside any
+    # `def initialize` or directly in a class body. Public so the analyzer
+    # can apply the definite-initialization rule to attr types inferred
+    # from external setter call-sites (felixefelip/rbs_infer#71).
+    def collect_prism_initialized_ivars(tree)
+      result = Set.new
+      walk_prism_init_targets(tree, in_init: false, in_class_body: false, result: result)
+      result
+    end
+
     private
 
     attr_reader :method_type_resolver
@@ -277,16 +287,10 @@ module RbsInfer::Inference
     end
 
     # Walks the Prism tree of a class body and collects ivar names that
-    # are assigned inside `def initialize` or directly in the class body
-    # (outside any method). Mirrors `SteepBridge#collect_initialized_ivars`
-    # for the Prism path. Used by the definite-initialization rule
-    # (felixefelip/rbs_infer#4).
-    def collect_prism_initialized_ivars(tree)
-      result = Set.new
-      walk_prism_init_targets(tree, in_init: false, in_class_body: false, result: result)
-      result
-    end
-
+    # Walks Prism nodes collecting ivar names assigned inside `initialize`
+    # or a class body (outside any method). Mirrors
+    # `SteepBridge#collect_initialized_ivars` for the Prism path. Used by
+    # the definite-initialization rule (felixefelip/rbs_infer#4).
     def walk_prism_init_targets(node, in_init:, in_class_body:, result:)
       return unless node
 

--- a/spec/dummy/sig/rbs_infer/app/models/example.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example.rbs
@@ -1,5 +1,5 @@
 class Column
-  attr_accessor board: untyped
+  attr_accessor board: Board?
   attr_accessor column_name: String
   attr_accessor user_name: untyped
   def initialize: (column_name: String) -> void

--- a/spec/expectations/models/example.rbs
+++ b/spec/expectations/models/example.rbs
@@ -1,5 +1,5 @@
 class Column
-  attr_accessor board: untyped
+  attr_accessor board: Board?
   attr_accessor column_name: String
   attr_accessor user_name: untyped
   def initialize: (column_name: String) -> void

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -6,6 +6,7 @@ app/models/concerns/test/filtrable.rb:7:24: [error] Type `(singleton(::Test) & s
 app/models/concerns/test/filtrable.rb:7:4: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `scope`
 app/models/concerns/test/filtrable.rb:8:26: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `where`
 app/models/concerns/test/filtrable.rb:8:4: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `scope`
+app/models/example.rb:9:27: [error] Type `(::Board | nil)` does not have method `user_name`
 app/models/post/notifiable.rb:28:24: [error] Type `(::User | nil)` does not have method `full_name`
 app/models/user/recoverable.rb:10:6: [error] Cannot allow method body have type `::User` because declared as type `self`
 app/models/user/recoverable.rb:14:6: [error] Cannot allow method body have type `::User` because declared as type `self`

--- a/spec/expectations/steep_contracts.yml
+++ b/spec/expectations/steep_contracts.yml
@@ -1,6 +1,15 @@
 ---
 version: 1
 methods:
+  Column#set_default_user_name:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: board
+    enforced: false
   Comment#author_name:
     requires:
     - kind: not_nil

--- a/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
@@ -397,4 +397,51 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
       end
     end
   end
+
+  describe "external attr-setter call-sites (rbs_infer#71)" do
+    def collect_method_usages(source, target_class:, target_methods:, local_var_types: {})
+      result = Prism.parse(source)
+      visitor = described_class.new(
+        target_class: target_class,
+        method_return_types: {},
+        local_var_types: local_var_types,
+        constant_arg_resolver: null_constant_resolver,
+        target_methods: target_methods
+      )
+      result.value.accept(visitor)
+      visitor.method_call_usages
+    end
+
+    it "captures `receiver.attr = value` as a usage of the synthetic `attr=` writer" do
+      # `board=` is exposed as a target method (the attr writer). A
+      # `column.board = value` with `column : Column` is just a call to it.
+      source = <<~RUBY
+        column = build_column
+        assigned = build_board
+        column.board = assigned
+      RUBY
+      usages = collect_method_usages(
+        source,
+        target_class: "Column",
+        target_methods: { "board=" => ["board"] },
+        local_var_types: { "column" => "Column", "assigned" => "Board" }
+      )
+      expect(usages["board="]).to eq([{ "board" => "Board" }])
+    end
+
+    it "ignores the setter when the receiver is not the target class" do
+      source = <<~RUBY
+        other = build_other
+        assigned = build_board
+        other.board = assigned
+      RUBY
+      usages = collect_method_usages(
+        source,
+        target_class: "Column",
+        target_methods: { "board=" => ["board"] },
+        local_var_types: { "other" => "Widget", "assigned" => "Board" }
+      )
+      expect(usages).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
## Goal

Close out the `Column#board` investigation: make it infer **`Board?`** instead of `untyped`. `board` is an `attr_accessor` never assigned in `initialize` — it's set only from outside via `column.board = board`. Two pieces were missing: the **type** (from the external setter) and the **`?`** (never initialized).

## Approach (Option A — reuse the call-inference machinery)

`attr_accessor :board` defines a `board=` method, and `column.board = board` is just a call to it. So rather than a parallel "setter scan", this goes through the **existing** cross-class call-site inference:

- **Collect** — attr writers are exposed as synthetic target methods (`extract_attr_writer_methods`), so `infer_method_param_types_from_callers` types their argument like any other method parameter. That inherits all of `NewCallCollector`'s receiver resolution, Steep local-var typing, callback self-narrowing, and cross-file union **for free** — no new matching logic in the hot path.
- **Route + nilablize** — `apply_external_setter_attr_types` maps the inferred `board=` parameter back to the attr and applies the definite-init `| nil` via `collect_prism_initialized_ivars` (now public). An `attr_accessor` whose ivar is never initialized is nilable (its getter observes the pre-assignment `nil`); a pure `attr_writer` keeps the bare accepted type.

This is the principled path per `prefer-principled-over-shortcuts.md`: a setter *is* a method, so we reuse the method-param machinery instead of re-deriving a slice of it.

## Result

`Column#board`: `untyped` → **`Board?`**. Integration blast radius is exactly one model (`example.rbs`); no other snapshot moved.

## Intended side effect

With `board: Board?`, the unguarded `board.user_name` in `set_default_user_name` becomes a **visible nil-deref** — the exact `Type (::Board | nil) does not have method …` pattern this whole thread is about. Per your call, it's recorded in the steep baseline and as a `not_nil` contract (alongside the pre-existing equivalent `post/notifiable.rb` `(::User | nil)`), documenting the full scenario end-to-end in the dummy app rather than hiding it.

## Tests

- `new_call_collector_spec`: `receiver.attr = value` is captured as a `attr=` usage when the receiver is the target class, and ignored otherwise.
- Updated `example.rbs` expectation + `sig/rbs_infer` fixture (`board: Board?`), steep baseline (+1 error), steep contracts (+1 `not_nil`).
- Green: **611 unit + 56 integration**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)