### PR TITLE
test(dummy): example6 now narrows across both if/else branches

### DIFF
--- a/spec/dummy/app/models/example6.rb
+++ b/spec/dummy/app/models/example6.rb
@@ -13,29 +13,31 @@ class Example6
     # Reached only from the `else` branch of `run`, where `Foo.name` is already
     # established — so a human reading the source sees this read as non-nil.
     def greet
-      Example6::Foo.name.upcase # should: "JOHN DOE"; actual: error (else-branch gap)
+      Example6::Foo.name.upcase # => "JOHN DOE" (else-branch call now carries the fact)
     end
   end
 
-  # BRANCH-SENSITIVE FLOW EXTRACTION gap ("peça (a)"). `Foo.name` is established
+  # BRANCH-SENSITIVE FLOW EXTRACTION ("peça (a)"). `Foo.name` is established
   # before the `if`, so it holds in BOTH branches; the `else` calls `greet` with
-  # a non-nil `Foo.name`. But the fork's flow extractor walks only ONE clause of
-  # a full `if/else` — `MethodEntryInferrer#call_target` returns the `then`
-  # clause when it is non-empty — so the `else`-branch call `Bar.new.greet` is
-  # never visited and `greet` never receives the entry fact. Its read is a
-  # baselined error until the extractor descends into every branch (recording
-  # each call with the branch-sensitive type `@typing` already computes).
+  # a non-nil `Foo.name`. The fork's flow extractor used to walk only ONE clause
+  # of a full `if/else` — `MethodEntryInferrer#call_target` returned the `then`
+  # clause when non-empty — so the `else`-branch call `Bar.new.greet` was never
+  # visited and `greet` never received the entry fact. Now the extractor descends
+  # into EVERY branch of a full `if/else` (and every `case/when`), recording each
+  # call with the branch-sensitive type `@typing` already computes, so `greet`
+  # narrows here just as the `then`-branch read does.
   #
   # This is the exact shape of `render :new` sitting in the `else` of
   # `if @post.save` (felixefelip/rbs_infer#104): the per-controller `render`
-  # override's dispatch stays inert until this same extraction lands.
+  # override's dispatch was inert until this extraction landed — now both the
+  # `then` and `else` render targets propagate their entry facts to the view.
   def run(condition)
     Example6::Foo.name = 'John Doe'
 
     if condition
-      Example6::Foo.name.upcase # then branch: narrows within `run` today
+      Example6::Foo.name.upcase # then branch: narrows within `run`
     else
-      Example6::Bar.new.greet # else branch: NOT walked -> greet errors (the gap)
+      Example6::Bar.new.greet # else branch: now walked -> greet carries the fact
     end
   end
 end

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -636,12 +636,27 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+- class: ERBPostsEdit
+  method: __rbs_infer__body
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
 - class: ERBPostsIndex
   method: __rbs_infer__body
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+- class: ERBPostsNew
+  method: __rbs_infer__body
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
 - class: ERBPostsShow
+  method: __rbs_infer__body
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+- class: ERBUsersAvatarsEdit
   method: __rbs_infer__body
   consts:
     Current.author_name: "::String"
@@ -671,6 +686,14 @@ method_entry_facts:
   method: name
   consts:
     Example5::Foo.name: "::String"
+- class: Example6::Bar
+  method: greet
+  consts:
+    Example6::Foo.name: "::String"
+- class: Example6::Foo
+  method: name
+  consts:
+    Example6::Foo.name: "::String"
 - class: FilterConfiguration
   method: configure_filter
   self_methods:
@@ -769,6 +792,13 @@ method_entry_facts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
 - class: PostsController
+  method: render
+  self_methods:
+    current_user: "(::User & ::User::Validated)"
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+- class: PostsController
   method: set_post
   self_methods:
     current_user: "(::User & ::User::Validated)"
@@ -796,6 +826,13 @@ method_entry_facts:
     Current.user: "(::User & ::User::Validated)"
 - class: Users::AvatarsController
   method: edit
+  self_methods:
+    current_user: "(::User & ::User::Validated)"
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+- class: Users::AvatarsController
+  method: render
   self_methods:
     current_user: "(::User & ::User::Validated)"
   consts:

--- a/spec/dummy/sig/rbs_infer/app/models/example6.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example6.rbs
@@ -1,5 +1,5 @@
 class Example6
-  def run: (untyped condition) -> untyped
+  def run: (untyped condition) -> String
 end
 
 class Example6
@@ -13,6 +13,6 @@ end
 
 class Example6
   class Bar
-    def greet: () -> untyped
+    def greet: () -> String
   end
 end

--- a/spec/expectations/models/example6.rbs
+++ b/spec/expectations/models/example6.rbs
@@ -1,5 +1,5 @@
 class Example6
-  def run: (untyped condition) -> untyped
+  def run: (untyped condition) -> String
 end
 
 class Example6
@@ -13,6 +13,6 @@ end
 
 class Example6
   class Bar
-    def greet: () -> untyped
+    def greet: () -> String
   end
 end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -15,7 +15,6 @@ app/models/example4.rb:14:25: [error] Type `(::String | nil)` does not have meth
 app/models/example4.rb:22:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:27:23: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:40:23: [error] Type `(::String | nil)` does not have method `upcase`
-app/models/example6.rb:16:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example7.rb:30:41: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example7.rb:31:42: [error] Type `(::Integer | nil)` does not have method `abs`
 app/models/post/notifiable.rb:28:24: [error] Type `(::User | nil)` does not have method `full_name`


### PR DESCRIPTION
Depends on **felixefelip/steep#88** (branch-sensitive flow extraction).

## What example6 demonstrated

`Foo.name` is established before an `if/else`, so it holds in **both** branches. The `else` branch calls `Bar.new.greet`, whose body reads `Foo.name.upcase`. A human reading the source sees that read as non-nil — but the fork's flow extractor walked only the `then` clause, so the `else`-branch call was never visited and `greet` never received the entry fact. `example6.rb:16` was a baselined error.

## What changed

With felixefelip/steep#88 the extractor descends into every branch of a full `if/else` (and `case/when`):

- **`example6.rb:16` (`greet`) no longer errors** — removed from `steep_baseline.txt`, mirroring the example5 precedent (`7aaec23`) when its gap closed.
- rbs_infer's SteepBridge now resolves `Bar#greet` and `Example6#run` from `untyped` → `String` (regenerated `sig/rbs_infer/.../example6.rbs` + `spec/expectations/models/example6.rbs`).
- `.steep_postconditions.yml` gains the real facts: `Example6::Bar#greet` now carries `Example6::Foo.name`, and the #104 per-controller `render` override's `case`/`when` dispatch propagates facts to **both** `ERBPostsEdit` and `ERBPostsNew`.
- Fixture comment updated to describe the working behavior instead of the gap.

## Verification

- `steep check`: **29 problems** (was 30); set-difference against the baseline is empty in both directions.
- Integration suite (`rails_dummy_spec.rb`): **61 examples, 0 failures**.
- CarrierWave `user.rbs` side-effect reverted; tree carries only the 5 intended files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)