### PR TITLE
feat(ar-runtime): model belongs_to `default:` lambdas as a before_validation save flow

### DIFF
--- a/lib/rbs_infer/extensions/rails/active_record/runtime/pseudo_code_builder.rb
+++ b/lib/rbs_infer/extensions/rails/active_record/runtime/pseudo_code_builder.rb
@@ -62,12 +62,20 @@ module RbsInfer
               end
             end
 
-            # class_name => { callbacks: [...], getters: [{ name:, proxy:, element: }, ...] }
+            # class_name => { callbacks: [...], belongs_to_defaults: [BelongsTo],
+            #                 getters: [{ name:, proxy:, element: }, ...] }
             def reopen_plan
-              plan = Hash.new { |h, k| h[k] = { callbacks: [], getters: [] } }
+              plan = Hash.new { |h, k| h[k] = { callbacks: [], belongs_to_defaults: [], getters: [] } }
 
               @models.each do |model|
                 plan[model.class_name][:callbacks] = model.before_validation_callbacks if model.before_validation_callbacks.any?
+
+                # A `belongs_to ... default: -> { expr }` runs `expr` in a
+                # before_validation callback with `self` = the record, so its
+                # nilable-belongs_to deref becomes reachable from `save` — the
+                # same flow as a named callback.
+                defaults = model.belongs_to.select(&:default_body)
+                plan[model.class_name][:belongs_to_defaults] = defaults if defaults.any?
 
                 model.has_many.each do |assoc|
                   # Emit a getter for EVERY has_many whose element is a known
@@ -91,13 +99,35 @@ module RbsInfer
 
             def class_source(class_name, info)
               body = []
-              if info[:callbacks].any?
+              defaults = info[:belongs_to_defaults]
+              if info[:callbacks].any? || defaults.any?
                 # `save(**)` matches the real `save: (?context:, ?validate:,
-                # ?touch:) -> bool`; it runs the before_validation callbacks so
-                # their nilable-belongs_to deref is reachable from `save`.
+                # ?touch:) -> bool`; it runs the before_validation callbacks (the
+                # named ones and the belongs_to `default:` lambdas) so their
+                # nilable-belongs_to deref is reachable from `save`.
+                rbvc = info[:callbacks].dup
+                rbvc << "run_belongs_to_default_callbacks" if defaults.any?
+
                 body.concat(method_lines("save", "**") { ["run_before_validation_callbacks", "true"] })
                 body << ""
-                body.concat(method_lines("run_before_validation_callbacks") { info[:callbacks] })
+                body.concat(method_lines("run_before_validation_callbacks") { rbvc })
+
+                if defaults.any?
+                  # `default: -> { expr }` sets the association if unset, so
+                  # `self.<assoc> ||= expr` models `writer(...) if reader.nil?`;
+                  # `expr`'s deref (`post.user`) narrows once `save` enforces the
+                  # inferred precondition, exactly like a named callback.
+                  body << ""
+                  body.concat(method_lines("run_belongs_to_default_callbacks") do
+                    defaults.map { |b| "run_belongs_to_default_#{b.name}" }
+                  end)
+                  defaults.each do |b|
+                    body << ""
+                    body.concat(method_lines("run_belongs_to_default_#{b.name}") do
+                      ["self.#{b.name} ||= #{b.default_body}"]
+                    end)
+                  end
+                end
               end
               info[:getters].each do |getter|
                 body << "" unless body.empty?

--- a/lib/rbs_infer/extensions/rails/active_record/runtime/reflection_scanner.rb
+++ b/lib/rbs_infer/extensions/rails/active_record/runtime/reflection_scanner.rb
@@ -8,7 +8,7 @@ module RbsInfer
     module Rails
       module ActiveRecord
         module Runtime
-          BelongsTo = Struct.new(:name, :class_name, keyword_init: true)
+          BelongsTo = Struct.new(:name, :class_name, :default_body, keyword_init: true)
           HasMany   = Struct.new(:name, :class_name, keyword_init: true)
 
           # One model's reflections relevant to the AR-runtime pseudo-code:
@@ -56,7 +56,11 @@ module RbsInfer
                 case call.name
                 when :belongs_to
                   name = first_symbol(call) or next
-                  belongs_to << BelongsTo.new(name: name, class_name: belongs_to_class(name, call))
+                  belongs_to << BelongsTo.new(
+                    name: name,
+                    class_name: belongs_to_class(name, call),
+                    default_body: default_expr_source(call)
+                  )
                 when :has_many
                   name = first_symbol(call) or next
                   has_many << HasMany.new(name: name, class_name: has_many_class(name, call))
@@ -105,6 +109,29 @@ module RbsInfer
 
             def belongs_to_class(name, call)
               string_kwarg(call, "class_name") || name.camelize
+            end
+
+            # The source of a `default: -> { expr }` lambda's single-expression
+            # body (`"post.user"`), for the AR-runtime generator to reopen as a
+            # real before_validation method (`self.<assoc> ||= post.user`) that
+            # the contract machinery can narrow (felixefelip/rbs_infer#XXX).
+            # nil unless `default:` is a one-expression lambda.
+            def default_expr_source(call)
+              hash = call.arguments.arguments.find { |a| a.is_a?(Prism::KeywordHashNode) }
+              return nil unless hash
+
+              assoc = hash.elements.find do |elem|
+                elem.is_a?(Prism::AssocNode) && elem.key.is_a?(Prism::SymbolNode) && elem.key.value.to_s == "default"
+              end
+              return nil unless assoc
+
+              node = assoc.value
+              return nil unless node.is_a?(Prism::LambdaNode)
+
+              body = node.body
+              return nil unless body.is_a?(Prism::StatementsNode) && body.body.size == 1
+
+              body.body.first.slice
             end
 
             def has_many_class(name, call)

--- a/spec/dummy/.gem_rbs_collection/actioncable/7.1/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/actioncable/7.1/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '7.1'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/actionmailer/7.0/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/actionmailer/7.0/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '7.0'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/actionpack/7.2/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/actionpack/7.2/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '7.2'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/actiontext/7.2/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/actiontext/7.2/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '7.2'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/actionview/6.0/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/actionview/6.0/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '6.0'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/activejob/6.0/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/activejob/6.0/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '6.0'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/activemodel/7.1/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/activemodel/7.1/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '7.1'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/activerecord/8.0/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/activerecord/8.0/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '8.0'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/activerecord/8.0/activerecord.rbs
+++ b/spec/dummy/.gem_rbs_collection/activerecord/8.0/activerecord.rbs
@@ -42,11 +42,16 @@ module ActiveRecord
     extend ::ActiveRecord::Validations::ClassMethods
     extend ::ActiveSupport::Callbacks::ClassMethods
 
