### PR TITLE
fix(inference): narrow inferred nilable return to Steep's non-nil type

### DIFF
--- a/lib/rbs_infer/inference/return_type_resolver.rb
+++ b/lib/rbs_infer/inference/return_type_resolver.rb
@@ -121,6 +121,32 @@ module RbsInfer::Inference
             m.signature = m.signature.sub(/-> #{Regexp.escape(current_type)}$/, "-> #{steep_type}")
           end
 
+          # Narrow an already-inferred nilable return to Steep's non-nil type when
+          # Steep — with the postcondition / method-entry facts applied — proves the
+          # body can't return nil (e.g. `Foo.name.upcase` where a method-entry fact
+          # makes `Foo.name` non-nil at the callee's entry, felixefelip/steep#78).
+          # The first loop only upgrades `-> untyped`; this handles `T?` -> `T`.
+          # Restricted to a strict `nilablize(steep) == current` match, so an
+          # unrelated Steep type can never clobber a good signature, and skipped when
+          # the body has an explicit `nil` return (then nilable is the honest answer).
+          members.each do |m|
+            next unless method_member?(m)
+            next if m.name == "initialize"
+            current_type = m.signature[/->\s*(.+)$/, 1]&.strip
+            next unless current_type&.end_with?("?")
+
+            steep_type = steep_returns_for(m, steep_returns)[m.name]
+            next unless steep_type && steep_type != "untyped" && steep_type != "nil" && steep_type != "bot"
+            next if steep_type == current_type
+            next unless RbsInfer::Signatures::RbsParserUtil.nilablize(steep_type) == current_type
+
+            defn = def_map[m.name]
+            next if defn && has_nil_return?(defn)
+
+            steep_type = "self" if self_return?(m, steep_type, self_types)
+            m.signature = m.signature.sub(/-> #{Regexp.escape(current_type)}$/, "-> #{steep_type}")
+          end
+
           # Refine record types containing untyped values using Steep's body type inference
           members.each do |m|
             next unless method_member?(m)

--- a/spec/dummy/sig/rbs_infer/app/models/example4.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example4.rbs
@@ -1,6 +1,6 @@
 class Example4
   def run: () -> untyped
-  def run_foo_name: () -> untyped
+  def run_foo_name: () -> String
 end
 
 class Example4
@@ -15,7 +15,7 @@ end
 class Example4
   class Bar
     def foo_name_before: () -> untyped
-    def foo_name: () -> String?
+    def foo_name: () -> String
     def foo_name_after: () -> untyped
   end
 end

--- a/spec/expectations/models/example4.rbs
+++ b/spec/expectations/models/example4.rbs
@@ -15,7 +15,7 @@ end
 class Example4
   class Bar
     def foo_name_before: () -> untyped
-    def foo_name: () -> String?
+    def foo_name: () -> String
     def foo_name_after: () -> untyped
   end
 end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -11,7 +11,6 @@ app/models/example3.rb:52:24: [error] Type `(::String | nil)` does not have meth
 app/models/example4.rb:14:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:22:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:27:23: [error] Type `(::String | nil)` does not have method `upcase`
-app/models/example4.rb:36:31: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:40:23: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/post/notifiable.rb:28:24: [error] Type `(::User | nil)` does not have method `full_name`
 app/models/user/recoverable.rb:10:6: [error] Cannot allow method body have type `::User` because declared as type `self`


### PR DESCRIPTION
## Problem

`ReturnTypeResolver#improve_method_return_types` only upgraded `-> untyped` signatures to Steep's inferred type. A return **already** inferred as `T?` was never replaced by Steep's narrowed `T` — even when Steep, with the method-entry / postcondition facts applied ([felixefelip/steep#78](https://github.com/felixefelip/steep/issues/78)), proves the body can't return nil.

Concretely, in the `example4` fixture:

```ruby
class Example4::Bar
  def foo_name
    Example4::Foo.name.upcase # => "JOHN DOE"
  end
end
```

A const-establishment fact makes `Example4::Foo.name` non-nil at the callee's entry, so `foo_name` returns `String`, not `String?`. `run_foo_name` happened to start as `-> untyped` (so the first loop upgraded it to `String`), while `foo_name` started as `-> String?` and the upgrade was skipped — same body, different result purely from which loop owned it.

## Fix

Add a dedicated `T? -> T` narrowing loop after the Array-override loop in `improve_method_return_types`. It is deliberately conservative:

- only fires on an already-nilable signature (`current` ends in `?`);
- requires a strict `nilablize(steep) == current` match, so an unrelated Steep type can never clobber a good signature;
- skips `untyped`/`nil`/`bot` Steep types and methods whose body has an explicit `nil` return (nilable is then the honest answer);
- reuses the existing `self`-return rewrite.

`Example4::Bar#foo_name` now infers `() -> String`, resolving the steep-check error on `example4.rb:36` (`Example4::Bar.new.foo_name.upcase`).

## Validation

- `steep check app/models/example4.rb` in the dummy: line 36 resolved; only the 4 intentional `# error not method` lines (14, 22, 27, 40) remain.
- `spec/integration` — 60 examples, 0 failures (snapshot + steep baseline).
- `spec/lib/.../return_type_resolver_spec.rb` — 10 examples, 0 failures.

Updates the dummy snapshot, the rbs_infer expectation, and drops the now-resolved line from `steep_baseline.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)