### PR TITLE
fix(rbs): don't suppress a class-instance var when an instance attr shares its name

### DIFF
--- a/lib/rbs_infer/inference/class_member_collector.rb
+++ b/lib/rbs_infer/inference/class_member_collector.rb
@@ -12,7 +12,11 @@ module RbsInfer::Inference
   # `old_name` = para membros `:alias`/`:singleton_alias`, o método original
   # apontado pelo alias; o RBS resolve o tipo nativamente via `alias`
   # (felixefelip/rbs_infer#63).
-  Member = Struct.new(:kind, :name, :signature, :visibility, :owner, :value_node, :param_constant_defaults, :old_name, keyword_init: true)
+  # `singleton` = para membros `:attr_*`, se o attr foi declarado dentro de
+  # `class << self` (attr de singleton, `self.attr x`). Distingue o attr de
+  # instância `x` da class-instance variable `@x` escrita em `def self.x`, que
+  # compartilham nome mas são slots diferentes (felixefelip/rbs_infer#86).
+  Member = Struct.new(:kind, :name, :signature, :visibility, :owner, :value_node, :param_constant_defaults, :old_name, :singleton, keyword_init: true)
 
   # Metadata extraída de uma chamada `delegate` — tipos são resolvidos depois no Analyzer
   DelegateInfo = Struct.new(:methods, :target, :prefix, :allow_nil, keyword_init: true)
@@ -395,7 +399,11 @@ module RbsInfer::Inference
           name: attr_name,
           signature: "#{attr_name}: #{type}",
           visibility: @current_visibility,
-          owner: current_owner
+          owner: current_owner,
+          # `class << self; attr_accessor :x` declares a singleton attr — its
+          # `@x` is a class-instance variable, a slot distinct from an instance
+          # attr of the same name (felixefelip/rbs_infer#86).
+          singleton: in_singleton_self?
         )
       end
     end

--- a/lib/rbs_infer/inference/return_type_resolver.rb
+++ b/lib/rbs_infer/inference/return_type_resolver.rb
@@ -149,9 +149,15 @@ module RbsInfer::Inference
     def infer_ivar_types(members, attr_types, parsed_target: nil, method_param_types: {})
       return IvarInference.new({}, {}) unless parsed_target
 
-      # Nomes de attrs já declarados (attr_accessor, attr_reader) → pular
-      attr_names = members.select { |m| [:attr_accessor, :attr_reader, :attr_writer].include?(m.kind) }
-                          .map(&:name).to_set
+      # Attr names already declared → the ivar they back is typed by the attr,
+      # so we skip re-emitting it. Split by receiver scope: an instance attr
+      # `x` covers the instance `@x`, but NOT the class-instance variable `@x`
+      # written in `def self.x` (a distinct `self.@x` slot). Only a singleton
+      # attr (`class << self; attr_accessor :x`) covers that one
+      # (felixefelip/rbs_infer#86).
+      attrs = members.select { |m| [:attr_accessor, :attr_reader, :attr_writer].include?(m.kind) }
+      instance_attr_names = attrs.reject(&:singleton).map(&:name).to_set
+      singleton_attr_names = attrs.select(&:singleton).map(&:name).to_set
 
       ivar_types = {}
 
@@ -169,7 +175,7 @@ module RbsInfer::Inference
       if @steep_bridge && parsed_target.source
         steep_ivars = @steep_bridge.ivar_write_types(parsed_target.source, target_class: @target_class)
         steep_ivars.each do |name, type|
-          next if attr_names.include?(name)
+          next if instance_attr_names.include?(name)
           if type == "nil"
             steep_nil_only << name
             next
@@ -195,8 +201,10 @@ module RbsInfer::Inference
 
       collector.defs.each do |defn|
         param_types = method_param_types[defn.name.to_s] || {}
-        target = collector.class_method?(defn) ? singleton_type_sets : fallback_type_sets
-        collect_ivar_writes(defn, known_return_types, target, attr_names, param_types: param_types)
+        singleton = collector.class_method?(defn)
+        target = singleton ? singleton_type_sets : fallback_type_sets
+        skip_names = singleton ? singleton_attr_names : instance_attr_names
+        collect_ivar_writes(defn, known_return_types, target, skip_names, param_types: param_types)
       end
 
       # Class-instance variables are also written directly in the class body
@@ -205,7 +213,7 @@ module RbsInfer::Inference
       # can have (no constructor runs for them). Feeds both the type set and the
       # set of names that are non-nilable (felixefelip/rbs_infer#86).
       class_instance_initialized =
-        collect_class_body_ivar_writes(parsed_target.tree, known_return_types, singleton_type_sets, attr_names)
+        collect_class_body_ivar_writes(parsed_target.tree, known_return_types, singleton_type_sets, singleton_attr_names)
 
       fallback_type_sets.each do |name, type_set|
         next if ivar_types.key?(name)

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -326,6 +326,32 @@ postconditions:
   effects:
     may_write:
     - "@nickname"