-    # type belongs_to_default[T] = ^(T) [self: untyped] -> untyped
+    # The `default:` block runs via `owner.instance_exec(&block)`, so its self is
+    # the record — but binding self to the concrete model type would type-check
+    # the block body (e.g. `-> { post.user }`) and flag any nilable association
+    # deref inside it. The block is framework-driven and not something the app
+    # writes to a signature, so its self and result are left untyped.
+    type belongs_to_default = ^(untyped) [self: untyped] -> untyped
 
     def self.abstract_class=: (bool) -> void
     def self.scope: (Symbol, Proc) ?{ () -> untyped } -> void
-    def self.belongs_to: (Symbol, ?untyped, **untyped, ?default: (^(untyped) [self: untyped] -> untyped)) -> void
+    def self.belongs_to: (Symbol, ?untyped, **untyped, ?default: belongs_to_default) -> void
     def self.has_many: (Symbol, ?untyped, **untyped) -> void
     def self.has_one: (Symbol, ?untyped, **untyped) -> void
     def self.has_and_belongs_to_many: (untyped name, ?untyped? scope, **untyped options) ?{ () -> untyped } -> untyped
@@ -511,6 +516,49 @@ module ActiveRecord
       def count: () -> ::Integer
                | () { (Model) -> boolish } -> ::Integer
                | (Symbol | String column_name) -> ::Integer
+
+      # Array-positional & collection methods that `ActiveRecord::Delegation`
+      # delegates to `records` (an `Array[Model & ValidatedModel]`). `Enumerable`
+      # can't provide these (they aren't derivable from `each`), so they must be
+      # declared here to be type-checkable on every Relation and CollectionProxy.
+      def []: (Integer index) -> (Model & ValidatedModel)?
+            | (Integer start, Integer length) -> Array[Model & ValidatedModel]?
+            | (Range[Integer] range) -> Array[Model & ValidatedModel]?
+      def slice: (Integer index) -> (Model & ValidatedModel)?
+               | (Integer start, Integer length) -> Array[Model & ValidatedModel]?
+               | (Range[Integer] range) -> Array[Model & ValidatedModel]?
+      def length: () -> ::Integer
+      def size: () -> ::Integer
+      def to_ary: () -> Array[Model & ValidatedModel]
+      def index: (untyped value) -> ::Integer?
+               | () { (Model & ValidatedModel) -> boolish } -> ::Integer?
+      def rindex: (untyped value) -> ::Integer?
+                | () { (Model & ValidatedModel) -> boolish } -> ::Integer?
+      def sample: () -> (Model & ValidatedModel)?
+                | (Integer n, ?random: untyped) -> Array[Model & ValidatedModel]
+      def reverse: () -> Array[Model & ValidatedModel]
+      def rotate: (?Integer count) -> Array[Model & ValidatedModel]
+      def shuffle: (?random: untyped) -> Array[Model & ValidatedModel]
+      def &: (untyped other) -> Array[Model & ValidatedModel]
+      def -: (untyped other) -> Array[Model & ValidatedModel]
+      def |: (untyped other) -> Array[untyped]
+      def +: (untyped other) -> Array[untyped]
+      def intersect?: (untyped other) -> bool
+      def in_groups: (Integer number, ?untyped fill_with) -> Array[Array[(Model & ValidatedModel)?]]
+                   | (Integer number, ?untyped fill_with) { (Array[(Model & ValidatedModel)?]) -> void } -> Array[Array[(Model & ValidatedModel)?]]
+      def in_groups_of: (Integer number, ?untyped fill_with) -> Array[Array[(Model & ValidatedModel)?]]
+                      | (Integer number, ?untyped fill_with) { (Array[(Model & ValidatedModel)?]) -> void } -> Array[Array[(Model & ValidatedModel)?]]
+      def split: (?untyped value) -> Array[Array[Model & ValidatedModel]]
+               | () { (Model & ValidatedModel) -> boolish } -> Array[Array[Model & ValidatedModel]]
+
+      # Serialization / string rendering, also delegated to `records`.
+      def join: (?untyped separator) -> ::String
+      def to_sentence: (?untyped options) -> ::String
+      def to_fs: (?untyped format) -> ::String
+      def to_formatted_s: (?untyped format) -> ::String
+      def to_xml: (?untyped options) -> ::String
+      def as_json: (?untyped options) -> untyped
+      def encode_with: (untyped coder) -> void
     end
   end
 

--- a/spec/dummy/.gem_rbs_collection/activerecord/8.0/activerecord.rbs
+++ b/spec/dummy/.gem_rbs_collection/activerecord/8.0/activerecord.rbs
@@ -42,11 +42,11 @@ module ActiveRecord
     extend ::ActiveRecord::Validations::ClassMethods
     extend ::ActiveSupport::Callbacks::ClassMethods
 
-    type belongs_to_default[T] = ^(T) [self: T] -> ::ActiveRecord::Base?
+    # type belongs_to_default[T] = ^(T) [self: untyped] -> untyped
 
     def self.abstract_class=: (bool) -> void
     def self.scope: (Symbol, Proc) ?{ () -> untyped } -> void
-    def self.belongs_to: (Symbol, ?untyped, **untyped, ?default: belongs_to_default[instance]) -> void
+    def self.belongs_to: (Symbol, ?untyped, **untyped, ?default: (^(untyped) [self: untyped] -> untyped)) -> void
     def self.has_many: (Symbol, ?untyped, **untyped) -> void
     def self.has_one: (Symbol, ?untyped, **untyped) -> void
     def self.has_and_belongs_to_many: (untyped name, ?untyped? scope, **untyped options) ?{ () -> untyped } -> untyped

--- a/spec/dummy/.gem_rbs_collection/activestorage/7.0/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/activestorage/7.0/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '7.0'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/activesupport/7.0/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/activesupport/7.0/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '7.0'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/activesupport/7.0/activesupport-generated.rbs
+++ b/spec/dummy/.gem_rbs_collection/activesupport/7.0/activesupport-generated.rbs
@@ -2192,13 +2192,13 @@ class Date
   def self.find_beginning_of_week!: (untyped week_start) -> untyped
 
   # Returns a new Date representing the date 1 day ago (i.e. yesterday's date).
-  def self.yesterday: () -> untyped
+  def self.yesterday: () -> Date
 
   # Returns a new Date representing the date 1 day after today (i.e. tomorrow's date).
-  def self.tomorrow: () -> untyped
+  def self.tomorrow: () -> Date
 
   # Returns Time.zone.today when <tt>Time.zone</tt> or <tt>config.time_zone</tt> are set, otherwise just returns Date.today.
-  def self.current: () -> untyped
+  def self.current: () -> Date
 
   # Converts Date to a Time (or DateTime if necessary) with the time portion set to the beginning of the day (0:00)
   # and then subtracts the specified number of seconds.

