### PR TITLE
test(dummy): document known const-narrowing gaps in example3

### DIFF
--- a/spec/dummy/app/models/example3.rb
+++ b/spec/dummy/app/models/example3.rb
@@ -35,6 +35,12 @@ class Example3
       foo_instance.name = value
     end
 
+    # Mutates the `user` slot to nil, but the caller only sees `Foo.clear_user`
+    # (no `=`), so nothing tells the caller the slot was invalidated.
+    def self.clear_user
+      foo_instance.user = nil
+    end
+
     def user=(value)
       super(value)
 
@@ -60,5 +66,59 @@ class Example3
     Foo.name.upcase # error not method
 
     nil
+  end
+
+  # ---------------------------------------------------------------------------
+  # Known const-narrowing gaps (companions to felixefelip/steep#83). Each is a
+  # spelling that reaches the SAME slot Steep narrows for `Foo.user` /
+  # `Foo.foo_instance.user`, but through a path the syntactic-path keying can't
+  # tie back — so the narrowing is either unsound (a nil slips past) or
+  # incomplete (a provably non-nil read is rejected). Marked SOUNDNESS GAP /
+  # COMPLETENESS GAP; the `# should:` vs `# actual:` comments record today's
+  # behavior and flip when the fork closes the gap.
+  # ---------------------------------------------------------------------------
+
+  # SOUNDNESS GAP — write through a local alias. `f` holds the same object as
+  # `Foo.foo_instance`, but the write's receiver is a plain local, which
+  # `memoized_singleton_accessor_base` doesn't recognize, so neither the fact
+  # nor the pure-send cache for `Foo.user` is invalidated.
+  def self.gap_alias_write
+    u = User.new(name: 'x')
+    Foo.user = u
+    Foo.user.name.upcase # ok: narrowed here
+    f = Foo.foo_instance
+    f.user = nil
+    Foo.user.name.upcase # should: error (nil); actual: NO error (stale non-nil)
+  end
+
+  # SOUNDNESS GAP — conditional write. The nil write invalidates on the `then`
+  # path, but the branch join keeps the fact from the other path, so the read
+  # after the `if` stays narrowed.
+  def self.gap_conditional(cond)
+    u = User.new(name: 'x')
+    Foo.user = u
+    Foo.user = nil if cond
+    Foo.user.name.upcase # should: error (nil on a path); actual: NO error
+  end
+
+  # SOUNDNESS GAP — mutation hidden behind a method call. The caller sees
+  # `Foo.clear_user` (no `=`), so the const-path write handling never fires and
+  # there is no const-path analog to `apply_ivar_effects` to drop the fact.
+  def self.gap_callee_mutation
+    u = User.new(name: 'x')
+    Foo.user = u
+    Foo.clear_user
+    Foo.user.name.upcase # should: error (nil); actual: NO error (stale non-nil)
+  end
+
+  # COMPLETENESS GAP — read through a local alias. Provably non-nil right after
+  # the establishing write, but `g.user` is a third spelling the fact isn't
+  # keyed under, so it is not narrowed. Conservative (a false positive), not
+  # dangerous.
+  def self.gap_alias_read
+    u = User.new(name: 'x')
+    Foo.user = u
+    g = Foo.foo_instance
+    g.user.name.upcase # should: no error (non-nil); actual: error (false positive)
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example3.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example3.rbs
@@ -1,5 +1,9 @@
 class Example3
   def self.run: () -> nil
+  def self.gap_alias_write: () -> String
+  def self.gap_conditional: (untyped cond) -> String
+  def self.gap_callee_mutation: () -> String
+  def self.gap_alias_read: () -> untyped
 end
 
 class Example3
@@ -27,6 +31,7 @@ class Example3
     def self.user=: ((User | nil) value) -> (User | nil)
     def self.name: () -> String?
     def self.name=: (String? value) -> String?
+    def self.clear_user: () -> nil
 
     def user=: ((User | nil) value) -> untyped
   end

--- a/spec/expectations/models/example3.rbs
+++ b/spec/expectations/models/example3.rbs
@@ -1,5 +1,9 @@
 class Example3
   def self.run: () -> nil
