### PR TITLE
test(dummy): example3/4 singleton const-path narrowing fixed (steep#76)

### DIFF
--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -70,6 +70,12 @@ postconditions:
   unconditional:
     establishes_consts:
       author_name: "::String"
+      user: "((::User & ::User::Validated) | ::User)"
+- class: Current
+  method: author_name=
+  unconditional:
+    establishes_consts:
+      author_name: "::String"
 - class: Current
   method: set
   effects:
@@ -81,6 +87,9 @@ postconditions:
     returns_ivar: "@user"
 - class: Current
   method: user=
+  unconditional:
+    establishes_consts:
+      user: "((::User & ::User::Validated) | ::User)"
   effects:
     may_write:
     - "@user"
@@ -117,6 +126,7 @@ postconditions:
   unconditional:
     establishes_consts:
       name: "::String"
+      user: "::Example3::User"
 - class: Example3::Foo
   method: foo_instance
   effects:
@@ -133,6 +143,9 @@ postconditions:
     returns_ivar: "@name"
 - class: Example4::Foo
   method: name=
+  unconditional:
+    establishes_consts:
+      name: "::String"
   effects:
     may_write:
     - "@name"

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -6,14 +6,12 @@ app/models/concerns/test/filtrable.rb:7:24: [error] Type `(singleton(::Test) & s
 app/models/concerns/test/filtrable.rb:7:4: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `scope`
 app/models/concerns/test/filtrable.rb:8:26: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `where`
 app/models/concerns/test/filtrable.rb:8:4: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `scope`
-app/models/example3.rb:50:11: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:51:24: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:52:24: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:14:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:18:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:22:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:27:23: [error] Type `(::String | nil)` does not have method `upcase`
-app/models/example4.rb:32:23: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:34:31: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:38:23: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/post/notifiable.rb:28:24: [error] Type `(::User | nil)` does not have method `full_name`


### PR DESCRIPTION
Consumes felixefelip/steep#77.

Regenerated dummy-app fixtures now that Steep narrows a directly-assigned singleton / const-path attribute (`Const.attr = <non-nil>` → `Const.attr` non-nil).

## Changes
- **`.steep_postconditions.yml`** — regenerated. The inferrer now emits own-attribute `establishes_consts`: `Example3::Foo#user=` gains `user: ::Example3::User`, `Example4::Foo.name=` gains `name: ::String`, and the `Current` CurrentAttributes setters generalize the same way.
- **`steep_baseline.txt`** — dropped the two errors now fixed:
  - `example3.rb:50` (`Foo.user.name` after `Foo.user = user`)
  - `example4.rb:32` (`Foo.name` after `Foo.name = 'John Doe'`)

`example4.rb:38` (`Foo.name` after `Foo.name = nil`) stays in the baseline, confirming the invalidation half of the fix. The remaining example4 errors (14/18/22/27/34 — reads with no in-scope non-nil write, incl. the interprocedural 18/34) are unchanged and tracked on steep#76.

## Verification
Steep check against the dummy matches the updated baseline exactly — the only diff from the previous baseline is the two intended fixes, no collateral changes.

> Requires felixefelip/steep#77 to be merged into the `rbs_infer` branch first (the local `../steep` path dependency already points at it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
