### PR TITLE
feat(erb): render each guarded action's view in the controller-runtime

### DIFF
--- a/lib/rbs_infer/extensions/rails/controllers/pseudo_code_builder.rb
+++ b/lib/rbs_infer/extensions/rails/controllers/pseudo_code_builder.rb
@@ -2,6 +2,7 @@
 
 require "active_support/core_ext/string/inflections"
 require_relative "callback_chain_scanner"
+require_relative "../erb_convention_generator/view_path_naming"
 
 module RbsInfer
   module Extensions
@@ -64,8 +65,12 @@ module RbsInfer
             # Regenerated on every run; do not edit.
           RUBY
 
-          def initialize(scanner:)
+          # app_dir: used to check whether an action's convention view template
+          # exists (to emit the view render site). Required — a nil default would
+          # silently skip every view render site.
+          def initialize(scanner:, app_dir:)
             @scanner = scanner
+            @app_dir = app_dir
           end
 
           # => [FileEntry] (framework reopen first, then one .rb per controller
@@ -175,9 +180,41 @@ module RbsInfer
               link_lines(callback) + ["return if #{HALTED}", ""]
             end
 
-            body = (lines + [action]).map { |line| line.empty? ? "" : "    #{line}" }
+            body = (lines + [action] + view_render_lines(class_name, action))
+                     .map { |line| line.empty? ? "" : "    #{line}" }
 
             ["  def __rbs_infer__run_#{action}", *body, "  end"].join("\n") + "\n"
+          end
+
+          # After the action, model Rails' implicit convention render: unless the
+          # action already responded (`redirect_to`/explicit `render`/`head` set
+          # `performed?`), it renders `action`'s view. Calling the view's
+          # compiled-method body (`__rbs_infer__body`, felixefelip/steep#85) at
+          # this point — where the guard chain's facts hold — lets those facts
+          # narrow reads in the view. The `return if performed?` before it makes
+          # the redirect / explicit-render case a no-op automatically. Empty when
+          # the action has no convention template.
+          def view_render_lines(class_name, action)
+            erb_class = convention_view_class(class_name, action) or return []
+            ["", "return if #{HALTED}", "", "#{erb_class}.new.__rbs_infer__body"]
+          end
+
+          # The ERB class of `action`'s convention template, or nil when none
+          # exists. `PostsController#show` → `posts/show.html.erb` → `ERBPostsShow`.
+          def convention_view_class(class_name, action)
+            view_dir = class_name.sub(/Controller\z/, "").underscore
+            return nil if view_dir.empty?
+
+            fmt = %w[html turbo_stream].find do |f|
+              File.exist?(File.join(@app_dir, "app/views", view_dir, "#{action}.#{f}.erb"))
+            end
+            return nil unless fmt
+
+            view_path_naming.erb_class_name("#{view_dir}/#{action}.#{fmt}.erb")
+          end
+
+          def view_path_naming
+            @view_path_naming ||= Object.new.extend(ErbConventionGenerator::ViewPathNaming)
           end
 
           # A handler link is a self-send; a block link is the block's body

--- a/lib/rbs_infer/extensions/rails/controllers/runtime_generator.rb
+++ b/lib/rbs_infer/extensions/rails/controllers/runtime_generator.rb
@@ -33,7 +33,7 @@ module RbsInfer
           # controller with actions). Public so the CLI/specs can inspect the
           # pseudo-code without touching disk.
           def build
-            PseudoCodeBuilder.new(scanner: CallbackChainScanner.new(app_dir: @app_dir)).build
+            PseudoCodeBuilder.new(scanner: CallbackChainScanner.new(app_dir: @app_dir), app_dir: @app_dir).build
           end
 
           # Writes the sidecar directory (one .rb/.rbs pair per controller, plus

--- a/lib/rbs_infer/extensions/rails/erb_convention_generator.rb
+++ b/lib/rbs_infer/extensions/rails/erb_convention_generator.rb
@@ -87,6 +87,13 @@ module RbsInfer
 
           lines << "  def params: () -> ActionController::Parameters"
 
+          # The template-as-method identity (Steep `@type self_method:`). At
+          # runtime ActionView compiles the template into a method; the
+          # controller-runtime "renders" the view by calling this, so guarded
+          # actions' method-entry facts (e.g. a populated `Current`) narrow reads
+          # in the view body (felixefelip/steep#85).
+          lines << "  def __rbs_infer__body: () -> void"
+
           helpers.each do |helper|
             lines << "  include #{helper}"
           end

--- a/spec/dummy/sig/generated/steep_controller_runtime/posts_controller.rb
+++ b/spec/dummy/sig/generated/steep_controller_runtime/posts_controller.rb
@@ -10,12 +10,14 @@ class PostsController
     authenticate_user
     return if performed?
 
-    current_user.full_name
-
     log_user_author_name if current_user_present?
     return if performed?
 
     index
+
+    return if performed?
+
+    ERBPostsIndex.new.__rbs_infer__body
   end
 
   def __rbs_infer__run_show