--- a/spec/dummy/.gem_rbs_collection/addressable/2.8/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/addressable/2.8/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '2.8'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/ast/2.4/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/ast/2.4/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '2.4'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/bigdecimal/4.0/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/bigdecimal/4.0/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '4.0'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 932252528636d0c07b8430cf167f1a77c1e23cf0
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/carrierwave/3.0/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/carrierwave/3.0/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '3.0'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/cgi/0.5/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/cgi/0.5/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '0.5'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/concurrent-ruby/1.1/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/concurrent-ruby/1.1/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '1.1'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/concurrent-ruby/1.1/errors.rbs
+++ b/spec/dummy/.gem_rbs_collection/concurrent-ruby/1.1/errors.rbs
@@ -1,0 +1,7 @@
+module Concurrent
+  class Error < StandardError
+  end
+
+  class RejectedExecutionError < Error
+  end
+end

--- a/spec/dummy/.gem_rbs_collection/concurrent-ruby/1.1/executor.rbs
+++ b/spec/dummy/.gem_rbs_collection/concurrent-ruby/1.1/executor.rbs
@@ -23,4 +23,29 @@ module Concurrent
 
   def self.new_io_executor: (?Hash[Symbol, untyped] opts) -> ExecutorService
   def self.new_fast_executor: (?Hash[Symbol, untyped] opts) -> ExecutorService
+
+  class AbstractExecutorService
+    include ExecutorService
+
+    def shutdown: () -> void
+    def kill: () -> void
+    def wait_for_termination: (?Numeric? timeout) -> bool
+    def running?: () -> bool
+    def shuttingdown?: () -> bool
+    def shutdown?: () -> bool
+  end
+
+  class RubyExecutorService < AbstractExecutorService
+  end
+
+  class RubyThreadPoolExecutor < RubyExecutorService
+    def initialize: (?Hash[Symbol, untyped] opts) -> void
+  end
+
+  class ThreadPoolExecutor < RubyThreadPoolExecutor
+  end
+
+  class FixedThreadPool < ThreadPoolExecutor
+    def initialize: (Integer num_threads, ?Hash[Symbol, untyped] opts) -> void
+  end
 end

--- a/spec/dummy/.gem_rbs_collection/connection_pool/2.4/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/connection_pool/2.4/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '2.4'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/csv/3.3/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/csv/3.3/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '3.3'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/enumerize/2.5/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/enumerize/2.5/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '2.5'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/globalid/1.1/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/globalid/1.1/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '1.1'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/i18n/1.10/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/i18n/1.10/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '1.10'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/listen/3.9/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/listen/3.9/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '3.9'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/logger/1.7/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/logger/1.7/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '1.7'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/loofah/2.0/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/loofah/2.0/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '2.0'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/mail/2.8/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/mail/2.8/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '2.8'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/marcel/1.0/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/marcel/1.0/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '1.0'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/mini_magick/5.0/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/mini_magick/5.0/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '5.0'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/mini_mime/0.1/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/mini_mime/0.1/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '0.1'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/minitest/5.25/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/minitest/5.25/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '5.25'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/net-smtp/0.5/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/net-smtp/0.5/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '0.5'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/nokogiri/1.11/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/nokogiri/1.11/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '1.11'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/parser/3.2/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/parser/3.2/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '3.2'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/parser/3.2/parser.rbs
+++ b/spec/dummy/.gem_rbs_collection/parser/3.2/parser.rbs
@@ -55,6 +55,7 @@ module Parser
       attr_reader source_buffer: Buffer
       attr_reader begin_pos: Integer
       attr_reader end_pos: Integer
+      def initialize: (Buffer buffer, Integer begin_pos, Integer end_pos) -> void
       def begin: () -> Range
       def end: () -> Range
       def size: () -> Integer
@@ -113,8 +114,8 @@ module Parser
       def decompose_position: (Integer) -> [Integer, Integer]
       def source_lines: () -> Array[String]
       def source_line: (Integer) -> String
-      def line_range: (Integer) -> ::Range[Integer]
-      def source_range: () -> ::Range[Integer]
+      def line_range: (Integer) -> Range
+      def source_range: () -> Range
       def last_line: () -> Integer
     end
 

--- a/spec/dummy/.gem_rbs_collection/pstore/0.2/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/pstore/0.2/.rbs_meta.yaml
@@ -1,6 +1,6 @@
 ---
-name: tzinfo
-version: '2.0'
+name: pstore
+version: '0.2'
 source:
   type: git
   name: ruby/gem_rbs_collection

