### PR TITLE
test(dummy): example4 cross-method const narrowing (steep#78)

### DIFF
--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -527,6 +527,10 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+- class: Example4::Bar
+  method: foo_name
+  consts:
+    Example4::Foo.name: "::String"
 - class: Posts::AssignmentsController
   method: create
   self_methods:

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -9,7 +9,6 @@ app/models/concerns/test/filtrable.rb:8:4: [error] Type `(singleton(::Test) & si
 app/models/example3.rb:51:24: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:52:24: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:14:25: [error] Type `(::String | nil)` does not have method `upcase`
-app/models/example4.rb:18:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:22:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:27:23: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:34:31: [error] Type `(::String | nil)` does not have method `upcase`


### PR DESCRIPTION
Consumes felixefelip/steep#79.

Regenerated dummy fixtures now that Steep delivers const-path establishment facts into plain-Ruby callees.

## Changes
- **`.steep_postconditions.yml`** — regenerated. Adds a `method_entry_facts` entry `Example4::Bar#foo_name → consts: { Example4::Foo.name: "::String" }` (plus one benign `ActionController::Base#redirect_to` entry from controller flows that write `Current.* =`). +9 lines.
- **`steep_baseline.txt`** — drops the now-fixed `example4.rb:18` (`Foo.name.upcase` inside `Bar#foo_name`).

`run` establishes `Foo.name` before its sole `Bar.new.foo_name` call site, so `foo_name`'s entry sees `Foo.name` non-nil and line 18 narrows. Lines 14/22 — the identical bodies of `foo_name_before`/`foo_name_after`, called in nil contexts — still error, confirming the per-method call-site intersection.

## Verification
Dummy `steep check` matches the updated baseline exactly — the only change from the previous baseline is the fixed line 18, no controller regressions.

## Follow-up — line 34
`example4.rb:34` (`Bar.new.foo_name.upcase`) still errors: it needs `foo_name`'s **inferred RBS return type** to be `String`. Steep now narrows `Foo.name` inside the body, but rbs_infer's return-type inference doesn't yet consume the method-entry fact when inferring `foo_name: () -> …`. Separate rbs_infer integration; will open a dedicated issue.

> Requires felixefelip/steep#79 merged into the `rbs_infer` branch first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
