### PR TITLE
fix(inference): resolve a class/module argument to its singleton type

### DIFF
--- a/lib/rbs_infer/inference/constant_arg_type_resolver.rb
+++ b/lib/rbs_infer/inference/constant_arg_type_resolver.rb
@@ -1,13 +1,15 @@
 module RbsInfer::Inference
   # Resolves a constant used as a method ARGUMENT to its VALUE's RBS type
-  # (felixefelip/rbs_infer#46). A bare name is a valid type only for a
-  # class/module (`foo(User)` → `User`); a value constant (`CODE_LENGTH = 6`)
-  # is not, so it must resolve to its value's type (`Integer`).
+  # (felixefelip/rbs_infer#46). A class/module reference passed as an argument
+  # (`foo(User)`) is the class OBJECT, so its type is `singleton(User)` — NOT
+  # the instance `User`. A value constant (`CODE_LENGTH = 6`) resolves to its
+  # value's type (`Integer`).
   #
   # Two tiers: the referencing source's own constants (`constant_types`,
-  # precise), then the RBS environment (`constant_type_from_env`: stdlib,
-  # gems, generated `sig/`) for cross-file constants. A class/module isn't a
-  # constant declaration, so it resolves to nothing and keeps its name;
+  # precise — captures value `:casgn`s, not class defs), then the RBS
+  # environment (`constant_type_from_env`: stdlib, gems, generated `sig/`) for
+  # cross-file constants. A class/module isn't a value-constant declaration, so
+  # `constant_type_from_env` misses it and we emit `singleton(<name>)`;
   # anything else unresolved → nil → caller emits `untyped`.
   class ConstantArgTypeResolver
     # caller_constant_types: bare-name => type for constants defined in the
@@ -21,9 +23,10 @@ module RbsInfer::Inference
       @caller_constant_types = caller_constant_types
     end
 
-    # Returns a valid RBS type (value type, or the name for a class/module),
-    # or nil when nothing resolved — never an unresolved value-constant name,
-    # which is invalid RBS and poisons the shared env.
+    # Returns a valid RBS type (value type, or `singleton(...)` for a
+    # class/module reference), or nil when nothing resolved — never an
+    # unresolved value-constant name, which is invalid RBS and poisons the
+    # shared env.
     def resolve(name:, namespace:)
       return nil if name.nil?
 
@@ -39,7 +42,7 @@ module RbsInfer::Inference
       return nil unless @steep_bridge
 
       @steep_bridge.constant_type_from_env(bare, namespace: namespace) ||
-        (@steep_bridge.class_or_module?(bare, namespace: namespace) ? name : nil)
+        (@steep_bridge.class_or_module?(bare, namespace: namespace) ? "singleton(#{name})" : nil)
     end
   end
 end

--- a/spec/dummy/app/helpers/posts_helper.rb
+++ b/spec/dummy/app/helpers/posts_helper.rb
@@ -19,7 +19,8 @@ module PostsHelper
   # constant must take the constant's VALUE type, not its bare name (which
   # is invalid RBS for a value constant). `Palette::WEIGHTS` is `Array[Integer]`
   # and `Coupon::CODE_LENGTH` is `Integer` — both resolved cross-file via the
-  # RBS env. A class/module default (`Palette`) keeps its name.
+  # RBS env. A class/module default (`Palette`) is the class object, so it
+  # takes the `singleton(Palette)` type.
   def post_weights(weights = Palette::WEIGHTS, length = Coupon::CODE_LENGTH, klass = Palette)
     content_tag(:p, "#{weights.sum} #{length} #{klass}")
   end

--- a/spec/expectations/helpers/posts_helper.rbs
+++ b/spec/expectations/helpers/posts_helper.rbs
@@ -1,6 +1,6 @@
 module PostsHelper
   def post_status_badge: ((Post & Post::Validated | Post) post) -> String
   def post_summary: ((Post & Post::Validated | Post) post, ?Integer length) -> String
-  def post_weights: (?Array[Integer] weights, ?Integer length, ?Palette klass) -> String
+  def post_weights: (?Array[Integer] weights, ?Integer length, ?singleton(Palette) klass) -> String
   def post_index_marker: (Post & Post::Validated post) -> String
 end

--- a/spec/lib/rbs_infer/inference/constant_arg_type_resolver_spec.rb
+++ b/spec/lib/rbs_infer/inference/constant_arg_type_resolver_spec.rb
@@ -33,10 +33,12 @@ RSpec.describe RbsInfer::Inference::ConstantArgTypeResolver do
       expect(resolver.resolve(name: "Settings::CODE_LEN", namespace: "Widget")).to eq("Integer")
     end
 
-    it "keeps the bare name for a class/module reference" do
+    it "resolves a class/module reference to its singleton type" do
+      # `foo(User)` passes the class object, whose value type is
+      # `singleton(User)` — not the instance `User`.
       bridge = FakeBridge.new({}, ["User"])
       resolver = described_class.new(steep_bridge: bridge, caller_constant_types: {})
-      expect(resolver.resolve(name: "User", namespace: nil)).to eq("User")
+      expect(resolver.resolve(name: "User", namespace: nil)).to eq("singleton(User)")
     end
 
     it "returns nil for an unresolved constant (caller emits untyped, never a poisoning bare name)" do


### PR DESCRIPTION
## Problema

`ConstantArgTypeResolver` devolvia o **nome nu** para uma classe/módulo usado como argumento:

```ruby
(@steep_bridge.class_or_module?(bare, namespace:) ? name : nil)   # "User" → tipo INSTÂNCIA ::User
```

Mas o valor passado (`foo(User)`) é o **objeto-classe**, cujo tipo é `singleton(User)`, não a instância `User`. Isso deixava, por exemplo, a proxy do AR-runtime:

```
def initialize: (Assignment klass, Post owner) -> void   # errado
def initialize: (singleton(::Assignment) klass, Post owner) -> void   # correto
```

## Correção

Envolver o ramo classe/módulo em `singleton(...)`:

```ruby
(@steep_bridge.class_or_module?(bare, namespace:) ? "singleton(#{name})" : nil)
```

Constantes de valor (`CODE_LENGTH` → `Integer`) e não-resolvidas (→ untyped) não mudam.

## Testes

- `constant_arg_type_resolver_spec.rb`: o caso classe/módulo passa a esperar `singleton(User)`.
- Snapshot: `PostsHelper#post_weights` (default `klass = Palette`) agora tipa `singleton(Palette)`; expectation e comentário do fixture atualizados. Teste do PostsHelper verde.

## Nota sobre a suite de integração

`rails_dummy_spec` tem **8 falhas pré-existentes de ambiente** neste sandbox — o `main` limpo (sem este fix) já falha as mesmas 8 (User/Post/PostsController/Taggable/TagDestroy/3 ERB), porque a resolução de RBS de gems/Rails aqui difere de onde os snapshots foram gerados. Verifiquei que **este fix afeta só o `PostsHelper`** (único `+singleton` no diff; as demais diferenças são `→ untyped` ambientais). Por isso atualizei **apenas** a expectation do `posts_helper` — as outras 8 são pré-existentes e devem ser regeneradas num ambiente limpo (CI), fora do escopo deste PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)