--- a/spec/dummy/.gem_rbs_collection/pstore/0.2/pstore.rbs
+++ b/spec/dummy/.gem_rbs_collection/pstore/0.2/pstore.rbs
@@ -1,0 +1,608 @@
+# <!-- rdoc-file=lib/pstore.rb -->
+# PStore implements a file based persistence mechanism based on a Hash. User
+# code can store hierarchies of Ruby objects (values) into the data store by
+# name (keys). An object hierarchy may be just a single object. User code may
+# later read values back from the data store or even update data, as needed.
+#
+# The transactional behavior ensures that any changes succeed or fail together.
+# This can be used to ensure that the data store is not left in a transitory
+# state, where some values were updated but others were not.
+#
+# Behind the scenes, Ruby objects are stored to the data store file with
+# Marshal. That carries the usual limitations. Proc objects cannot be
+# marshalled, for example.
+#
+# There are three important concepts here (details at the links):
+#
+# *   [Store](rdoc-ref:PStore@The+Store): a store is an instance of PStore.
+# *   [Entries](rdoc-ref:PStore@Entries): the store is hash-like; each entry is
+#     the key for a stored object.
+# *   [Transactions](rdoc-ref:PStore@Transactions): each transaction is a
+#     collection of prospective changes to the store; a transaction is defined
+#     in the block given with a call to PStore#transaction.
+#
+# ## About the Examples
+#
+# Examples on this page need a store that has known properties. They can get a
+# new (and populated) store by calling thus:
+#
+#     example_store do |store|
+#       # Example code using store goes here.
+#     end
+#
+# All we really need to know about `example_store` is that it yields a fresh
+# store with a known population of entries; its implementation:
+#
+#     require 'pstore'
+#     require 'tempfile'
+#     # Yield a pristine store for use in examples.
+#     def example_store
+#       # Create the store in a temporary file.
+#       Tempfile.create do |file|
+#         store = PStore.new(file)
+#         # Populate the store.
+#         store.transaction do
+#           store[:foo] = 0
+#           store[:bar] = 1
+#           store[:baz] = 2
+#         end
+#         yield store
+#       end
+#     end
+#
+# ## The Store
+#
+# The contents of the store are maintained in a file whose path is specified
+# when the store is created (see PStore.new). The objects are stored and
+# retrieved using module Marshal, which means that certain objects cannot be
+# added to the store; see [Marshal::dump](rdoc-ref:Marshal.dump).
+#
+# ## Entries
+#
+# A store may have any number of entries. Each entry has a key and a value, just
+# as in a hash:
+#
+# *   Key: as in a hash, the key can be (almost) any object; see [Hash
+#     Keys](rdoc-ref:Hash@Hash+Keys). You may find it convenient to keep it
+#     simple by using only symbols or strings as keys.
+# *   Value: the value may be any object that can be marshalled by Marshal (see
+#     [Marshal::dump](rdoc-ref:Marshal.dump)) and in fact may be a collection
+#     (e.g., an array, a hash, a set, a range, etc). That collection may in turn
+#     contain nested objects, including collections, to any depth; those objects
+#     must also be Marshal-able. See [Hierarchical
+#     Values](rdoc-ref:PStore@Hierarchical+Values).
+#
+# ## Transactions
+#
+# ### The Transaction Block
+#
+# The block given with a call to method #transaction# contains a *transaction*,
+# which consists of calls to PStore methods that read from or write to the store
+# (that is, all PStore methods except #transaction itself, #path, and
+# Pstore.new):
+#
+#     example_store do |store|
+#       store.transaction do
+#         store.keys # => [:foo, :bar, :baz]
+#         store[:bat] = 3
+#         store.keys # => [:foo, :bar, :baz, :bat]
+#       end
+#     end
+#
+# Execution of the transaction is deferred until the block exits, and is
+# executed *atomically* (all-or-nothing): either all transaction calls are
+# executed, or none are. This maintains the integrity of the store.
+#
+# Other code in the block (including even calls to #path and PStore.new) is
+# executed immediately, not deferred.
+#
+# The transaction block:
+#
+# *   May not contain a nested call to #transaction.
+# *   Is the only context where methods that read from or write to the store are
+#     allowed.
+#
+# As seen above, changes in a transaction are made automatically when the block
+# exits. The block may be exited early by calling method #commit or #abort.
+#
+# *   Method #commit triggers the update to the store and exits the block:
+#
+#         example_store do |store|
+#           store.transaction do
+#             store.keys # => [:foo, :bar, :baz]
+#             store[:bat] = 3
+#             store.commit
+#             fail 'Cannot get here'
+#           end
+#           store.transaction do
+#             # Update was completed.
+#             store.keys # => [:foo, :bar, :baz, :bat]
+#           end
+#         end
+#
+# *   Method #abort discards the update to the store and exits the block:
+#
+#         example_store do |store|
+#           store.transaction do
+#             store.keys # => [:foo, :bar, :baz]
+#             store[:bat] = 3
+#             store.abort
+#             fail 'Cannot get here'
+#           end
+#           store.transaction do
+#             # Update was not completed.
+#             store.keys # => [:foo, :bar, :baz]
+#           end
+#         end
+#
+# ### Read-Only Transactions
+#
+# By default, a transaction allows both reading from and writing to the store:
+#
+#     store.transaction do
+#       # Read-write transaction.
+#       # Any code except a call to #transaction is allowed here.
+#     end
+#
+# If argument `read_only` is passed as `true`, only reading is allowed:
+#
+#     store.transaction(true) do
+#       # Read-only transaction:
+#       # Calls to #transaction, #[]=, and #delete are not allowed here.
+#     end
+#
+# ## Hierarchical Values
+#
+# The value for an entry may be a simple object (as seen above). It may also be
+# a hierarchy of objects nested to any depth:
+#
+#     deep_store = PStore.new('deep.store')
+#     deep_store.transaction do
+#       array_of_hashes = [{}, {}, {}]
+#       deep_store[:array_of_hashes] = array_of_hashes
+#       deep_store[:array_of_hashes] # => [{}, {}, {}]
+#       hash_of_arrays = {foo: [], bar: [], baz: []}
+#       deep_store[:hash_of_arrays] = hash_of_arrays
+#       deep_store[:hash_of_arrays]  # => {:foo=>[], :bar=>[], :baz=>[]}
+#       deep_store[:hash_of_arrays][:foo].push(:bat)
+#       deep_store[:hash_of_arrays]  # => {:foo=>[:bat], :bar=>[], :baz=>[]}
+#     end
+#
+# And recall that you can use [dig methods](rdoc-ref:dig_methods.rdoc) in a
+# returned hierarchy of objects.
+#
+# ## Working with the Store
+#
+# ### Creating a Store
+#
+# Use method PStore.new to create a store. The new store creates or opens its
+# containing file:
+#
+#     store = PStore.new('t.store')
+#
+# ### Modifying the Store
+#
+# Use method #[]= to update or create an entry:
+#
+#     example_store do |store|
+#       store.transaction do
+#         store[:foo] = 1 # Update.
+#         store[:bam] = 1 # Create.
+#       end
+#     end
+#
+# Use method #delete to remove an entry:
+#
+#     example_store do |store|
+#       store.transaction do
+#         store.delete(:foo)
+#         store[:foo] # => nil
+#       end
+#     end
+#
+# ### Retrieving Values
+#
+# Use method #fetch (allows default) or #[] (defaults to `nil`) to retrieve an
+# entry:
+#
+#     example_store do |store|
+#       store.transaction do
+#         store[:foo]             # => 0
+#         store[:nope]            # => nil
+#         store.fetch(:baz)       # => 2
+#         store.fetch(:nope, nil) # => nil
+#         store.fetch(:nope)      # Raises exception.
+#       end
+#     end
+#
+# ### Querying the Store
+#
+# Use method #key? to determine whether a given key exists:
+#
+#     example_store do |store|
+#       store.transaction do
+#         store.key?(:foo) # => true
+#       end
+#     end
+#
+# Use method #keys to retrieve keys:
+#
+#     example_store do |store|
+#       store.transaction do
+#         store.keys # => [:foo, :bar, :baz]
+#       end
+#     end
+#
+# Use method #path to retrieve the path to the store's underlying file; this
+# method may be called from outside a transaction block:
+#
+#     store = PStore.new('t.store')
+#     store.path # => "t.store"
+#
+# ## Transaction Safety
+#
+# For transaction safety, see:
+#
+# *   Optional argument `thread_safe` at method PStore.new.
+# *   Attribute #ultra_safe.
+#
+# Needless to say, if you're storing valuable data with PStore, then you should
+# backup the PStore file from time to time.
+#
+# ## An Example Store
+#
+#     require "pstore"
+#
+#     # A mock wiki object.
+#     class WikiPage
+#
+#       attr_reader :page_name
+#
+#       def initialize(page_name, author, contents)
+#         @page_name = page_name
+#         @revisions = Array.new
+#         add_revision(author, contents)
+#       end
+#
+#       def add_revision(author, contents)
+#         @revisions << {created: Time.now,
+#                        author: author,
+#                        contents: contents}
+#       end
+#
+#       def wiki_page_references
+#         [@page_name] + @revisions.last[:contents].scan(/\b(?:[A-Z]+[a-z]+){2,}/)
+#       end
+#
+#     end
+#
+#     # Create a new wiki page.
+#     home_page = WikiPage.new("HomePage", "James Edward Gray II",
+#                              "A page about the JoysOfDocumentation..." )
+#
+#     wiki = PStore.new("wiki_pages.pstore")
+#     # Update page data and the index together, or not at all.
+#     wiki.transaction do
+#       # Store page.
+#       wiki[home_page.page_name] = home_page
+#       # Create page index.
+#       wiki[:wiki_index] ||= Array.new
+#       # Update wiki index.
+#       wiki[:wiki_index].push(*home_page.wiki_page_references)
+#     end
+#
+#     # Read wiki data, setting argument read_only to true.
+#     wiki.transaction(true) do
+#       wiki.keys.each do |key|
+#         puts key
+#         puts wiki[key]
+#       end
+#     end
+#
+class PStore[unchecked out K = untyped, unchecked out V = untyped]
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - [](key)
+  # -->
+  # Returns the value for the given `key` if the key exists. `nil` otherwise; if
+  # not `nil`, the returned value is an object or a hierarchy of objects:
+  #
+  #     example_store do |store|
+  #       store.transaction do
+  #         store[:foo]  # => 0
+  #         store[:nope] # => nil
+  #       end
+  #     end
+  #
+  # Returns `nil` if there is no such key.
+  #
+  # See also [Hierarchical Values](rdoc-ref:PStore@Hierarchical+Values).
+  #
+  # Raises an exception if called outside a transaction block.
+  #
+  def []: (K name) -> V?
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - []=(key, value)
+  # -->
+  # Creates or replaces the value for the given `key`:
+  #
+  #     example_store do |store|
+  #       temp.transaction do
+  #         temp[:bat] = 3
+  #       end
+  #     end
+  #
+  # See also [Hierarchical Values](rdoc-ref:PStore@Hierarchical+Values).
+  #
+  # Raises an exception if called outside a transaction block.
+  #
+  def []=: (K name, V value) -> V
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - abort()
+  # -->
+  # Exits the current transaction block, discarding any changes specified in the
+  # [transaction block](rdoc-ref:PStore@The+Transaction+Block).
+  #
+  # Raises an exception if called outside a transaction block.
+  #
+  def abort: () -> void
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - commit()
+  # -->
+  # Exits the current transaction block, committing any changes specified in the
+  # [transaction block](rdoc-ref:PStore@The+Transaction+Block).
+  #
+  # Raises an exception if called outside a transaction block.
+  #
+  def commit: () -> void
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - delete(key)
+  # -->
+  # Removes and returns the value at `key` if it exists:
+  #
+  #     example_store do |store|
+  #       store.transaction do
+  #         store[:bat] = 3
+  #         store.delete(:bat)
+  #       end
+  #     end
+  #
+  # Returns `nil` if there is no such key.
+  #
+  # Raises an exception if called outside a transaction block.
+  #
+  def delete: (K name) -> V?
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - fetch(key, default=PStore::Error)
+  # -->
+  # Like #[], except that it accepts a default value for the store. If the `key`
+  # does not exist:
+  #
+  # *   Raises an exception if `default` is `PStore::Error`.
+  # *   Returns the value of `default` otherwise:
+  #
+  #         example_store do |store|
+  #           store.transaction do
+  #             store.fetch(:nope, nil) # => nil
+  #             store.fetch(:nope)      # Raises an exception.
+  #           end
+  #         end
+  #
+  # Raises an exception if called outside a transaction block.
+  #
+  def fetch: (K name, ?V default) -> V
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - path()
+  # -->
+  # Returns the string file path used to create the store:
+  #
+  #     store.path # => "flat.store"
+  #
+  def path: () -> String
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - root?(key)
+  # -->
+  #
+  def key?: (K name) -> bool
+
+  alias root? key?
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - roots()
+  # -->
+  #
+  def keys: () -> Array[K]
+
+  alias roots keys
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - transaction(read_only = false) { |pstore| ... }
+  # -->
+  # Opens a transaction block for the store. See
+  # [Transactions](rdoc-ref:PStore@Transactions).
+  #
+  # With argument `read_only` as `false`, the block may both read from and write
+  # to the store.
+  #
+  # With argument `read_only` as `true`, the block may not include calls to
+  # #transaction, #[]=, or #delete.
+  #
+  # Raises an exception if called within a transaction block.
+  #
+  def transaction: [U] (?bool read_only) { (self) -> U } -> U
+
+  # <!-- rdoc-file=lib/pstore.rb -->
+  # Whether PStore should do its best to prevent file corruptions, even when an
+  # unlikely error (such as memory-error or filesystem error) occurs:
+  #
+  # *   `true`: changes are posted by creating a temporary file, writing the
+  #     updated data to it, then renaming the file to the given #path. File
+  #     integrity is maintained. Note: has effect only if the filesystem has
+  #     atomic file rename (as do POSIX platforms Linux, MacOS, FreeBSD and
+  #     others).
+  #
+  # *   `false` (the default): changes are posted by rewinding the open file and
+  #     writing the updated data. File integrity is maintained if the filesystem
+  #     raises no unexpected I/O error; if such an error occurs during a write to
+  #     the store, the file may become corrupted.
+  #
+  def ultra_safe: () -> bool
+
+  # <!-- rdoc-file=lib/pstore.rb -->
+  # Whether PStore should do its best to prevent file corruptions, even when an
+  # unlikely error (such as memory-error or filesystem error) occurs:
+  #
+  # *   `true`: changes are posted by creating a temporary file, writing the
+  #     updated data to it, then renaming the file to the given #path. File
+  #     integrity is maintained. Note: has effect only if the filesystem has
+  #     atomic file rename (as do POSIX platforms Linux, MacOS, FreeBSD and
+  #     others).
+  #
+  # *   `false` (the default): changes are posted by rewinding the open file and
+  #     writing the updated data. File integrity is maintained if the filesystem
+  #     raises no unexpected I/O error; if such an error occurs during a write to
+  #     the store, the file may become corrupted.
+  #
+  def ultra_safe=: (bool) -> bool
+
+  private
+
+  def dump: (untyped table) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - empty_marshal_checksum()
+  # -->
+  #
+  def empty_marshal_checksum: () -> String
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - empty_marshal_data()
+  # -->
+  #
+  def empty_marshal_data: () -> String
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - in_transaction()
+  # -->
+  # Raises PStore::Error if the calling code is not in a PStore#transaction.
+  #
+  def in_transaction: () -> void
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - in_transaction_wr()
+  # -->
+  # Raises PStore::Error if the calling code is not in a PStore#transaction or if
+  # the code is in a read-only PStore#transaction.
+  #
+  def in_transaction_wr: () -> void
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - new(file, thread_safe = false)
+  # -->
+  # Returns a new PStore object.
+  #
+  # Argument `file` is the path to the file in which objects are to be stored; if
+  # the file exists, it should be one that was written by PStore.
+  #
+  #     path = 't.store'
+  #     store = PStore.new(path)
+  #
+  # A PStore object is
+  # [reentrant](https://en.wikipedia.org/wiki/Reentrancy_(computing)). If argument
+  # `thread_safe` is given as `true`, the object is also thread-safe (at the cost
+  # of a small performance penalty):
+  #
+  #     store = PStore.new(path, true)
+  #
+  def initialize: (path file, ?boolish thread_safe) -> void
+
+  def load: (untyped content) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - load_data(file, read_only)
+  # -->
+  # Load the given PStore file. If `read_only` is true, the unmarshalled Hash will
+  # be returned. If `read_only` is false, a 3-tuple will be returned: the
+  # unmarshalled Hash, a checksum of the data, and the size of the data.
+  #
+  def load_data: (path file, true read_only) -> Hash[untyped, untyped]
+               | (path file, false read_only) -> [Hash[untyped, untyped], String, Integer]
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - on_windows?()
+  # -->
+  #
+  def on_windows?: () -> bool
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - open_and_lock_file(filename, read_only)
+  # -->
+  # Open the specified filename (either in read-only mode or in read-write mode)
+  # and lock it for reading or writing.
+  #
+  # The opened File object will be returned. If *read_only* is true, and the file
+  # does not exist, then nil will be returned.
+  #
+  # All exceptions are propagated.
+  #
+  def open_and_lock_file: (string filename, bool read_only) -> File?
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - save_data(original_checksum, original_file_size, file)
+  # -->
+  #
+  def save_data: (untyped original_checksum, untyped original_file_size, untyped file) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - save_data_with_atomic_file_rename_strategy(data, file)
+  # -->
+  #
+  def save_data_with_atomic_file_rename_strategy: (string data, File file) -> void
+
+  # <!--
+  #   rdoc-file=lib/pstore.rb
+  #   - save_data_with_fast_strategy(data, file)
+  # -->
+  #
+  def save_data_with_fast_strategy: (string data, File file) -> void
+
+  EMPTY_MARSHAL_CHECKSUM: String
+
+  EMPTY_MARSHAL_DATA: String
+
+  EMPTY_STRING: String
+
+  RDWR_ACCESS: { mode: Integer, encoding: Encoding }
+
+  RD_ACCESS: { mode: Integer, encoding: Encoding }
+
+  VERSION: String
+
+  WR_ACCESS: { mode: Integer, encoding: Encoding }
+end

