### PR TITLE
fix(rbs): reconcile an attr with an explicit def of the same name

### DIFF
--- a/lib/rbs_infer/signatures/rbs_builder.rb
+++ b/lib/rbs_infer/signatures/rbs_builder.rb
@@ -17,7 +17,10 @@ module RbsInfer::Signatures
       @type_params = type_params
     end
 
+    ATTR_KINDS = %i[attr_reader attr_writer attr_accessor].freeze
+
     def build(members, init_arg_types, attr_types, optional_params = Set.new, method_param_types = {}, ivar_types: {}, markers: [])
+      members = reconcile_attrs_with_explicit_defs(members)
       parts = @target_class.split("::")
       class_name = parts.pop
       modules = parts
@@ -154,6 +157,54 @@ module RbsInfer::Signatures
     end
 
     private
+
+    # `attr_accessor :x` declares `x` and `x=`; `attr_reader`/`attr_writer`
+    # declares one of them. When the same class ALSO defines that method
+    # explicitly (`def x=`), Ruby lets the later definition win — but RBS has
+    # no such rule and rejects the duplicate ("Non-overloading method
+    # definition of `x=` cannot be duplicated"). Reconcile by dropping the
+    # generated half an explicit `def` replaces: downgrade an accessor to the
+    # surviving reader/writer, or drop the attr entirely when both halves are
+    # overridden.
+    #
+    # Scoped to the same owner: a `def x=` in the class legitimately overrides
+    # an `attr_accessor :x` mixed in from a nested module, and RBS models that
+    # as ordinary inheritance, not a duplicate — those must NOT reconcile.
+    def reconcile_attrs_with_explicit_defs(members)
+      defs_by_owner = Hash.new { |h, k| h[k] = Set.new }
+      members.each { |m| defs_by_owner[m.owner] << m.name if m.kind == :method }
+
+      members.flat_map do |m|
+        next [m] unless ATTR_KINDS.include?(m.kind)
+
+        kind = surviving_attr_kind(m, defs_by_owner[m.owner])
+        if kind.nil?
+          []
+        elsif kind == m.kind
+          [m]
+        else
+          [m.dup.tap { |copy| copy.kind = kind }]
+        end
+      end
+    end
+
+    # The attr kind left after an explicit `def name` / `def name=` replaces
+    # part of what the attr would generate, or nil when nothing survives.
+    def surviving_attr_kind(member, explicit_defs)
+      reader_overridden = explicit_defs.include?(member.name)
+      writer_overridden = explicit_defs.include?("#{member.name}=")
+
+      case member.kind
+      when :attr_reader then reader_overridden ? nil : :attr_reader
+      when :attr_writer then writer_overridden ? nil : :attr_writer
+      when :attr_accessor
+        if reader_overridden && writer_overridden then nil
+        elsif writer_overridden then :attr_reader
+        elsif reader_overridden then :attr_writer
+        else :attr_accessor
+        end
+      end
+    end
 
     # Renders a single value member (method / attr_*) as one RBS line, or
     # nil for other kinds. Shared between the class body and nested-module

--- a/spec/integration/steep_scenarios_spec.rb
+++ b/spec/integration/steep_scenarios_spec.rb
@@ -330,4 +330,37 @@ RSpec.describe "rbs_infer -> Steep precondition scenarios" do
     expect(result.generated_rbs.chomp).to eq(expected_rbs.chomp)
     expect(result.diagnostics).to be_empty
   end
+
+  # `attr_accessor :user` declares `user` and `user=`; the explicit `def user=`
+  # in the same class redefines the writer (Ruby lets it win). Emitting both
+  # declared `user=` twice — invalid RBS, rejected with "Non-overloading method
+  # definition of `user=` cannot be duplicated". The builder now downgrades the
+  # accessor to `attr_reader` and keeps the explicit writer.
+  it "reconciles an attr_accessor with an explicit setter of the same name" do
+    result = steep_scenario(<<~RUBY)
+      class Widget
+        attr_accessor :user
+
+        def user=(value)
+          @user = value
+        end
+
+        def use
+          self.user = Widget.new
+          user
+        end
+      end
+    RUBY
+
+    expected_rbs = <<~RBS
+      class Widget
+        attr_reader user: Widget
+        def user=: (Widget value) -> untyped
+        def use: () -> Widget
+      end
+    RBS
+
+    expect(result.generated_rbs.chomp).to eq(expected_rbs.chomp)
+    expect(result.diagnostics).to be_empty
+  end
 end

--- a/spec/lib/rbs_infer/signatures/rbs_builder_spec.rb
+++ b/spec/lib/rbs_infer/signatures/rbs_builder_spec.rb
@@ -219,4 +219,53 @@ RSpec.describe RbsInfer::Signatures::RbsBuilder do
       expect(result).to include("  MAX: Integer\n\n  private")
     end
   end
