### PR TITLE
test(dummy): example5 — the second-hop transitive const-narrowing gap

### DIFF
--- a/spec/dummy/app/models/example5.rb
+++ b/spec/dummy/app/models/example5.rb
@@ -1,0 +1,39 @@
+class Example5
+  class Foo
+    def self.name
+      @name
+    end
+
+    def self.name=(value)
+      @name = value
+    end
+  end
+
+  class Bar
+    # FIRST HOP — called directly from `run`, where `Foo.name` was just
+    # established. The method-entry fact reaches `foo_name`'s entry, so the read
+    # narrows. This is the same one-hop propagation example4 relies on.
+    def foo_name
+      Example5::Foo.name.upcase # => "JOHN DOE" (1st hop: narrows)
+
+      deep_foo_name
+    end
+
+    # SECOND HOP — reached only THROUGH `foo_name`. At runtime `Foo.name` is
+    # still established (nobody cleared it between `run` and here), so a human
+    # reading the source sees this is non-nil. But the fact does not propagate
+    # past the first hop: when the Runner walks `foo_name`'s body it starts with
+    # no facts (it isn't seeded with `foo_name`'s own entry fact), so nothing is
+    # attributed to `deep_foo_name`. A fixpoint over the call graph would close
+    # this — the reusable piece that also unlocks view -> partial rendering.
+    def deep_foo_name
+      Example5::Foo.name.upcase # should: "JOHN DOE"; actual: error (2nd-hop gap)
+    end
+  end
+
+  def run
+    Example5::Foo.name = 'John Doe'
+
+    Example5::Bar.new.foo_name # 1st hop narrows; foo_name -> deep_foo_name is the 2nd hop
+  end
+end

--- a/spec/dummy/sig/rbs_infer/app/models/example5.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example5.rbs
@@ -1,0 +1,19 @@
+class Example5
+  def run: () -> untyped
+end
+
+class Example5
+  class Foo
+    self.@name: String?
+
+    def self.name: () -> String?
+    def self.name=: (String value) -> untyped
+  end
+end
+
+class Example5
+  class Bar
+    def foo_name: () -> untyped
+    def deep_foo_name: () -> untyped
+  end
+end

--- a/spec/expectations/models/example5.rbs
+++ b/spec/expectations/models/example5.rbs
@@ -1,0 +1,19 @@
+class Example5
+  def run: () -> untyped
+end
+
+class Example5
+  class Foo
+    self.@name: String?
+
+    def self.name: () -> String?
+    def self.name=: (String value) -> untyped
+  end
+end
+
+class Example5
+  class Bar
+    def foo_name: () -> untyped
+    def deep_foo_name: () -> untyped
+  end
+end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -15,6 +15,7 @@ app/models/example4.rb:14:25: [error] Type `(::String | nil)` does not have meth
 app/models/example4.rb:22:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:27:23: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:40:23: [error] Type `(::String | nil)` does not have method `upcase`
+app/models/example5.rb:30:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/post/notifiable.rb:28:24: [error] Type `(::User | nil)` does not have method `full_name`
 app/models/user/recoverable.rb:10:6: [error] Cannot allow method body have type `::User` because declared as type `self`
 app/models/user/recoverable.rb:14:6: [error] Cannot allow method body have type `::User` because declared as type `self`

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -202,6 +202,28 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     expect(rbs.chomp).to eq(expected_rbs(name).chomp)
   end
 
+  # Second-hop transitive gap: `run` establishes `Foo.name` then calls
+  # `Bar#foo_name` (1st hop — narrows, like example4), which calls
+  # `Bar#deep_foo_name` (2nd hop — should narrow but doesn't, since the
+  # method-entry fact isn't seeded into `foo_name`'s body to reach its callee).
+  # The `deep_foo_name` read is a baselined error until a call-graph fixpoint
+  # lands (the piece that also unlocks view -> partial rendering).
+  it "example5" do
+    name = "models/example5"
+    rbs = RbsInfer::Analyzer.new(
+      target_file: "app/models/example5.rb",
+      source_files: source_files
+    ).generate_rbs
+
+    if ENV["UPDATE_EXPECTATIONS"]
+      path = expectations_dir.join("#{name}.rbs")
+      path.dirname.mkpath
+      path.write(rbs)
+    end
+
+    expect(rbs.chomp).to eq(expected_rbs(name).chomp)
+  end
+
   # Class-instance variables (felixefelip/rbs_infer#86). A `@x` written in a
   # singleton method (`def self.x`, `class << self`) or directly in the class
   # body is a class-instance variable — RBS declares it `self.@x`, a slot


### PR DESCRIPTION
## What

A dummy fixture (companion to `example4`) that pins the **second-hop transitive gap** in const-path method-entry narrowing.

```ruby
def run
  Example5::Foo.name = 'John Doe'     # establishes Foo.name
  Example5::Bar.new.foo_name          # 1st hop
end

class Bar
  def foo_name
    Example5::Foo.name.upcase   # line 17 — 1st hop: NARROWS ✅
    deep_foo_name               # → 2nd hop
  end
  def deep_foo_name
    Example5::Foo.name.upcase   # line 30 — 2nd hop: ERRORS ❌ (should be "JOHN DOE")
  end
end
```

- **1st hop works** — `run` establishes `Foo.name` and calls `foo_name` directly, so the method-entry fact reaches `foo_name`'s entry and the read narrows (exactly the one-hop propagation `example4` relies on).
- **2nd hop fails** — `deep_foo_name` is reached only *through* `foo_name`. `Foo.name` is still established at runtime, but the fact doesn't propagate past the first hop: the Runner walks `foo_name`'s body starting with no facts (it isn't seeded with `foo_name`'s own entry fact), so nothing is attributed to `deep_foo_name`.

## Why

Pins the gap a **call-graph fixpoint** in the Steep fork's Runner would close — the reusable piece that also unlocks **view → partial** rendering and explicit cross-renders (`create` → `render :new`). It's the acceptance test for that work: when the fixpoint lands, line 30 narrows and its baseline entry is removed.

## Notes

- **Standalone** — pure model narrowing on mainline Steep's `method_entry_facts`; independent of the ERB producer PRs.
- Wired like example3/4: integration snapshot + `spec/expectations/models/example5.rbs` + `steep_baseline.txt` entry (`example5.rb:30`). **68 examples, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
