### PR TITLE
fix(ivar): recognize `@x ||= v` / `@x &&= v` as ivar writes (#85)

### DIFF
--- a/lib/rbs_infer/inference/return_type_resolver.rb
+++ b/lib/rbs_infer/inference/return_type_resolver.rb
@@ -281,7 +281,14 @@ module RbsInfer::Inference
     def collect_ivar_writes(node, known_return_types, type_sets, attr_names, param_types: {})
       queue = [node]
       while (current = queue.shift)
-        if current.is_a?(Prism::InstanceVariableWriteNode)
+        # `@x = v`, plus `@x ||= v` / `@x &&= v` — all carry `.name`/`.value`
+        # and assign approximately the RHS type. `||=`/`&&=` were dropped
+        # before (felixefelip/rbs_infer#85); `InstanceVariableOperatorWriteNode`
+        # (`+=`, `<<=`) stays out — its result type is the operator's, not
+        # `.value`'s.
+        if current.is_a?(Prism::InstanceVariableWriteNode) ||
+           current.is_a?(Prism::InstanceVariableOrWriteNode) ||
+           current.is_a?(Prism::InstanceVariableAndWriteNode)
           name = current.name.to_s.sub(/\A@/, "")
           unless attr_names.include?(name)
             inferred = basic_value_type(current.value, known_return_types)

--- a/lib/rbs_infer/signatures/steep_bridge.rb
+++ b/lib/rbs_infer/signatures/steep_bridge.rb
@@ -383,12 +383,12 @@ module RbsInfer::Signatures
       typing.each_typing do |node, type|
         next unless in_scope.include?(node.object_id)
         case node.type
-        when :ivasgn
-          rhs = node.children[1]
-          next unless rhs
+        when :ivasgn, :or_asgn, :and_asgn
+          parts = ivar_write_name_and_rhs(node)
+          next unless parts
+          var_name, rhs = parts
           rhs_type = intrinsic_type_of(rhs, typing)
           next unless rhs_type
-          var_name = node.children[0].to_s.sub(/\A@/, "")
           type_sets[var_name].add(format_type(rhs_type))
         when :send
           receiver, method_name, *args = node.children
@@ -652,6 +652,16 @@ module RbsInfer::Signatures
         node.children.each do |c|
           collect_scoped_write_node_ids(c, attr_writer_to_ivar, target_class, namespace: namespace, result: result)
         end
+      when :or_asgn, :and_asgn
+        # `@x ||= v` / `@x &&= v`: the write `each_typing` will key on is this
+        # whole node, not its argument-less inner `:ivasgn`, so collect this
+        # id (felixefelip/rbs_infer#85).
+        if node.children[0].type == :ivasgn && class_scope_match?(namespace, target_class)
+          result << node.object_id
+        end
+        node.children.each do |c|
+          collect_scoped_write_node_ids(c, attr_writer_to_ivar, target_class, namespace: namespace, result: result)
+        end
       when :send
         receiver, method_name = node.children[0], node.children[1]
         if attr_writer_to_ivar.key?(method_name) &&
@@ -711,10 +721,11 @@ module RbsInfer::Signatures
       when :defs
         # Singleton `def self.X` — class-instance variable scope, not
         # relevant for the per-action narrowing this method serves.
-      when :ivasgn
-        rhs = node.children[1]
-        if current_method && rhs && class_scope_match?(namespace, target_class)
-          var_name = node.children[0].to_s.sub(/\A@/, "")
+      when :ivasgn, :or_asgn, :and_asgn
+        parts = ivar_write_name_and_rhs(node)
+        rhs = parts&.last
+        if current_method && parts && class_scope_match?(namespace, target_class)
+          var_name = parts.first
           # Use the RHS's INTRINSIC type, not what `typing` recorded.
           # When the ivar is already declared in RBS (e.g.,
           # `@name: String?`), Steep's `:ivasgn` synthesize widens
@@ -1025,6 +1036,28 @@ module RbsInfer::Signatures
     # Same pattern as `Steep::Postconditions::Inferrer#intrinsic_type_of`
     # (felixefelip/steep#35). Both call sites need to bypass the same
     # widening for the cross-receiver narrowing pipeline to fire.
+    # Instance-variable writes take two AST shapes. A plain `@x = v` is an
+    # `:ivasgn` carrying its RHS as the second child. A `@x ||= v` / `@x &&= v`
+    # wraps an argument-less `:ivasgn` (the name alone) in an `:or_asgn` /
+    # `:and_asgn` whose second child is the RHS — so walking down to the inner
+    # `:ivasgn` finds no RHS, which is why `||=` writes were silently dropped
+    # (felixefelip/rbs_infer#85). Returns `[name_without_@, rhs_node]` for any
+    # of the three, or nil for anything else — including the bare inner
+    # `:ivasgn` of an `||=`. `||=`/`&&=` assign approximately the RHS type, so
+    # callers type them exactly like a plain write; `:op_asgn` (`+=`, `<<=`) is
+    # deliberately excluded, since there the result type is the operator's, not
+    # the RHS's.
+    def ivar_write_name_and_rhs(node)
+      case node.type
+      when :ivasgn
+        name, rhs = node.children
+        [name.to_s.sub(/\A@/, ""), rhs] if rhs
+      when :or_asgn, :and_asgn
+        lhs, rhs = node.children
+        [lhs.children[0].to_s.sub(/\A@/, ""), rhs] if lhs.type == :ivasgn && rhs
+      end
+    end
+
     def intrinsic_type_of(node, typing)
       case node.type
       when :nil

--- a/spec/lib/rbs_infer/signatures/steep_bridge_spec.rb
+++ b/spec/lib/rbs_infer/signatures/steep_bridge_spec.rb
@@ -454,6 +454,52 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
       expect(result["x"]).to eq("String?")
     end
 
+    # `@x ||= v` / `@x &&= v` are ivar writes too, but their AST parks the
+    # name in an argument-less inner `:ivasgn` and the RHS one level up in an
+    # `:or_asgn`/`:and_asgn`, so the collector used to walk past them and drop
+    # the write entirely (felixefelip/rbs_infer#85).
+    it "collects an `||=` memoization write (nilable, lazy by nature)" do
+      code = <<~RUBY
+        class Foo
+          def cache
+            @x ||= "hello"
+          end
+        end
+      RUBY
+
+      result = bridge.ivar_write_types(code, target_class: "Foo")
+      expect(result["x"]).to eq("String?")
+    end
+
+    it "collects an `&&=` write" do
+      code = <<~RUBY
+        class Foo
+          def guard
+            @x &&= "hello"
+          end
+        end
+      RUBY
+
+      result = bridge.ivar_write_types(code, target_class: "Foo")
+      expect(result["x"]).to eq("String?")
+    end
+
+    # `+=`/`<<=` are `InstanceVariableOperatorWriteNode` (`:op_asgn`): the
+    # result type is the operator's, not the RHS's, so the RHS-intrinsic
+    # approach doesn't apply. Left uncollected on purpose.
+    it "does not mis-type an `+=` operator write from its RHS literal" do
+      code = <<~RUBY
+        class Foo
+          def bump
+            @count += 1
+          end
+        end
+      RUBY
+
+      result = bridge.ivar_write_types(code, target_class: "Foo")
+      expect(result).not_to have_key("count")
+    end
+
     it "unions multiple distinct writes across non-initialize methods" do
       code = <<~RUBY
         class Foo


### PR DESCRIPTION
Fecha #85.

## Problema

`@x ||= v` (memoização — um dos idiomas mais comuns de Ruby) não era reconhecido como escrita de ivar: o ivar ficava sem declaração na RBS e o tipo se perdia. `@x = v` na mesma posição funcionava.

## Causa

As duas formas têm ASTs diferentes, e o RHS muda de lugar:

```
@x = v    ->  s(:ivasgn, :@x, <rhs>)              # 2 filhos: nome + RHS
@x ||= v  ->  s(:or_asgn, s(:ivasgn, :@x), <rhs>) # o :ivasgn interno fica sem RHS
```

Todos os coletores desciam até o `:ivasgn`, liam `children[1]`, achavam `nil` e pulavam o nó.

## Correção

Um helper compartilhado `ivar_write_name_and_rhs` extrai o nome do nó interno e o RHS do `:or_asgn`/`:and_asgn`, usado nos três walkers do Steep (`ivar_write_types` each_typing, `collect_scoped_write_node_ids`, `collect_ivar_writes_per_method`). O fallback Prism no `ReturnTypeResolver` ganha `InstanceVariableOrWriteNode`/`AndWriteNode`.

```rbs
# antes -> depois
class IvarProbe
  def cache; @x ||= "hello"; end
end
# (nada)  ->  @x: String?
```

## Decisões

- **`||=` e `&&=` cobertos; `+=`/`<<=` deixados de fora de propósito.** Neles o tipo do resultado é do operador, não do RHS — usar o tipo do RHS tiparia `@count += 1` como `Integer` a partir do literal `1`, o que é enganoso. Um spec trava exatamente isso.
- **Nilabilidade não precisou de nada.** Um `@x ||= v` é lazy por natureza (pode ser lido nil antes da primeira chamada) e não passa pelo `initialize`, então os walkers de definite-init já o deixam `T?` — o correto.

## Testes

**735 exemplos, 0 falhas**, incluindo o `steep check` do dummy. Três specs unitários em `#ivar_write_types` cobrem `||=` (nilable), `&&=`, e a exclusão do `+=`; reverter o `each_typing` os faz falhar com `got: nil`.

## Notas

- **Nenhum snapshot do dummy muda.** O `@foo_instance ||= Foo.new` do `example3` continua não emitido — agora porque o `attr_writer :foo_instance` reivindica o nome, não porque a escrita é invisível.
- **Interage com #86** (class-instance variable emitida com escopo errado): um `@x ||= v` dentro de `def self.x` agora sai como ivar de instância, tornando o #86 mais visível. Os dois bugs se cancelavam; este PR corrige só a metade do `||=`. Ver #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