@@ -29,6 +31,10 @@ class PostsController
     return if performed?
 
     show
+
+    return if performed?
+
+    ERBPostsShow.new.__rbs_infer__body
   end
 
   def __rbs_infer__run_new
@@ -39,6 +45,10 @@ class PostsController
     return if performed?
 
     new
+
+    return if performed?
+
+    ERBPostsNew.new.__rbs_infer__body
   end
 
   def __rbs_infer__run_create

--- a/spec/dummy/sig/generated/steep_controller_runtime/users_avatars_controller.rb
+++ b/spec/dummy/sig/generated/steep_controller_runtime/users_avatars_controller.rb
@@ -17,6 +17,10 @@ class Users::AvatarsController
     return if performed?
 
     edit
+
+    return if performed?
+
+    ERBUsersAvatarsEdit.new.__rbs_infer__body
   end
 
   def __rbs_infer__run_update

--- a/spec/dummy/sig/generated/steep_controller_runtime/users_controller.rb
+++ b/spec/dummy/sig/generated/steep_controller_runtime/users_controller.rb
@@ -24,5 +24,9 @@ class UsersController
     return if performed?
 
     show
+
+    return if performed?
+
+    ERBUsersShow.new.__rbs_infer__body
   end
 end

--- a/spec/dummy/sig/rbs_infer_erb/app/views/layouts/application.rbs
+++ b/spec/dummy/sig/rbs_infer_erb/app/views/layouts/application.rbs
@@ -2,5 +2,6 @@
 
 class ERBLayoutsApplication
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include ActionViewContext
 end

--- a/spec/dummy/sig/rbs_infer_erb/app/views/posts/_comment.rbs
+++ b/spec/dummy/sig/rbs_infer_erb/app/views/posts/_comment.rbs
@@ -3,5 +3,6 @@
 class ERBPartialPostsComment
   attr_reader comment: Comment & Comment::Validated
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include ActionViewContext
 end

--- a/spec/dummy/sig/rbs_infer_erb/app/views/posts/_form.rbs
+++ b/spec/dummy/sig/rbs_infer_erb/app/views/posts/_form.rbs
@@ -3,5 +3,6 @@
 class ERBPartialPostsForm
   attr_reader post: Post | (Post & Post::Validated)
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include ActionViewContext
 end

--- a/spec/dummy/sig/rbs_infer_erb/app/views/posts/_summary.rbs
+++ b/spec/dummy/sig/rbs_infer_erb/app/views/posts/_summary.rbs
@@ -3,5 +3,6 @@
 class ERBPartialPostsSummary
   attr_reader post: (Post & Post::Validated)
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include ActionViewContext
 end

--- a/spec/dummy/sig/rbs_infer_erb/app/views/posts/edit.rbs
+++ b/spec/dummy/sig/rbs_infer_erb/app/views/posts/edit.rbs
@@ -3,6 +3,7 @@
 class ERBPostsEdit
   @post: Post | (Post & Post::Validated)
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include PostsHelper
   include ActionViewContext
 end

--- a/spec/dummy/sig/rbs_infer_erb/app/views/posts/index.rbs
+++ b/spec/dummy/sig/rbs_infer_erb/app/views/posts/index.rbs
@@ -3,6 +3,7 @@
 class ERBPostsIndex
   @posts: Post::ActiveRecord_Relation
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include PostsHelper
   include ActionViewContext
 end

--- a/spec/dummy/sig/rbs_infer_erb/app/views/posts/new.rbs
+++ b/spec/dummy/sig/rbs_infer_erb/app/views/posts/new.rbs
@@ -3,6 +3,7 @@
 class ERBPostsNew
   @post: Post | (Post & Post::Validated)
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include PostsHelper
   include ActionViewContext
 end

--- a/spec/dummy/sig/rbs_infer_erb/app/views/posts/show.rbs
+++ b/spec/dummy/sig/rbs_infer_erb/app/views/posts/show.rbs
@@ -4,6 +4,7 @@ class ERBPostsShow
   @comments: Comment::ActiveRecord_Relation
   @post: (Post & Post::Validated)
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include PostsHelper
   include ActionViewContext
 end

--- a/spec/dummy/sig/rbs_infer_erb/app/views/users/avatars/edit.rbs
+++ b/spec/dummy/sig/rbs_infer_erb/app/views/users/avatars/edit.rbs
@@ -3,5 +3,6 @@
 class ERBUsersAvatarsEdit
   @user: User & User::Validated
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include ActionViewContext
 end

--- a/spec/dummy/sig/rbs_infer_erb/app/views/users/show.rbs
+++ b/spec/dummy/sig/rbs_infer_erb/app/views/users/show.rbs
@@ -2,7 +2,8 @@
 
 class ERBUsersShow
   @user: (User & User::Validated)
-  @posts: Post::ActiveRecord_Associations_CollectionProxy
+  @posts: User_Post::ActiveRecord_Associations_CollectionProxy
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include ActionViewContext
 end