+
+  # `attr_accessor :x` + an explicit `def x=` in the same class declare `x=`
+  # twice; RBS rejects the duplicate. The builder drops the generated half an
+  # explicit def replaces (felixefelip/rbs_infer, attr-writer reconciliation).
+  describe "#build attr/def reconciliation" do
+    def attr(kind, name)
+      RbsInfer::Inference::Member.new(kind: kind, name: name, signature: "#{name}: untyped", visibility: :public)
+    end
+
+    def meth(name)
+      RbsInfer::Inference::Member.new(kind: :method, name: name, signature: "#{name}: (untyped v) -> untyped", visibility: :public)
+    end
+
+    let(:builder) { make_builder(target_class: "Foo", superclass_name: nil) }
+
+    it "downgrades attr_accessor to attr_reader when only the writer is overridden" do
+      result = builder.build([attr(:attr_accessor, "x"), meth("x=")], {}, {})
+
+      expect(result).to include("attr_reader x: untyped")
+      expect(result).not_to include("attr_accessor")
+      expect(result.scan(/def x=|attr_\w+ x=/).size).to eq(1)
+    end
+
+    it "downgrades attr_accessor to attr_writer when only the reader is overridden" do
+      result = builder.build([attr(:attr_accessor, "x"), meth("x")], {}, {})
+
+      expect(result).to include("attr_writer x: untyped")
+      expect(result).not_to include("attr_accessor")
+    end
+
+    it "drops attr_writer entirely when the writer is defined explicitly" do
+      result = builder.build([attr(:attr_writer, "x"), meth("x=")], {}, {})
+
+      expect(result).not_to match(/attr_\w+ x/)
+      expect(result).to include("def x=:")
+    end
+
+    it "drops attr_accessor entirely when both halves are overridden" do
+      result = builder.build([attr(:attr_accessor, "x"), meth("x"), meth("x=")], {}, {})
+
+      expect(result).not_to match(/attr_\w+ x/)
+    end
+
+    it "leaves an attr untouched when no explicit def collides" do
+      result = builder.build([attr(:attr_accessor, "x")], {}, {})
+
+      expect(result).to include("attr_accessor x: untyped")
+    end
+  end
 end


### PR DESCRIPTION
## Problema

`attr_accessor :x` declara `x` e `x=`; um `def x=` explícito na mesma classe declara `x=` de novo. Em Ruby o `def` posterior vence, mas o RBS não tem essa regra e rejeita o arquivo inteiro:

```
[error] Non-overloading method definition of `user=` cannot be duplicated
```

Ou seja, qualquer classe que combine um macro `attr_*` com um accessor escrito à mão de mesmo nome gerava RBS inválido.

## Correção

O `RbsBuilder` passa a dropar a metade gerada que um `def` explícito substitui, seguindo a semântica de override do Ruby:

| fonte | vira |
|---|---|
| `attr_accessor :x` + `def x=` | `attr_reader x:` + `def x=` |
| `attr_accessor :x` + `def x` | `attr_writer x:` + `def x` |
| `attr_writer :x` + `def x=` | só o `def x=` |
| `attr_accessor :x` + `def x` + `def x=` | só os dois `def` |

Duas garantias:

- **Escopo por owner.** Um `def x=` na classe que sobrescreve um `attr_accessor :x` vindo de um módulo aninhado é herança legítima, que o RBS modela nativamente — esses **não** reconciliam. É o que mantém a forma módulo(attr) + classe(def) do `example3` válida e inalterada.
- **Fica no core.** Semântica pura de Ruby (`attr` + `def`), sem conhecimento de framework, então mora no builder.

O resultado passa no Steep com zero diagnósticos, e a inferência até melhora — o reader deixa de ser `untyped`:

```ruby
class Widget
  attr_accessor :user
  def user=(value); @user = value; end
  def use; self.user = Widget.new; user; end
end
```
```rbs
# antes: attr_accessor user: untyped + def user=  -> Steep rejeita (duplicata)
# agora:
class Widget
  attr_reader user: Widget
  def user=: (Widget value) -> untyped
  def use: () -> Widget
end
```

## Testes

**741 exemplos, 0 falhas**, incluindo o `steep check` do dummy. Cinco specs unitários no `RbsBuilder` (um por caso de reconciliação) e um cenário Steep end-to-end que prova que o RBS reconciliado type-checka limpo. Reverter a reconciliação faz os dois conjuntos falharem — os unitários no kind errado do attr, o cenário no erro de duplicata do Steep.

Nenhum snapshot do dummy muda: os fixtures atuais não têm o caso duplicado (o `example3` usa owners diferentes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