+  def self.gap_alias_write: () -> String
+  def self.gap_conditional: (untyped cond) -> String
+  def self.gap_callee_mutation: () -> String
+  def self.gap_alias_read: () -> untyped
 end
 
 class Example3
@@ -27,6 +31,7 @@ class Example3
     def self.user=: ((User | nil) value) -> (User | nil)
     def self.name: () -> String?
     def self.name=: (String? value) -> String?
+    def self.clear_user: () -> nil
 
     def user=: ((User | nil) value) -> untyped
   end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -6,10 +6,11 @@ app/models/concerns/test/filtrable.rb:7:24: [error] Type `(singleton(::Test) & s
 app/models/concerns/test/filtrable.rb:7:4: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `scope`
 app/models/concerns/test/filtrable.rb:8:26: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `where`
 app/models/concerns/test/filtrable.rb:8:4: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `scope`
-app/models/example3.rb:57:13: [error] Type `(::Example3::User | nil)` does not have method `name`
-app/models/example3.rb:58:26: [error] Type `(::Example3::User | nil)` does not have method `name`
-app/models/example3.rb:59:26: [error] Type `(::String | nil)` does not have method `upcase`
-app/models/example3.rb:60:13: [error] Type `(::String | nil)` does not have method `upcase`
+app/models/example3.rb:63:13: [error] Type `(::Example3::User | nil)` does not have method `name`
+app/models/example3.rb:64:26: [error] Type `(::Example3::User | nil)` does not have method `name`
+app/models/example3.rb:65:26: [error] Type `(::String | nil)` does not have method `upcase`
+app/models/example3.rb:66:13: [error] Type `(::String | nil)` does not have method `upcase`
+app/models/example3.rb:122:11: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example4.rb:14:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:22:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:27:23: [error] Type `(::String | nil)` does not have method `upcase`


### PR DESCRIPTION
## What

Materializes the const-narrowing gaps as living fixtures in `example3.rb`, alongside the steep#83 case. Each is a spelling that reaches the **same slot** Steep narrows for `Foo.user` / `Foo.foo_instance.user`, but through a path the syntactic-path keying can't tie back — so the narrowing is either unsound (a nil slips past) or incomplete (a provably non-nil read is rejected).

| Fixture | Kind | Behavior today |
|---|---|---|
| `gap_alias_write` | **soundness** | `f = Foo.foo_instance; f.user = nil` — write through a local; neither the fact nor the pure-send cache is invalidated. Read after keeps stale non-nil. **No error.** |
| `gap_conditional` | **soundness** | `Foo.user = nil if cond` — the branch join keeps the fact from the other path. Read after stays narrowed. **No error.** |
| `gap_callee_mutation` | **soundness** | `Foo.clear_user` whose body nils the slot; caller sees no `=`, and there's no const-path analog to `apply_ivar_effects`. **No error.** |
| `gap_alias_read` | **completeness** | `g = Foo.foo_instance; g.user` is provably non-nil but not narrowed — a false positive. **Errors** (the one baseline entry). |

Each method carries `# should:` vs `# actual:` comments recording today's behavior. The three soundness gaps produce **no** error today, so they're documented in-code but contribute nothing to the baseline; `gap_alias_read` is the single new baseline entry. They flip automatically when the fork closes each gap.

## Why these exist (one root)

All const-path narrowing is keyed on **syntactic spelling** — `Foo.user`, plus the memoized twin `Foo.foo_instance.user` (stable by construction, `@x ||= Foo.new`). Any other path to the same runtime slot that can't be tied back to that syntax is invisible: on a **write** that's a soundness hole (missed invalidation), on a **read** a completeness hole (missed narrowing). steep#83 fixed one instance (a second store, the pure-send cache, wasn't invalidated); these are the neighbors.

## Notes

- Adding `Foo.clear_user` shifted `run()`'s reads, so their baseline lines move `57–60 → 63–66` (mechanical). `example2` is unaffected; the single-pass expectation and multi-pass on-disk sig regenerated to an identical fixed-point.
- My read on priority: the **conditional/join** gap is the most impactful next fork fix — it's ordinary code (`x = nil if …`), it's a soundness hole, and it likely shares a root with a loop back-edge case (how the fact / pure-send stores join at control-flow merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