--- a/spec/dummy/.gem_rbs_collection/rack/2.2/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/rack/2.2/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '2.2'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/rails-dom-testing/2.0/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/rails-dom-testing/2.0/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '2.0'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/rails-html-sanitizer/1.6/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/rails-html-sanitizer/1.6/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '1.6'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/railties/6.0/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/railties/6.0/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '6.0'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/rainbow/3.0/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/rainbow/3.0/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '3.0'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/rake/13.0/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/rake/13.0/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '13.0'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/sqlite3/2.0/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/sqlite3/2.0/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '2.0'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/thor/1.2/.rbs_meta.yaml
+++ b/spec/dummy/.gem_rbs_collection/thor/1.2/.rbs_meta.yaml
@@ -4,6 +4,6 @@ version: '1.2'
 source:
   type: git
   name: ruby/gem_rbs_collection
-  revision: 8b8537e147d1166a4879346389c2f5e479e75680
+  revision: 4d9d8513381f344add6de90fac339953a57d142c
   remote: https://github.com/felixefelip/gem_rbs_collection.git
   repo_dir: gems

--- a/spec/dummy/.gem_rbs_collection/thor/1.2/thor.rbs
+++ b/spec/dummy/.gem_rbs_collection/thor/1.2/thor.rbs
@@ -17,7 +17,25 @@ class Thor
     attr_accessor options: Hash[String | Symbol, untyped]
   end
 
