### PR TITLE
feat(current): delegate singleton setters through a typed __rbs_infer_instance

### DIFF
--- a/lib/rbs_infer/extensions/rails/current_attributes_runtime_generator.rb
+++ b/lib/rbs_infer/extensions/rails/current_attributes_runtime_generator.rb
@@ -115,6 +115,7 @@ module RbsInfer
         def reopen_source(reopen)
           blocks = [module_block(reopen.names)]
           reopen.names.each { |name| blocks.concat(singleton_accessor_defs(name, reopen.overrides)) }
+          blocks.concat(instance_helper_defs(reopen.class_name, reopen.names, reopen.overrides))
           blocks.concat(initialize_def(reopen.defaults))
           blocks.concat(set_with_defs(reopen.names))
 
@@ -153,6 +154,13 @@ module RbsInfer
         # writes it (unifying the pool) AND delegates to the instance so an
         # override runs. Skips the ones the class overrides at the singleton
         # level.
+        #
+        # The delegation goes through `__rbs_infer_instance` (a memoized helper
+        # this generator emits, typed as the concrete subclass) rather than the
+        # framework `instance`, whose gem RBS is `() -> untyped`. That lets the
+        # Steep fork recognize the delegation by the receiver's RETURN TYPE (the
+        # same generic path a `@foo ||= Foo.new` accessor rides) instead of a
+        # hard-coded `instance` name in the checker core.
         def singleton_accessor_defs(name, overrides)
           defs = []
           defs << ["def self.#{name}", "  @#{name}", "end"] unless overrides.include?([true, name])
@@ -160,11 +168,28 @@ module RbsInfer
             defs << [
               "def self.#{name}=(value)",
               "  @#{name} = value",
-              "  instance.#{name} = value",
+              "  __rbs_infer_instance.#{name} = value",
               "end"
             ]
           end
           defs
+        end
+
+        # The memoized singleton-instance helper the singleton setters delegate
+        # through. Modeled as `@x ||= Klass.new` — the same shape Steep infers a
+        # concrete return type for — so `__rbs_infer_instance` types as the
+        # subclass and the delegation is recognized structurally, without the
+        # checker knowing the Rails `instance` name. Only emitted when at least
+        # one setter actually delegates (i.e. isn't overridden at the singleton
+        # level).
+        def instance_helper_defs(class_name, names, overrides)
+          return [] unless names.any? { |name| !overrides.include?([true, "#{name}="]) }
+
+          [[
+            "def self.__rbs_infer_instance",
+            "  @__rbs_infer_instance ||= #{class_name}.new",
+            "end"
+          ]]
         end
 
         def initialize_def(defaults)

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -72,6 +72,11 @@ postconditions:
       author_name: "::String"
       user: "((::User & ::User::Validated) | ::User)"
 - class: Current
+  method: __rbs_infer_instance
+  effects:
+    may_write:
+    - "@__rbs_infer_instance"
+- class: Current
   method: author_name=
   unconditional:
     establishes_consts:

--- a/spec/dummy/sig/generated/steep_current_runtime/current.rb
+++ b/spec/dummy/sig/generated/steep_current_runtime/current.rb
@@ -26,7 +26,7 @@ class Current
 
   def self.user=(value)
     @user = value
-    instance.user = value
+    __rbs_infer_instance.user = value
   end
 
   def self.author_name
@@ -35,7 +35,11 @@ class Current
 
   def self.author_name=(value)
     @author_name = value
-    instance.author_name = value
+    __rbs_infer_instance.author_name = value
+  end
+
+  def self.__rbs_infer_instance
+    @__rbs_infer_instance ||= Current.new
   end
 
   def self.set(user: nil, author_name: nil, &block)

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs
@@ -1,5 +1,6 @@
 class Current
   self.@user: ((User & User::Validated) | User)?
+  self.@__rbs_infer_instance: Current?
 
   @user: ((User & User::Validated) | User)?
   @author_name: String?
@@ -17,6 +18,7 @@ class Current
   def self.user=: (((User & User::Validated)? | User?) value) -> ((User & User::Validated)? | User?)
   def self.author_name: () -> String?
   def self.author_name=: (String? value) -> String?
+  def self.__rbs_infer_instance: () -> Current
   def self.set: (?user: ((User & User::Validated) | User)?, ?author_name: String?) ?{ (untyped) -> untyped } -> nil
   def self.with: (?user: (User & User::Validated)?, ?author_name: String?) ?{ (untyped) -> untyped } -> nil
 end