+- class: SingletonIvarProbe
+  method: initialize
+  effects:
+    may_write:
+    - "@instance_ivar"
+- class: SingletonIvarProbe
+  method: build
+  unconditional:
+    ivars:
+      "@singleton_ivar": "::String"
+  effects:
+    may_write:
+    - "@singleton_ivar"
+- class: SingletonIvarProbe
+  method: configure
+  effects:
+    may_write:
+    - "@config"
+- class: SingletonIvarProbe
+  method: label
+  unconditional:
+    ivars:
+      "@label": "::String"
+  effects:
+    may_write:
+    - "@label"
 - class: TagDestroy
   method: atribui_user
   effects:

--- a/spec/dummy/sig/rbs_infer/app/models/example3.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example3.rbs
@@ -12,6 +12,8 @@ end
 
 class Example3
   class Foo
+    self.@foo_instance: Foo?
+
     module GeneratedAttributes
       attr_accessor user: User?
       attr_accessor name: String

--- a/spec/expectations/models/example3.rbs
+++ b/spec/expectations/models/example3.rbs
@@ -12,6 +12,8 @@ end
 
 class Example3
   class Foo
+    self.@foo_instance: Foo?
+
     module GeneratedAttributes
       attr_accessor user: User?
       attr_accessor name: String

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -166,6 +166,10 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
   #   the synthetic name won, the call-site type was filed under `user` while
   #   the signature said `value`, so the substitution missed and both setters
   #   stayed `untyped`.
+  # - `@foo_instance ||= Foo.new` in `def self.foo_instance` is a class-instance
+  #   variable → `self.@foo_instance: Foo?`. It shares its name with the instance
+  #   `attr_writer :foo_instance`, but that's an INSTANCE attr; only a singleton
+  #   attr would suppress the `self.@foo_instance` slot (felixefelip/rbs_infer#86).
   it "nested-class file matches expected RBS (targets + setter param names)" do
     name = "models/example3"
     rbs = RbsInfer::Analyzer.new(

--- a/spec/lib/rbs_infer/inference/class_member_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/class_member_collector_spec.rb
@@ -224,6 +224,28 @@ RSpec.describe RbsInfer::Inference::ClassMemberCollector do
       bar = collect(source).members.find { |m| m.name == "bar" }
       expect(bar.kind).not_to eq(:class_method)
     end
+
+    # A singleton attr (`class << self; attr_accessor :x`) backs the
+    # class-instance variable `@x`, a slot distinct from an instance attr of
+    # the same name; the `singleton` flag lets consumers tell them apart
+    # (felixefelip/rbs_infer#86).
+    it "marca attr de `class << self` com singleton: true" do
+      source = <<~RUBY
+        class Foo
+          attr_accessor :instance_one
+
+          class << self
+            attr_reader :singleton_one
+          end
+        end
+      RUBY
+
+      collector = collect(source)
+      instance_one = collector.members.find { |m| m.name == "instance_one" }
+      singleton_one = collector.members.find { |m| m.name == "singleton_one" }
+      expect(instance_one.singleton).to be_falsey
+      expect(singleton_one.singleton).to be(true)
+    end
   end
 
   describe "delegate parsing" do


### PR DESCRIPTION
## Problem

Follow-up to #86 (#91). A class-instance variable (`@x` written in `def self.x` or the class body) that **shares its name with an instance attr** was silently dropped.

`infer_ivar_types` skipped every ivar write whose name matched any `attr_*` member — a name-only filter with no scope awareness. But an instance attr `x` backs the *instance* `@x`, not the *class-instance* `self.@x`; they are distinct slots that merely share a name.

Concretely, `Example3::Foo`:

```ruby
class Example3
  class Foo
    module GeneratedAttributes
      attr_writer :foo_instance   # instance attr
    end
    include GeneratedAttributes

    def self.foo_instance
      @foo_instance ||= Foo.new   # class-instance variable
    end
  end
end
```

`self.@foo_instance: Foo?` was suppressed because `foo_instance` was an (instance) attr name. This is the interaction issue #86 flagged ("os dois bugs se cancelam no example3").

## Fix

- **`class_member_collector.rb`** — `Member` gains a `singleton` field; `extract_attrs` sets `singleton: in_singleton_self?`, so a `class << self; attr_accessor :x` is recorded as a *singleton* attr (`self.attr x`), distinct from an instance attr of the same name.
- **`return_type_resolver.rb`** — `infer_ivar_types` splits the skip set by scope: the instance path skips **instance-attr** names, the singleton/class-body path skips **singleton-attr** names only.

## Effect

`Example3::Foo` now emits `self.@foo_instance: Foo?`. No other snapshot changes (e.g. `Current` is unaffected). The only expectation update is the one new line in `example3.rbs`.

## Tests

- Unit: `ClassMemberCollector` marks `class << self` attrs with `singleton: true`.
- Integration: `example3` snapshot now pins `self.@foo_instance: Foo?`.
- Full suite green (664 unit + integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)