+  module Base
+    module ClassMethods
+      def class_option: (
+        Symbol | String name,
+        ?aliases: String | Symbol | Array[String | Symbol],
+        ?banner: String,
+        ?default: untyped,
+        ?desc: String,
+        ?group: untyped,
+        ?hide: untyped,
+        ?required: bool,
+        ?type: :string | :hash | :array | :numeric | :boolean,
+        **untyped
+      ) -> void
+    end
+  end
+
   include Base
+  extend Base::ClassMethods
 
   def self.desc: (
       String usage,

--- a/spec/dummy/rbs_collection.lock.yaml
+++ b/spec/dummy/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: actionmailer
@@ -14,7 +14,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: actionpack
@@ -22,7 +22,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: actiontext
@@ -30,7 +30,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: actionview
@@ -38,7 +38,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: activejob
@@ -46,7 +46,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: activemodel
@@ -54,7 +54,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: activerecord
@@ -62,7 +62,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: activestorage
@@ -70,7 +70,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: activesupport
@@ -78,7 +78,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: addressable
@@ -86,7 +86,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: ast
@@ -94,7 +94,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: base64
@@ -106,15 +106,19 @@ gems:
   source:
     type: stdlib
 - name: bigdecimal
-  version: 4.1.2
+  version: '4.0'
   source:
-    type: rubygems
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
+    remote: https://github.com/felixefelip/gem_rbs_collection.git
+    repo_dir: gems
 - name: carrierwave
   version: '3.0'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: cgi
@@ -122,7 +126,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: concurrent-ruby
@@ -130,7 +134,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: connection_pool
@@ -138,7 +142,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: csv
@@ -146,7 +150,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: date
@@ -170,7 +174,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: erb
@@ -178,7 +182,7 @@ gems:
   source:
     type: stdlib
 - name: ffi
-  version: 1.17.4
+  version: 1.17.3
   source:
     type: rubygems
 - name: fileutils
@@ -194,7 +198,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: herb
@@ -206,7 +210,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: io-console
@@ -222,19 +226,23 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: logger
-  version: '0'
+  version: '1.7'
   source:
-    type: stdlib
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
+    remote: https://github.com/felixefelip/gem_rbs_collection.git
+    repo_dir: gems
 - name: loofah
   version: '2.0'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: mail
@@ -242,7 +250,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: marcel
@@ -250,7 +258,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: mini_magick
@@ -258,7 +266,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: mini_mime
@@ -266,7 +274,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: minitest
@@ -274,7 +282,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: monitor
@@ -290,7 +298,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: nokogiri
@@ -298,10 +306,14 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: openssl
+  version: '0'
+  source:
+    type: stdlib
+- name: optparse
   version: '0'
   source:
     type: stdlib
@@ -310,7 +322,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: pathname
@@ -326,13 +338,17 @@ gems:
   source:
     type: stdlib
 - name: prism
-  version: 1.9.0
+  version: 1.6.0
   source:
     type: rubygems
 - name: pstore
-  version: '0'
+  version: '0.2'
   source:
-    type: stdlib
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
+    remote: https://github.com/felixefelip/gem_rbs_collection.git
+    repo_dir: gems
 - name: psych
   version: '0'
   source:
@@ -342,7 +358,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: rails-dom-testing
@@ -350,7 +366,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: rails-html-sanitizer
@@ -358,7 +374,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: railties
@@ -366,7 +382,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: rainbow
@@ -374,7 +390,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: rake
@@ -382,7 +398,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: random-formatter
@@ -390,7 +406,7 @@ gems:
   source:
     type: stdlib
 - name: rbs
-  version: 4.0.2
+  version: 4.1.0.pre.1
   source:
     type: rubygems
 - name: rbs_infer
@@ -418,11 +434,11 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: steep
-  version: 2.0.0.dev
+  version: 2.1.0.dev
   source:
     type: rubygems
 - name: stringio
@@ -442,7 +458,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: time
@@ -466,7 +482,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8b8537e147d1166a4879346389c2f5e479e75680
+    revision: 4d9d8513381f344add6de90fac339953a57d142c
     remote: https://github.com/felixefelip/gem_rbs_collection.git
     repo_dir: gems
 - name: uri

--- a/spec/dummy/sig/generated/.steep_contracts.yml
+++ b/spec/dummy/sig/generated/.steep_contracts.yml
@@ -51,6 +51,22 @@ methods:
         chain:
         - user
         - name
+  Assignment#run_belongs_to_default_callbacks:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: post
+  Assignment#run_belongs_to_default_owner:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: post
   Assignment#save:
     requires:
     - kind: not_nil

--- a/spec/dummy/sig/generated/steep_ar_runtime/Assignment.rb
+++ b/spec/dummy/sig/generated/steep_ar_runtime/Assignment.rb
@@ -11,5 +11,14 @@ class Assignment
 
   def run_before_validation_callbacks
     log_post_user_name
+    run_belongs_to_default_callbacks
+  end
+
+  def run_belongs_to_default_callbacks
+    run_belongs_to_default_owner
+  end
+
+  def run_belongs_to_default_owner
+    self.owner ||= post.user
   end
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_ar_runtime/Assignment.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_ar_runtime/Assignment.rbs
@@ -1,4 +1,6 @@
 class Assignment
   def save: (**untyped) -> bool
   def run_before_validation_callbacks: () -> untyped
+  def run_belongs_to_default_callbacks: () -> untyped
+  def run_belongs_to_default_owner: () -> untyped
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_ar_runtime/Assignment.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_ar_runtime/Assignment.rbs
@@ -1,6 +1,6 @@
 class Assignment
   def save: (**untyped) -> bool
-  def run_before_validation_callbacks: () -> untyped
-  def run_belongs_to_default_callbacks: () -> untyped
-  def run_belongs_to_default_owner: () -> untyped
+  def run_before_validation_callbacks: () -> User?
+  def run_belongs_to_default_callbacks: () -> User?
+  def run_belongs_to_default_owner: () -> User?
 end

--- a/spec/expectations/steep_ar_runtime/Assignment.rb
+++ b/spec/expectations/steep_ar_runtime/Assignment.rb
@@ -11,5 +11,14 @@ class Assignment
 
   def run_before_validation_callbacks
     log_post_user_name
+    run_belongs_to_default_callbacks
+  end
+
+  def run_belongs_to_default_callbacks
+    run_belongs_to_default_owner
+  end
+
+  def run_belongs_to_default_owner
+    self.owner ||= post.user
   end
 end

--- a/spec/expectations/steep_ar_runtime/Post_Assignment.rb
+++ b/spec/expectations/steep_ar_runtime/Post_Assignment.rb
@@ -25,8 +25,6 @@ class Post_Assignment::ActiveRecord_Associations_CollectionProxy
   end
 
   def create!(*)
-    record = build
-    record.save
-    record
+    create or raise ActiveRecord::RecordInvalid
   end
 end

--- a/spec/expectations/steep_ar_runtime/Post_Comment.rb
+++ b/spec/expectations/steep_ar_runtime/Post_Comment.rb
@@ -25,8 +25,6 @@ class Post_Comment::ActiveRecord_Associations_CollectionProxy
   end
 
   def create!(*)
-    record = build
-    record.save
-    record
+    create or raise ActiveRecord::RecordInvalid
   end
 end

--- a/spec/expectations/steep_ar_runtime/Post_PostTag.rb
+++ b/spec/expectations/steep_ar_runtime/Post_PostTag.rb
@@ -25,8 +25,6 @@ class Post_PostTag::ActiveRecord_Associations_CollectionProxy
   end
 
   def create!(*)
-    record = build
-    record.save
-    record
+    create or raise ActiveRecord::RecordInvalid
   end
 end

--- a/spec/expectations/steep_ar_runtime/Tag_PostTag.rb
+++ b/spec/expectations/steep_ar_runtime/Tag_PostTag.rb
@@ -25,8 +25,6 @@ class Tag_PostTag::ActiveRecord_Associations_CollectionProxy
   end
 
   def create!(*)
-    record = build
-    record.save
-    record
+    create or raise ActiveRecord::RecordInvalid
   end
 end

--- a/spec/expectations/steep_ar_runtime/User_Comment.rb
+++ b/spec/expectations/steep_ar_runtime/User_Comment.rb
@@ -25,8 +25,6 @@ class User_Comment::ActiveRecord_Associations_CollectionProxy
   end
 
   def create!(*)
-    record = build
-    record.save
-    record
+    create or raise ActiveRecord::RecordInvalid
   end
 end

--- a/spec/expectations/steep_ar_runtime/User_Post.rb
+++ b/spec/expectations/steep_ar_runtime/User_Post.rb
@@ -25,8 +25,6 @@ class User_Post::ActiveRecord_Associations_CollectionProxy
   end
 
   def create!(*)
-    record = build
-    record.save
-    record
+    create or raise ActiveRecord::RecordInvalid
   end
 end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -1,5 +1,3 @@
-app/models/assignment.rb:19:60: [error] Type `(::Post | nil)` does not have method `user`
-app/models/assignment.rb:26:51: [error] Type `(::User | nil)` does not have method `name`
 app/models/concerns/test/filtrable.rb:12:27: [error] Type `(::Test & ::Test::Filtrable)` does not have method `updated_at`
 app/models/concerns/test/filtrable.rb:12:4: [error] Type `(::Test & ::Test::Filtrable)` does not have method `created_at`
 app/models/concerns/test/filtrable.rb:16:13: [error] Type `(::Test & ::Test::Filtrable)` does not have method `adddd`

--- a/spec/expectations/steep_contracts.yml
+++ b/spec/expectations/steep_contracts.yml
@@ -9,7 +9,57 @@ methods:
         receiver:
           kind: self
         method: post
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: post
+        chain:
+        - user
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: post
+        chain:
+        - user
+        - name
   Assignment#run_before_validation_callbacks:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: post
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: post
+        chain:
+        - user
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: post
+        chain:
+        - user
+        - name
+  Assignment#run_belongs_to_default_callbacks:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: post
+  Assignment#run_belongs_to_default_owner:
     requires:
     - kind: not_nil
       expr:
@@ -25,6 +75,23 @@ methods:
         receiver:
           kind: self
         method: post
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: post
+        chain:
+        - user
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: post
+        chain:
+        - user
+        - name
   Column#save:
     requires:
     - kind: not_nil
@@ -74,6 +141,44 @@ methods:
           kind: self
         method: user
     enforced: false
+  Post_Assignment::ActiveRecord_Associations_CollectionProxy#create:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: owner
+        chain:
+        - user
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: owner
+        chain:
+        - user
+        - name
+  Post_Assignment::ActiveRecord_Associations_CollectionProxy#create!:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: owner
+        chain:
+        - user
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: owner
+        chain:
+        - user
+        - name
   ProfileFormatter#call_without_check:
     requires:
     - kind: not_nil
@@ -91,4 +196,28 @@ methods:
         receiver:
           kind: self
         method: nickname
+    enforced: false
+  Test::Filtrable#filtrable?:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: created_at
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: updated_at
+    enforced: false
+  Test::Filtrable#teste:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: asdasd
     enforced: false

--- a/spec/lib/rbs_infer/extensions/rails/active_record/runtime_generator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/active_record/runtime_generator_spec.rb
@@ -66,6 +66,38 @@ RSpec.describe RbsInfer::Extensions::Rails::ActiveRecord::RuntimeGenerator do
       end
     end
 
+    it "reopens a belongs_to `default:` lambda as a before_validation callback" do
+      # `belongs_to :owner, default: -> { post.user }` runs its lambda in a
+      # before_validation callback (`self.owner ||= post.user`), so the deref of
+      # a nilable belongs_to inside it (`post.user`) becomes reachable from save
+      # and the contract machinery can narrow it — same flow as a named callback.
+      model_src = <<~RUBY
+        class Assignment < ApplicationRecord
+          belongs_to :post
+          belongs_to :owner, class_name: "User", default: -> { post.user }
+        end
+      RUBY
+      in_app("app/models/assignment.rb" => model_src, "app/models/post.rb" => POST) do |dir|
+        model = source_of(described_class.new(app_dir: dir).build, "Assignment.rb")
+
+        expect(model).to match(/def run_before_validation_callbacks\n\s*run_belongs_to_default_callbacks\n\s*end/)
+        expect(model).to match(/def run_belongs_to_default_callbacks\n\s*run_belongs_to_default_owner\n\s*end/)
+        expect(model).to match(/def run_belongs_to_default_owner\n\s*self\.owner \|\|= post\.user\n\s*end/)
+        expect(Prism.parse(model).success?).to be(true)
+      end
+    end
+
+    it "does not reopen a belongs_to without a `default:`" do
+      # A plain belongs_to has no default lambda to run, so no callback is emitted
+      # for it (only `belongs_to :owner, default:` would produce one).
+      plain = "class Assignment < ApplicationRecord\n  belongs_to :post\nend\n"
+      in_app("app/models/assignment.rb" => plain, "app/models/post.rb" => POST) do |dir|
+        model = source_of(described_class.new(app_dir: dir).build, "Assignment.rb")
+        # No save flow at all: no before_validation callback and no default lambda.
+        expect(model).to be_nil
+      end
+    end
+
     it "emits nothing when a has_many's element is not a scanned model" do
       # POST has `has_many :assignments` but Assignment isn't provided here, so
       # its class/proxy can't be modeled — the association is skipped, and with
@@ -101,9 +133,12 @@ RSpec.describe RbsInfer::Extensions::Rails::ActiveRecord::RuntimeGenerator do
         expect(proxy).to match(/def owner\n\s*@owner\n\s*end/)
         # build establishes the inverse belongs_to (`post`) from the owner.
         expect(proxy).to match(/def build\(\*\)\n\s*record = Assignment\.new\n\s*record\.post = owner\n\s*record\n\s*end/)
-        # create / create! = build (no args, matches the optional overload) + save.
+        # create = build (no args, matches the optional overload) + save.
         expect(proxy).to match(/def create\(\*\)\n\s*record = build\n\s*record\.save\n\s*record\n\s*end/)
-        expect(proxy).to match(/def create!\(\*\)\n\s*record = build\n\s*record\.save\n\s*record\n\s*end/)
+        # create! delegates to `create` (single `save` call site) rather than
+        # repeating build/save — keeps the caller chain linear so a precondition
+        # on `save` can enforce (felixefelip/steep#65).
+        expect(proxy).to match(/def create!\(\*\)\n\s*create or raise ActiveRecord::RecordInvalid\n\s*end/)
         expect(Prism.parse(proxy).success?).to be(true)
       end
     end


### PR DESCRIPTION
## Problem

`belongs_to :owner, default: -> { post.user }` runs its lambda in a `before_validation` callback — Rails calls `owner.instance_exec(&block)` when the association is unset — so a nilable-belongs_to deref inside the lambda (`post.user`, with `post.user: User?`) is reachable from `save`, exactly like a named callback. But the inline lambda was invisible to the AR-runtime pseudo-code, so Steep flagged the deref as a false positive at the declaration site (`app/models/assignment.rb:19`).

## Change

**Scanner** (`reflection_scanner.rb`) — capture a one-expression `default: -> { expr }` lambda body per `belongs_to` as `default_body`.

**Generator** (`pseudo_code_builder.rb`) — reopen each default as `self.<assoc> ||= <expr>` inside `run_belongs_to_default_<name>`, chained from `run_before_validation_callbacks` via `run_belongs_to_default_callbacks`. The deref is now reachable from `save`, and the Steep fork's contract machinery narrows it — no hand-written contract.

**`create!` -> `create` delegation** — the emitted `create!` now delegates (`create or raise ActiveRecord::RecordInvalid`) instead of repeating `build`/`save`, keeping the single `save` call site on a linear caller chain (`save` <- `create` <- `create!`) so precondition enforcement isn't blocked by a dead-but-uncountable sibling (felixefelip/steep#65).

## Tests

- `runtime_generator_spec.rb`: new test for the `belongs_to default:` reopen (and a negative case for a plain `belongs_to`); updated the `create!` assertion to the delegating form.
- Snapshots regenerated (`spec/expectations/steep_ar_runtime/*.rb`).
- **steep baseline** drops the two `app/models/assignment.rb` false positives — `:19` (the default lambda) and `:26` (the named callback).
- **contracts sidecar** gains the new `run_belongs_to_default_*` and proxy `create`/`create!` entries plus the multi-hop chain obligations the Steep fork infers (the `Test::Filtrable` entries are a pre-existing expectation refresh, unrelated).

## Dependencies

Closing `assignment.rb:19` end-to-end also needs:
- **felixefelip/steep#67** — Steep honoring `[self: untyped]` in a block body.
- **felixefelip/gem_rbs_collection#2** — typing the ActiveRecord `default:` proc as `^(untyped) [self: untyped] -> untyped`. **Merged**; the dummy's rbs collection is bumped to the merged revision (`4d9d851`) via `rbs collection update` in a follow-up commit, replacing the earlier hand-applied patch. The bump leaves `steep check` output byte-identical (baseline/contracts unchanged).

## Known follow-up

The generated `run_before_validation_callbacks` lists named callbacks before the `belongs_to default:` ones rather than in declaration order. Order-independent for the current fixtures (both narrow `post`), but a model whose declaration order matters would need the two callback kinds interleaved by source position — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