--- a/spec/expectations/steep_current_runtime/current.rb
+++ b/spec/expectations/steep_current_runtime/current.rb
@@ -26,7 +26,7 @@ class Current
 
   def self.user=(value)
     @user = value
-    instance.user = value
+    __rbs_infer_instance.user = value
   end
 
   def self.author_name
@@ -35,7 +35,11 @@ class Current
 
   def self.author_name=(value)
     @author_name = value
-    instance.author_name = value
+    __rbs_infer_instance.author_name = value
+  end
+
+  def self.__rbs_infer_instance
+    @__rbs_infer_instance ||= Current.new
   end
 
   def self.set(user: nil, author_name: nil, &block)

--- a/spec/lib/rbs_infer/extensions/rails/current_attributes_runtime_generator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/current_attributes_runtime_generator_spec.rb
@@ -52,10 +52,35 @@ RSpec.describe RbsInfer::Extensions::Rails::CurrentAttributesRuntimeGenerator do
     expect(source).to include("def user=(value)")
   end
 
-  it "makes the singleton setter delegate to the instance" do
+  it "makes the singleton setter delegate through the typed __rbs_infer_instance helper" do
     source = source_for("app/models/current.rb" => WITH_OVERRIDE)
     expect(source).to include("def self.user=(value)")
-    expect(source).to include("instance.user = value")
+    # Delegation routes through the memoized helper (typed as the subclass),
+    # NOT the framework `instance` (typed `untyped` by gem RBS).
+    expect(source).to include("__rbs_infer_instance.user = value")
+    expect(source).not_to match(/(?<!__rbs_infer_)instance\.user = value/)
+  end
+
+  it "emits the memoized __rbs_infer_instance helper when a setter delegates" do
+    source = source_for("app/models/current.rb" => WITH_OVERRIDE)
+    # `@x ||= Klass.new` — the shape Steep infers a concrete return type for,
+    # so the delegation is recognized by return type, not by the `instance` name.
+    expect(source).to include("def self.__rbs_infer_instance")
+    expect(source).to include("@__rbs_infer_instance ||= Current.new")
+  end
+
+  it "omits the __rbs_infer_instance helper when no setter delegates" do
+    source = source_for("app/models/current.rb" => <<~RUBY)
+      class Current < ActiveSupport::CurrentAttributes
+        attribute :user
+
+        def self.user=(value)
+          @user = value
+        end
+      end
+    RUBY
+
+    expect(source).not_to include("__rbs_infer_instance")
   end
 
   it "skips singleton accessors the class overrides itself" do


### PR DESCRIPTION
## What

The CurrentAttributes runtime reopen delegated its singleton setters through the framework `instance`:

```ruby
def self.user=(value)
  @user = value
  instance.user = value          # instance : () -> untyped  (gem RBS)
end
```

Because gem_rbs types `CurrentAttributes.instance` as `() -> untyped`, the Steep fork could only recognize this delegation by hard-coding the `instance` **name** in its postcondition inferrer — a Rails-ism in the checker core.

This routes the delegation through a memoized helper the generator emits and types precisely:

```ruby
def self.user=(value)
  @user = value
  __rbs_infer_instance.user = value
end

def self.__rbs_infer_instance
  @__rbs_infer_instance ||= Current.new   # analyzer infers () -> Current
end
```

`__rbs_infer_instance` uses the exact `@x ||= Klass.new` shape Steep already infers a concrete return type for, so the delegation is now recognized by the receiver's **return type** — the same generic memoized-accessor path a `@foo ||= Foo.new` singleton accessor rides — with no framework name in the checker. Emitted only when a setter actually delegates (skipped when the class overrides the singleton setter itself).

## Why

Removes a framework name from the checker's inference core (see `keep-core-framework-agnostic.md`). It's the enabling half of a coordinated pair: it lets **felixefelip/steep#84** drop the `instance`-name special-case in `delegating_instance_receiver?`.

## Verification

- Generator unit spec updated: asserts the delegation targets `__rbs_infer_instance`, the memoized helper is emitted (and omitted when no setter delegates). Unit suite 670, integration snapshots green (only the `steep_current_runtime/current.rb` snapshot moves; the `Current` model RBS is unchanged — it uses `super`).
- Dummy `steep check`: **identical 27-error set** both with the current fork (line still present — the new delegation rides the type path) **and** with the fork's removal applied. No `current.rb` errors; `Current.new` type-checks.
- `.steep_postconditions.yml` gains only the new `__rbs_infer_instance` effect entry; the `Current.user=` establishment is unchanged.

## Merge order

Merge **this first**, then felixefelip/steep#84. Between the two, nothing regresses (the fork still has its name check; the new delegation is recognized either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
