### PR TITLE
test(dummy): example8 now narrows per literal argument (ivars)

### DIFF
--- a/spec/dummy/app/models/example8.rb
+++ b/spec/dummy/app/models/example8.rb
@@ -9,6 +9,16 @@ class Example8
     show(:age)
   end
 
+  # IVAR partitions. Same dispatch as example7, but the facts each caller
+  # establishes are INSTANCE VARIABLES rather than constant attributes. The
+  # whole-method meet still proves neither (`run_name` sets only `@name`,
+  # `run_age` only `@value`), so the partitioning by literal argument is what
+  # makes each branch readable.
+  #
+  # An ivar fact is about the CALLER's `self`, so unlike a const it only
+  # transfers across a same-self call — `show(:name)` here, not
+  # `other.show(:name)` — and it is dropped if an intervening call may write the
+  # ivar. Both gates are in the producer.
   def show(which)
     case which
     when :name

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -925,6 +925,18 @@ argument_entry_facts:
   pattern: ":name"
   consts:
     Example7::Foo.name: "::String"
+- class: Example8
+  method: show
+  param: which
+  pattern: ":age"
+  ivars:
+    "@value": "::Integer"
+- class: Example8
+  method: show
+  param: which
+  pattern: ":name"
+  ivars:
+    "@name": "::String"
 - class: Example9::Dispatcher
   method: show
   param: which

--- a/spec/dummy/sig/rbs_infer/app/models/example8.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example8.rbs
@@ -2,7 +2,7 @@ class Example8
   @name: String?
   @value: Integer?
 
-  def run_name: () -> untyped
-  def run_age: () -> untyped
-  def show: (Symbol which) -> untyped
+  def run_name: () -> (String | Integer | nil)
+  def run_age: () -> (String | Integer | nil)
+  def show: (Symbol which) -> (String | Integer | nil)
 end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -17,8 +17,6 @@ app/models/example4.rb:27:23: [error] Type `(::String | nil)` does not have meth
 app/models/example4.rb:40:23: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example7.rb:31:28: [error] Type `(::Integer | nil)` does not have method `abs`
 app/models/example7.rb:34:27: [error] Type `(::String | nil)` does not have method `upcase`
-app/models/example8.rb:15:12: [error] Type `(::String | nil)` does not have method `upcase`
-app/models/example8.rb:17:13: [error] Type `(::Integer | nil)` does not have method `abs`
 app/models/post/notifiable.rb:28:24: [error] Type `(::User | nil)` does not have method `full_name`
 app/models/user/recoverable.rb:10:6: [error] Cannot allow method body have type `::User` because declared as type `self`
 app/models/user/recoverable.rb:14:6: [error] Cannot allow method body have type `::User` because declared as type `self`


### PR DESCRIPTION
Depends on **felixefelip/steep#91**.

## What example8 isolated

example8 is example7 with one thing changed: the facts each caller establishes are **instance variables** instead of constant attributes. Argument partitions carried only `consts:`, so the whole-method meet (each caller sets a different ivar) left both branch reads nilable.

## What changed

felixefelip/steep#91 partitions ivar facts too:

- **`example8.rb:15` and `:17` no longer error** — removed from `steep_baseline.txt`.
- `.steep_postconditions.yml` gains the two ivar partitions — the entire sidecar diff is +12/−0:

```yaml
- class: Example8
  method: show
  param: which
  pattern: ":name"
  ivars:
    "@name": "::String"
```

- `show` and `run_name`/`run_age` resolve from `untyped` → `String | Integer | nil` (regenerated sig).
- Fixture comment records the working behavior and the two gates ivars need that consts do not (same-self call; dropped if an intervening call may write the ivar).

## Verification

- `steep check`: **29 problems** (was 31); set-difference against the baseline empty in both directions.
- Integration suite: **61 examples, 0 failures**.
- CarrierWave `user.rbs` side-effect reverted.

This closes the example7/8/9 family: consts (#89), `if`/`elsif` consumption (#90), and ivars (#91).

🤖 Generated with [Claude Code](https://claude.com/claude-code)