--- a/spec/expectations/views/layouts/application.rbs
+++ b/spec/expectations/views/layouts/application.rbs
@@ -2,5 +2,6 @@
 
 class ERBLayoutsApplication
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include ActionViewContext
 end

--- a/spec/expectations/views/posts/_comment.rbs
+++ b/spec/expectations/views/posts/_comment.rbs
@@ -3,5 +3,6 @@
 class ERBPartialPostsComment
   attr_reader comment: Comment & Comment::Validated
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include ActionViewContext
 end

--- a/spec/expectations/views/posts/_form.rbs
+++ b/spec/expectations/views/posts/_form.rbs
@@ -3,5 +3,6 @@
 class ERBPartialPostsForm
   attr_reader post: Post | (Post & Post::Validated)
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include ActionViewContext
 end

--- a/spec/expectations/views/posts/_summary.rbs
+++ b/spec/expectations/views/posts/_summary.rbs
@@ -3,5 +3,6 @@
 class ERBPartialPostsSummary
   attr_reader post: (Post & Post::Validated)
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include ActionViewContext
 end

--- a/spec/expectations/views/posts/edit.rbs
+++ b/spec/expectations/views/posts/edit.rbs
@@ -3,6 +3,7 @@
 class ERBPostsEdit
   @post: Post | (Post & Post::Validated)
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include PostsHelper
   include ActionViewContext
 end

--- a/spec/expectations/views/posts/index.rbs
+++ b/spec/expectations/views/posts/index.rbs
@@ -3,6 +3,7 @@
 class ERBPostsIndex
   @posts: Post::ActiveRecord_Relation
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include PostsHelper
   include ActionViewContext
 end

--- a/spec/expectations/views/posts/new.rbs
+++ b/spec/expectations/views/posts/new.rbs
@@ -3,6 +3,7 @@
 class ERBPostsNew
   @post: Post | (Post & Post::Validated)
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include PostsHelper
   include ActionViewContext
 end

--- a/spec/expectations/views/posts/show.rbs
+++ b/spec/expectations/views/posts/show.rbs
@@ -4,6 +4,7 @@ class ERBPostsShow
   @comments: Comment::ActiveRecord_Relation
   @post: (Post & Post::Validated)
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include PostsHelper
   include ActionViewContext
 end

--- a/spec/expectations/views/users/avatars/edit.rbs
+++ b/spec/expectations/views/users/avatars/edit.rbs
@@ -3,5 +3,6 @@
 class ERBUsersAvatarsEdit
   @user: User & User::Validated
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include ActionViewContext
 end

--- a/spec/expectations/views/users/show.rbs
+++ b/spec/expectations/views/users/show.rbs
@@ -4,5 +4,6 @@ class ERBUsersShow
   @user: (User & User::Validated)
   @posts: User_Post::ActiveRecord_Associations_CollectionProxy
   def params: () -> ActionController::Parameters
+  def __rbs_infer__body: () -> void
   include ActionViewContext
 end


### PR DESCRIPTION
## What

The rbs_infer **producer** half of ERB-view narrowing (paired with felixefelip/steep **#85** consumer + **#86** producer). It lets a guarded action's proven facts — a populated `Current` past an auth `before_action` — narrow reads in the view that action renders, with **no marker sidecar**.

## How

- **`ErbConventionGenerator`** declares `def __rbs_infer__body: () -> void` on each ERB class. That's the method a template *becomes* at runtime (ActionView compiles each template to a method), addressed via Steep's `@type self_method:`.
- **`PseudoCodeBuilder#runner_method`** (the controller-runtime) now, after the action, models Rails' implicit convention render:
  ```ruby
  def __rbs_infer__run_show
    authenticate_user
    return if performed?
    …
    show
    return if performed?
    ERBPostsShow.new.__rbs_infer__body   # ← the view render site
  end
  ```
  emitted only when the action has a convention template (`app/views/<c>/<action>.{html,turbo_stream}.erb`). The `return if performed?` before it makes a `redirect_to` / explicit `render` a no-op automatically.

At that call the guard chain's facts hold, so the fork (#86) records a method-entry fact for `ERBPostsShow#__rbs_infer__body` — **intersected across every render site** (sound for a view rendered by several actions) — and #85 applies it to the template body. Verified end-to-end: a guarded view's `Current.user.name` narrows non-nil; the dummy Steep error set is unchanged (27).

## Standalone-safe

Without the fork producer, the render site is an **inert `void` call** — the method is declared but no fact is inferred and no `@type self_method:` is emitted — so nothing changes until #85/#86 merge. This can merge in any order.

## Tests

- ERB snapshot expectations regenerated: each class gains `def __rbs_infer__body: () -> void`.
- Unit **670** + integration **67** green.
- `.steep_postconditions.yml` (a Steep-written artifact) is intentionally **not** committed — it materializes the ERB facts only once the fork producer is present.

## Not here (follow-up)

Partials (a view rendering another view) need the fork Runner to seed each method with its own entry facts (a fixpoint) — orthogonal, tracked for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
