### PR TITLE
test(dummy): example9 now narrows in if/elsif branches

### DIFF
--- a/spec/dummy/app/models/example9.rb
+++ b/spec/dummy/app/models/example9.rb
@@ -31,22 +31,21 @@ class Example9
     # (`:name` -> `Foo.name`, `:age` -> `Age.value`) — verified directly against
     # the Runner.
     #
-    # The CONSUMER side is where it stops. Partitions are applied in
-    # `TypeInference::CaseWhen`, which only runs for a `case` node; an
+    # The CONSUMER side used to stop here: partitions were applied only in
+    # `TypeInference::CaseWhen`, which runs for a `case` node, and an
     # `if which == :name` test is an ordinary `:send` predicate that nothing
-    # correlates back to the `:name` partition. So both reads are baselined
-    # errors even though the facts needed to type them are sitting in the
-    # sidecar, already computed and correctly partitioned.
+    # correlated back to the `:name` partition. Both reads errored even though
+    # the facts were sitting in the sidecar, already computed and partitioned.
     #
-    # Closing it means recognizing an equality test against a literal on a
-    # method parameter as the same correlation `when :name` expresses, and
-    # merging that partition into the truthy branch's env — the `if` analogue of
-    # what CaseWhen.apply_argument_facts already does.
+    # Both shapes now go through `TypeInference::ArgumentFacts`: an equality test
+    # of a parameter against a literal selects the same partition `when :name`
+    # selects, merged into the TRUTHY branch only ("not this literal" pins the
+    # argument to nothing). `elsif` is a nested `if`, so it rides the same path.
     def show(which)
       if which == :name
-        Example9::Foo.name.upcase # should: "JOHN DOE"; actual: error (consumer gap)
+        Example9::Foo.name.upcase # => "JOHN DOE" (:name partition)
       elsif which == :age
-        Example9::Age.value.abs # should: 42;         actual: error (consumer gap)
+        Example9::Age.value.abs # => 42         (:age partition)
       end
     end
   end

--- a/spec/dummy/sig/rbs_infer/app/models/example9.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example9.rbs
@@ -1,6 +1,6 @@
 class Example9
-  def run_name: () -> untyped
-  def run_age: () -> untyped
+  def run_name: () -> (String | Integer | nil)
+  def run_age: () -> (String | Integer | nil)
 end
 
 class Example9
@@ -23,6 +23,6 @@ end
 
 class Example9
   class Dispatcher
-    def show: (Symbol which) -> untyped
+    def show: (Symbol which) -> (String | Integer | nil)
   end
 end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -19,8 +19,6 @@ app/models/example7.rb:31:28: [error] Type `(::Integer | nil)` does not have met
 app/models/example7.rb:34:27: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example8.rb:15:12: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example8.rb:17:13: [error] Type `(::Integer | nil)` does not have method `abs`
-app/models/example9.rb:47:27: [error] Type `(::String | nil)` does not have method `upcase`
-app/models/example9.rb:49:28: [error] Type `(::Integer | nil)` does not have method `abs`
 app/models/post/notifiable.rb:28:24: [error] Type `(::User | nil)` does not have method `full_name`
 app/models/user/recoverable.rb:10:6: [error] Cannot allow method body have type `::User` because declared as type `self`
 app/models/user/recoverable.rb:14:6: [error] Cannot allow method body have type `::User` because declared as type `self`


### PR DESCRIPTION
Depends on **felixefelip/steep#90**.

## What example9 isolated

example9 is example7 with exactly one variable changed: `case/when` → `if/elsif`. Same call sites, same establishing writes, same literals. That isolation showed the gap was **purely on the consumer side** — the sidecar already carried the same two partitions:

```yaml
- class: Example9::Dispatcher
  method: show
  param: which
  pattern: ":name"
  consts:
    Example9::Foo.name: "::String"
```

The facts were computed and correctly partitioned; they just were not consumed, because partitions were applied only in `TypeInference::CaseWhen`.

## What changed

felixefelip/steep#90 routes both shapes through `TypeInference::ArgumentFacts`, so an equality test of a parameter against a literal selects the same partition `when :name` selects, in the truthy branch only.

- **`example9.rb:47` and `:49` no longer error** — removed from `steep_baseline.txt`.
- `Dispatcher#show` and `run_name`/`run_age` resolve from `untyped` → `String | Integer | nil` (regenerated sig).
- **The sidecar is unchanged** — the partitions were always correct, which is exactly what made this a consumer-only gap.

## Verification

- `steep check`: **31 problems** (was 33); set-difference against the baseline empty in both directions.
- Integration suite: **61 examples, 0 failures**.
- CarrierWave `user.rbs` side-effect reverted.

Note: steep#90 also fixes a soundness hole in the partitions themselves (a call site passing a non-literal used to be silently skipped instead of invalidating the partition). The dummy's facts are unaffected — every call site there passes a literal — which the unchanged sidecar confirms.

Remaining gap in the family: **example8** (ivar partitions; the producer serializes `consts:` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)