### PR TITLE
fix(cli): include input files in source_files for call-site resolution

### DIFF
--- a/bin/rbs_infer
+++ b/bin/rbs_infer
@@ -66,7 +66,13 @@ if files.empty?
   exit 1
 end
 
-source_files = Dir["app/**/*.rb", "engines/**/*.rb", "lib/**/*.rb"]
+# `source_files` é o corpus varrido para resolver call-sites (`.new`,
+# setter externo, wrappers de forwarding). Precisa incluir os arquivos de
+# INPUT, não só o layout Rails: quando o caller de um `.new` vive fora de
+# `app/`/`engines/`/`lib/` — p.ex. o pseudo-código AR-runtime sob `sig/` —
+# o call-site ficava invisível e a inferência de param/getter degradava
+# para `untyped`. Unir input + layout padrão cobre os dois casos.
+source_files = (files + Dir["app/**/*.rb", "engines/**/*.rb", "lib/**/*.rb"]).uniq
 
 rails_project = Gem::Specification.find_by_name("rails") rescue nil
 

--- a/spec/bin/rbs_infer_spec.rb
+++ b/spec/bin/rbs_infer_spec.rb
@@ -255,4 +255,49 @@ RSpec.describe "bin/rbs_infer" do
       expect(stderr).not_to include("Warning")
     end
   end
+
+  # ─── Callers fora do layout Rails (input entra no source_files) ──────
+  #
+  # `source_files` (o corpus de resolução de call-sites) precisa incluir os
+  # arquivos de input, não só `app/`/`engines/`/`lib/`. Quando o caller de um
+  # `.new` vive fora desse layout — p.ex. o pseudo-código AR-runtime sob
+  # `sig/` — o call-site tem que continuar visível, senão a inferência de
+  # param/getter degrada para `untyped`.
+  describe "com callers fora de app/ (input no source_files)" do
+    def setup_pseudo_project
+      write_file("pseudo/widget.rb", <<~RUBY)
+        class Widget
+          attr_reader :name
+
+          def initialize(name:)
+            self.name = name
+          end
+
+          private
+
+          attr_writer :name
+        end
+      RUBY
+
+      # O ÚNICO caller de `Widget.new` vive sob `pseudo/`, fora de app/lib/engines.
+      write_file("pseudo/factory.rb", <<~RUBY)
+        class Factory
+          def build
+            Widget.new(name: "hi")
+          end
+        end
+      RUBY
+    end
+
+    it "infere o param do initialize a partir de um caller fora de app/" do
+      setup_pseudo_project
+      stdout, _stderr, status = run_rbs_infer("pseudo", dir: @tmpdir)
+
+      expect(status).to be_success
+      # Sem o input no source_files, o call-site em pseudo/factory.rb some e o
+      # param cai para `untyped`. Com a correção, resolve para String.
+      expect(stdout).to include("def initialize: (name: String) -> void")
+      expect(stdout).not_to include("name: untyped")
+    end
+  end
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_ar_runtime/Assignment.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_ar_runtime/Assignment.rbs
@@ -1,0 +1,4 @@
+class Assignment
+  def save: (**untyped) -> bool
+  def run_before_validation_callbacks: () -> untyped
+end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_ar_runtime/Post.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_ar_runtime/Post.rbs
@@ -1,0 +1,3 @@
+class Post
+  def assignments: () -> Post_Assignment::ActiveRecord_Associations_CollectionProxy
+end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_ar_runtime/Post_Assignment.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_ar_runtime/Post_Assignment.rbs
@@ -1,0 +1,10 @@
+module Post_Assignment
+  class ActiveRecord_Associations_CollectionProxy
+    @owner: Post
+    def initialize: (Assignment klass, Post owner) -> void
+    def owner: () -> Post
+    def build: (*untyped) -> ::Assignment
+    def create: (*untyped) -> ::Assignment
+    def create!: (*untyped) -> ::Assignment
+  end
+end


### PR DESCRIPTION
## Problema

A CLL (`bin/rbs_infer`) fixa o corpus de resolução de call-sites em:

```ruby
source_files = Dir["app/**/*.rb", "engines/**/*.rb", "lib/**/*.rb"]
```

Esse `source_files` é o que o `Analyzer` varre para achar `.new` / setter externo / wrappers de forwarding. Ele é **desacoplado dos paths de input**: quando o caller de um `.new` vive **fora** de `app/`/`engines/`/`lib/`, o call-site fica invisível e a inferência de param/getter degrada para `untyped`.

Caso concreto: `cd spec/dummy && rbs_infer sig/ --output`. O caller do proxy de associação está no pseudo-código AR-runtime `sig/generated/steep_ar_runtime/Post.rb`:

```ruby
class Post
  def assignments
    Post_Assignment::ActiveRecord_Associations_CollectionProxy.new(Assignment, self)
  end
end
```

Como `Post.rb` está sob `sig/` (fora do glob), o `.new(Assignment, self)` nunca é encontrado, e o proxy sai com `def initialize: (untyped klass, untyped owner)` / `def owner: () -> untyped`.

Prova (Analyzer-API, passando o caller no `source_files` explicitamente):

```
class Proxy
  def initialize: (untyped klass, Post owner) -> void
  def owner: () -> Post
end
```

→ `owner` resolve para `Post` (do `self` em `Post#assignments`). O `klass` fica `untyped` por ser uma constante-de-classe nua como arg (limitação separada).

## Correção

Unir os arquivos de input ao corpus:

```ruby
source_files = (files + Dir["app/**/*.rb", "engines/**/*.rb", "lib/**/*.rb"]).uniq
```

Apontar o rbs_infer para qualquer diretório (`sig/`, dir custom) passa a manter os callers no escopo. Os globs do layout Rails são preservados, então runs normais em `app/` não mudam (o input já está sob `app/**`).

## Testes

Novo describe em `spec/bin/rbs_infer_spec.rb`: um projeto onde o único caller de `Widget.new` vive sob `pseudo/` (fora de app/lib/engines); sem o fix o param cai para `untyped`, com o fix resolve para `String`. Verificado que o spec **falha sem** a correção. Suite da CLI verde (16/16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)