### PR TITLE
test(dummy): example3 reads after `Foo.user = nil` error (steep#83)

### DIFF
--- a/spec/dummy/app/models/example3.rb
+++ b/spec/dummy/app/models/example3.rb
@@ -1,64 +1,64 @@
 class Example3
-	class User
-		attr_reader :name
+  class User
+    attr_reader :name
 
-		def initialize(name:)
-			@name = name
-		end
-	end
+    def initialize(name:)
+      @name = name
+    end
+  end
 
-	class Foo
+  class Foo
     module GeneratedAttributes
-		  attr_accessor :user, :name
-		  attr_writer :foo_instance
+      attr_accessor :user, :name
+      attr_writer :foo_instance
     end
 
-	  include GeneratedAttributes
+    include GeneratedAttributes
 
     def self.foo_instance
-		  @foo_instance ||= Foo.new
+      @foo_instance ||= Foo.new
     end
 
     def self.user
-		  foo_instance.user
+      foo_instance.user
     end
 
-		def self.user=(value)
-			foo_instance.user = value
-		end
+    def self.user=(value)
+      foo_instance.user = value
+    end
 
-		def self.name
-		  foo_instance.name
-		end
+    def self.name
+      foo_instance.name
+    end
 
-		def self.name=(value)
-			foo_instance.name = value
-		end
+    def self.name=(value)
+      foo_instance.name = value
+    end
 
-		def user=(value)
-			super(value)
+    def user=(value)
+      super(value)
 
-			self.name = value&.name
-		end
-	end
+      self.name = value&.name
+    end
+  end
 
-	def self.run
-		user = User.new(name: 'John Doe')
+  def self.run
+    user = User.new(name: 'John Doe')
 
-		Foo.user = user
+    Foo.user = user
 
-		Foo.user.name.upcase
-		Foo.foo_instance.user.name.upcase
-		Foo.foo_instance.name.upcase
-		Foo.name.upcase # => "JOHN DOE"
+    Foo.user.name.upcase
+    Foo.foo_instance.user.name.upcase
+    Foo.foo_instance.name.upcase
+    Foo.name.upcase # => "JOHN DOE"
 
-		Foo.user = nil
+    Foo.user = nil
 
     Foo.user.name.upcase # error not method
     Foo.foo_instance.user.name.upcase # error not method
     Foo.foo_instance.name.upcase # error not method
     Foo.name.upcase # error not method
 
-		nil
-	end
+    nil
+  end
 end

--- a/spec/dummy/app/models/example3.rb
+++ b/spec/dummy/app/models/example3.rb
@@ -54,9 +54,11 @@ class Example3
 
 		Foo.user = nil
 
-		# Foo.user.name.upcase # error not method
-		# Foo.foo_instance.user.name.upcase # error not method
-		# Foo.foo_instance.name.upcase # error not method
-		# Foo.name.upcase # error not method
+    Foo.user.name.upcase # error not method
+    Foo.foo_instance.user.name.upcase # error not method
+    Foo.foo_instance.name.upcase # error not method
+    Foo.name.upcase # error not method
+
+		nil
 	end
 end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -6,6 +6,10 @@ app/models/concerns/test/filtrable.rb:7:24: [error] Type `(singleton(::Test) & s
 app/models/concerns/test/filtrable.rb:7:4: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `scope`
 app/models/concerns/test/filtrable.rb:8:26: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `where`
 app/models/concerns/test/filtrable.rb:8:4: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `scope`
+app/models/example3.rb:57:13: [error] Type `(::Example3::User | nil)` does not have method `name`
+app/models/example3.rb:58:26: [error] Type `(::Example3::User | nil)` does not have method `name`
+app/models/example3.rb:59:26: [error] Type `(::String | nil)` does not have method `upcase`
+app/models/example3.rb:60:13: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:14:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:22:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:27:23: [error] Type `(::String | nil)` does not have method `upcase`


### PR DESCRIPTION
## What

Uncomments the four reads after `Foo.user = nil` in `Example3.run`:

```ruby
Foo.user = nil

Foo.user.name.upcase              # (User | nil).name  → error
Foo.foo_instance.user.name.upcase # (User | nil).name  → error (memoized accessor)
Foo.foo_instance.name.upcase      # (String | nil).upcase → error (memoized accessor)
Foo.name.upcase                   # (String | nil).upcase → error
```

Once the write nils the slot, each read is a genuine nil-deref. The checker now reports all four — direct getter and memoized accessor alike — and they're recorded in `steep_baseline.txt`.

## Depends on felixefelip/steep#83

These errors only appear with the Steep fix. `Foo.user = nil` must invalidate Steep's **pure-send cache** for the slot, not just the const-path fact (which #82 already handled) — otherwise an earlier narrowed read's cached non-nil type masks the nil and the deref goes unreported. See steep#83 for the mechanism.

## No inference change

The added lines are reads, not call-sites, so they feed no parameter/return inference — `example3.rbs` and its snapshot are unchanged. Only `steep_baseline.txt` gains the four entries. The `example2`/`example3` integration snapshot cases still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
