### PR TITLE
fix(inference): resolve an ivar argument from the declaring class's RBS

### DIFF
--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -132,7 +132,31 @@ module RbsInfer::Inference
     # for in-class ivars).
     def lookup_ivar_type(node)
       full = node.name.to_s
-      @local_var_types[full] || @local_var_types[full.sub(/\A@/, "")]
+      @local_var_types[full] || @local_var_types[full.sub(/\A@/, "")] || declared_ivar_type(full)
+    end
+
+    # The type the ENCLOSING class's RBS declares for this ivar
+    # (felixefelip/rbs_infer#111).
+    #
+    # `collect_class_ivar_types` only records an ivar assigned from a CallNode
+    # (`@post = Post.new`), so `@post = post` — storing a constructor argument, the
+    # commonest shape there is — left the ivar unknown and every call site passing it
+    # resolved to `untyped`. The fact was never missing: a previous stabilization pass
+    # already wrote `@post: Post` into the class's own RBS. This reads it back rather
+    # than teaching the syntactic collector one more assignment shape.
+    # Resolved against the LEXICALLY ENCLOSING class, not the file's top-level one:
+    # `@caller_class_name` is per-file, so in a file of nested classes it names the
+    # outer one, whose RBS declares none of the inner `@x`. Reading the wrong class's
+    # declaration would be worse than reading none — two nested classes may each
+    # declare `@post` at different types.
+    def declared_ivar_type(name)
+      return nil unless @method_type_resolver
+
+      class_name = @class_name_stack.last || @caller_class_name
+      return nil unless class_name
+
+      type = @method_type_resolver.resolve_ivar_types(class_name)[name]
+      type if type && type != "untyped"
     end
 
     def collect_class_ivar_types(class_node)

--- a/lib/rbs_infer/signatures/method_type_resolver.rb
+++ b/lib/rbs_infer/signatures/method_type_resolver.rb
@@ -126,6 +126,19 @@ module RbsInfer::Signatures
       lookup_class_methods(class_name)
     end
 
+    # Declared instance-variable types of a class, keyed WITH the `@`
+    # (`{"@post" => "Post"}`), read from its RBS (felixefelip/rbs_infer#111).
+    #
+    # A previous pass already wrote `@post: Post` for the class; this lets a call
+    # site that passes `@post` as an argument READ that instead of re-deriving it
+    # from the assignment's shape — which only ever recognized `@x = Foo.new`.
+    def resolve_ivar_types(class_name)
+      return {} unless class_name && class_name != "untyped"
+
+      @ivar_types_cache ||= {}
+      @ivar_types_cache[class_name] ||= @rbs_type_lookup.lookup_ivar_types(class_name)
+    end
+
     # Retorna os tipos dos parâmetros do initialize inferidos via call-sites
     # Ex: Entity.new(nome: "x", email: "y") → {"nome" => "String", "email" => "String"}
     def resolve_init_param_types(class_name)

--- a/lib/rbs_infer/signatures/rbs_parser_util.rb
+++ b/lib/rbs_infer/signatures/rbs_parser_util.rb
@@ -56,9 +56,10 @@ module RbsInfer::Signatures
       types = {}
       includes = []
       class_method_types = {}
-      extract_members(decl.members, types, includes, class_method_types, normalized)
+      ivar_types = {}
+      extract_members(decl.members, types, includes, class_method_types, normalized, ivar_types)
 
-      RbsClassInfo.new(superclass:, types:, includes:, class_method_types:)
+      RbsClassInfo.new(superclass:, types:, includes:, class_method_types:, ivar_types:)
     end
 
     # Extrai superclass, tipos de método, includes e class methods de declarations já parseadas.
@@ -69,13 +70,14 @@ module RbsInfer::Signatures
       types = {}
       includes = []
       class_method_types = {}
+      ivar_types = {}
 
       find_declaration(declarations, normalized) do |decl|
         superclass = extract_superclass(decl)
-        extract_members(decl.members, types, includes, class_method_types, normalized)
+        extract_members(decl.members, types, includes, class_method_types, normalized, ivar_types)
       end
 
-      RbsClassInfo.new(superclass:, types:, includes:, class_method_types:)
+      RbsClassInfo.new(superclass:, types:, includes:, class_method_types:, ivar_types:)
     end
 
     # Extrai superclass, tipos de método, includes e class methods de uma classe/módulo.
@@ -131,7 +133,7 @@ module RbsInfer::Signatures
       decl.super_class&.name&.to_s&.sub(/\A::/, "")
     end
 
-    def extract_members(members, types, includes, class_method_types, parent_fqn)
+    def extract_members(members, types, includes, class_method_types, parent_fqn, ivar_types = {})
       members.each do |member|
         case member
         when RBS::AST::Members::MethodDefinition
@@ -154,6 +156,13 @@ module RbsInfer::Signatures
         when RBS::AST::Members::AttrReader, RBS::AST::Members::AttrAccessor, RBS::AST::Members::AttrWriter
           type_str = member.type.to_s
           types[member.name.to_s] ||= type_str unless type_str == "untyped"
+        when RBS::AST::Members::InstanceVariable
+          # `@post: Post`. Keyed WITH the `@`, matching how a Prism
+          # InstanceVariableReadNode names it. Class-instance variables
+          # (`self.@x`, ClassInstanceVariable) are a different slot and are not
+          # collected here.
+          type_str = member.type.to_s
+          ivar_types[member.name.to_s] ||= type_str unless type_str == "untyped"
         end
       end
     end

--- a/lib/rbs_infer/signatures/rbs_type_lookup.rb
+++ b/lib/rbs_infer/signatures/rbs_type_lookup.rb
@@ -6,7 +6,15 @@ module RbsInfer::Signatures
   #
   # Extraído de MethodTypeResolver para manter responsabilidades separadas.
 
-  RbsClassInfo = Data.define(:superclass, :types, :includes, :class_method_types)
+  # `ivar_types` maps an instance variable name (WITH the `@`) to its declared type,
+  # from `@post: Post` members. Needed to resolve an ivar passed as an argument at a
+  # call site (felixefelip/rbs_infer#111): the enclosing class's RBS already states the
+  # type, so the collector reads it instead of re-deriving one.
+  RbsClassInfo = Data.define(:superclass, :types, :includes, :class_method_types, :ivar_types) do
+    def initialize(superclass:, types:, includes:, class_method_types:, ivar_types: {})
+      super
+    end
+  end
 
   class RbsTypeLookup
     # Run-wide caches shared across every instance. A fresh RbsTypeLookup is
@@ -108,6 +116,34 @@ module RbsInfer::Signatures
       end
 
       return types, superclass, all_includes
+    end
+
+    # Declared instance-variable types of a class (`{"@post" => "Post"}`), merged over
+    # the RBS files that declare it. Same two-phase file search as `lookup_rbs_types`:
+    # by path first, then by scanning for an inner class.
+    #
+    # Unlike methods, ivars are NOT inherited here: a subclass's `@x` is its own slot
+    # and the superclass walk (`lookup_inherited_types`) would attribute the wrong
+    # declaration when both declare it.
+    def lookup_ivar_types(class_name)
+      normalized = class_name.sub(/\A::/, "")
+      ivars = {}
+
+      class_path = RbsInfer.class_name_to_path(normalized)
+      self.class.glob("sig/**/*.rbs").each do |rbs_file|
+        next unless rbs_file.end_with?("#{class_path}.rbs")
+        class_info_from_file(rbs_file, normalized).ivar_types.each { |name, type| ivars[name] ||= type }
+      end
+
+      if ivars.empty?
+        short_name = normalized.split("::").last
+        self.class.glob("sig/**/*.rbs").each do |rbs_file|
+          next unless cached_content_for(rbs_file).include?(short_name)
+          class_info_from_file(rbs_file, normalized).ivar_types.each { |name, type| ivars[name] ||= type }
+        end
+      end
+
+      ivars
     end
 
     # Parseia um arquivo RBS e extrai métodos, superclass e includes de uma classe específica.

--- a/spec/dummy/app/models/example11.rb
+++ b/spec/dummy/app/models/example11.rb
@@ -23,34 +23,32 @@ class Example11
     end
 
     # A human reads `@post` here as `Example11::Post`: the only caller passes
-    # `Post.new`, and nothing reassigns it. The analyzer agrees at the CLASS
-    # level — the generated RBS declares `@post: Example11::Post` — but not at
-    # this CALL SITE.
+    # `Post.new`, and nothing reassigns it. The analyzer now agrees at this CALL
+    # SITE too, by reading the type off the class's own RBS.
     def render
       Example11::Partial.new(post: @post)
     end
   end
 
-  # IVAR-ARGUMENT RESOLUTION gap. `Partial#initialize` should infer
-  # `(post: Example11::Post)` from the call site above, but infers
-  # `(post: untyped)`.
+  # IVAR-ARGUMENT RESOLUTION. `Partial#initialize` infers
+  # `(post: Example11::Post)` from the call site above.
   #
-  # Cause: `NewCallCollector#collect_class_ivar_types` records an ivar only when
-  # it is assigned from a CallNode (`@post = Post.new`, `@post = Foo.bar`). An
-  # ivar assigned from a PARAMETER is skipped, so `lookup_ivar_type` finds
-  # nothing and the argument resolves to `untyped`.
+  # It used to infer `(post: untyped)`. `NewCallCollector#collect_class_ivar_types`
+  # records an ivar only when it is assigned from a CallNode
+  # (`@post = Post.new`, `@post = Foo.bar`); an ivar assigned from a PARAMETER —
+  # the commonest shape there is, and the one the view-runtime pseudo-code emits —
+  # was skipped, so `lookup_ivar_type` found nothing.
   #
-  # The fact is not missing — it is discarded. `Example11::View`'s own generated
-  # RBS already declares `@post: Example11::Post`; the collector does not consult
-  # it and re-derives with narrower logic. Swapping the assignment to
-  # `@post = Example11::Post.new` makes this partial infer `Example11::Post`,
-  # which isolates the cause to the assignment SHAPE, not to anything about the
-  # call site.
+  # The fact was never missing, only discarded: `Example11::View`'s own generated
+  # RBS already declared `@post: Example11::Post`. The fix reads that back instead
+  # of teaching the syntactic collector one more assignment shape — and resolves
+  # it against the LEXICALLY ENCLOSING class, since the caller class tracked per
+  # file names the outer `Example11`, whose RBS declares no `@post` at all.
   #
-  # This blocks the view-RBS reformulation: every partial local depends on this
-  # second hop, so all of them infer `untyped` until it resolves. Note the gap is
-  # invisible to `steep check` — `untyped` absorbs every method call, so nothing
-  # errors. The evidence is the generated RBS snapshot.
+  # Note this gap was invisible to `steep check`: `untyped` absorbs every method
+  # call, so nothing errored. The evidence is the generated RBS snapshot, which is
+  # why this fixture is pinned by an integration expectation rather than by the
+  # steep baseline.
   class Partial
     def initialize(post:)
       @post = post

--- a/spec/dummy/sig/rbs_infer/app/models/example11.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example11.rbs
@@ -21,10 +21,10 @@ end
 
 class Example11
   class Partial
-    def initialize: (post: untyped) -> void
+    def initialize: (post: Example11::Post) -> void
 
     private
 
-    attr_reader post: untyped
+    attr_reader post: Example11::Post
   end
 end

--- a/spec/expectations/models/example11.rbs
+++ b/spec/expectations/models/example11.rbs
@@ -21,10 +21,10 @@ end
 
 class Example11
   class Partial
-    def initialize: (post: untyped) -> void
+    def initialize: (post: Example11::Post) -> void
 
     private
 
-    attr_reader post: untyped
+    attr_reader post: Example11::Post
   end
 end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -268,18 +268,19 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     expect(rbs.chomp).to eq(expected_rbs(name).chomp)
   end
 
-  # IVAR-ARGUMENT RESOLUTION gap (blocks felixefelip/rbs_infer#109). Pins the
-  # CURRENT, wrong output: `Example11::Partial#initialize` infers
-  # `(post: untyped)` although the call site passes `@post`, whose type the
-  # generated RBS of `Example11::View` declares one class above
-  # (`@post: Example11::Post`).
+  # IVAR-ARGUMENT RESOLUTION (unblocks felixefelip/rbs_infer#109).
+  # `Example11::Partial#initialize` infers `(post: Example11::Post)` from a call
+  # site that passes `@post`, whose type `Example11::View`'s generated RBS
+  # declares one class above.
   #
-  # `NewCallCollector#collect_class_ivar_types` records an ivar only when it is
-  # assigned from a CallNode, so `@post = post` (from a parameter) is skipped.
-  # When that is fixed this expectation flips to `Example11::Post` — which is the
-  # point of pinning it: the diff IS the fix landing.
+  # Guards two things that were both wrong: an ivar assigned from a PARAMETER is
+  # now resolvable at a call site (the syntactic collector only recorded
+  # `@x = Foo.new`), and it resolves against the LEXICALLY ENCLOSING class — here
+  # `Example11::View`, not the file's top-level `Example11`, which declares no
+  # `@post`.
   #
-  # Not baselined in steep: `untyped` absorbs every call, so nothing errors there.
+  # Not baselined in steep: `untyped` absorbs every call, so this never errored
+  # there. The generated RBS is the only place it shows.
   it "example11" do
     name = "models/example11"
     rbs = RbsInfer::Analyzer.new(

--- a/spec/lib/rbs_infer/analyzer_spec.rb
+++ b/spec/lib/rbs_infer/analyzer_spec.rb
@@ -1422,4 +1422,105 @@ RSpec.describe RbsInfer::Analyzer do
       end
     end
   end
+
+  # ─── ivar passed as an argument (felixefelip/rbs_infer#111) ─────
+
+  describe "#generate_rbs resolving an ivar argument against the declaring class" do
+    # The type is read from the RBS an earlier stabilization pass wrote, so each
+    # example lays down a `sig/` and runs from that directory.
+    around do |ex|
+      Dir.mktmpdir { |dir| Dir.chdir(dir) { ex.run } }
+    end
+    before { RbsInfer::Signatures::RbsTypeLookup.reset! }
+
+    def write(path, content)
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, content)
+      path
+    end
+
+    it "types a `.new` argument from the enclosing class's declared ivar" do
+      # `@post = post` assigns from a PARAMETER. The syntactic collector only ever
+      # recognized `@x = Foo.new`, so this used to resolve to `untyped` even though
+      # the class's own RBS states the type.
+      write("sig/view.rbs", "class View\n  @post: Post\nend\n")
+      source = write("app/view.rb", <<~RUBY)
+        class View
+          def initialize(post:)
+            @post = post
+          end
+
+          def render
+            Partial.new(post: @post)
+          end
+        end
+
+        class Partial
+          def initialize(post:)
+            @post = post
+          end
+        end
+      RUBY
+
+      rbs = described_class.new(target_class: "Partial", target_file: source, source_files: [source]).generate_rbs
+
+      expect(rbs).to include("def initialize: (post: Post) -> void")
+    end
+
+    it "resolves against the lexically enclosing class, not the file's outer one" do
+      # `caller_class_name` is per FILE. In a file of nested classes it names the
+      # OUTER class, whose RBS declares no `@post` — and, worse, could declare one
+      # at a different type. The lookup has to follow the lexical nesting.
+      write("sig/outer.rbs", <<~RBS)
+        class Outer
+          @post: String
+          class View
+            @post: Outer::Post
+          end
+        end
+      RBS
+      source = write("app/outer.rb", <<~RUBY)
+        class Outer
+          class View
+            def render
+              Outer::Partial.new(post: @post)
+            end
+          end
+
+          class Partial
+            def initialize(post:)
+              @post = post
+            end
+          end
+        end
+      RUBY
+
+      rbs = described_class.new(target_class: "Outer::Partial", target_file: source, source_files: [source]).generate_rbs
+
+      expect(rbs).to include("def initialize: (post: Outer::Post) -> void")
+      expect(rbs).not_to include("String")
+    end
+
+    it "leaves the argument untyped when no ivar is declared" do
+      write("sig/view.rbs", "class View\n  def render: () -> void\nend\n")
+      source = write("app/view.rb", <<~RUBY)
+        class View
+          def render
+            Partial.new(post: @post)
+          end
+        end
+
+        class Partial
+          def initialize(post:)
+            @post = post
+          end
+        end
+      RUBY
+
+      rbs = described_class.new(target_class: "Partial", target_file: source, source_files: [source]).generate_rbs
+
+      expect(rbs).to include("def initialize: (post: untyped) -> void")
+    end
+  end
+
 end

--- a/spec/lib/rbs_infer/signatures/rbs_parser_util_spec.rb
+++ b/spec/lib/rbs_infer/signatures/rbs_parser_util_spec.rb
@@ -4,6 +4,49 @@ require "rbs"
 
 RSpec.describe RbsInfer::Signatures::RbsParserUtil do
   describe ".class_info_from_rbs" do
+    # felixefelip/rbs_infer#111: instance-variable members used to be parsed and
+    # dropped, so a call site passing `@post` had nothing to resolve against even
+    # though the class's own RBS stated the type.
+    it "extrai tipos de instance variables, com o `@`" do
+      rbs = <<~RBS
+        class View
+          @post: Post
+          @count: Integer
+          def render: () -> void
+        end
+      RBS
+
+      info = described_class.class_info_from_rbs(rbs, "View")
+
+      expect(info.ivar_types).to eq("@post" => "Post", "@count" => "Integer")
+    end
+
+    it "ignora instance variable declarada como untyped" do
+      rbs = <<~RBS
+        class View
+          @post: untyped
+        end
+      RBS
+
+      expect(described_class.class_info_from_rbs(rbs, "View").ivar_types).to be_empty
+    end
+
+    it "não confunde instance variable com attr_reader de mesmo nome" do
+      # `attr_reader post: Post` is a METHOD (`types`); `@post: Post` is the ivar
+      # slot. They are keyed separately so a reader never masks the ivar lookup.
+      rbs = <<~RBS
+        class View
+          @post: Post
+          attr_reader post: String
+        end
+      RBS
+
+      info = described_class.class_info_from_rbs(rbs, "View")
+
+      expect(info.ivar_types).to eq("@post" => "Post")
+      expect(info.types).to include("post" => "String")
+    end
+
     it "extrai informações de classe simples" do
       rbs = <<~RBS
         class User

--- a/spec/lib/rbs_infer/signatures/rbs_type_lookup_spec.rb
+++ b/spec/lib/rbs_infer/signatures/rbs_type_lookup_spec.rb
@@ -122,6 +122,55 @@ RSpec.describe RbsInfer::Signatures::RbsTypeLookup do
     end
   end
 
+  # felixefelip/rbs_infer#111. Reads back what an earlier pass wrote, so a call
+  # site passing `@post` resolves against the class's declared ivar type.
+  describe "#lookup_ivar_types" do
+    around do |ex|
+      Dir.mktmpdir { |dir| Dir.chdir(dir) { ex.run } }
+    end
+    before { described_class.reset! }
+
+    def write_rbs(path, content)
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, content)
+    end
+
+    it "finds ivars in a file matching the class path" do
+      write_rbs("sig/view.rbs", "class View\n  @post: Post\nend\n")
+
+      expect(lookup.lookup_ivar_types("View")).to eq("@post" => "Post")
+    end
+
+    it "finds ivars of a nested class the filename does not name" do
+      # The shape the analyzer emits for `class Outer; class View; end; end` —
+      # one .rbs per source file, several classes inside it.
+      write_rbs("sig/outer.rbs", <<~RBS)
+        class Outer
+          class View
+            @post: Outer::Post
+          end
+        end
+      RBS
+
+      expect(lookup.lookup_ivar_types("Outer::View")).to eq("@post" => "Outer::Post")
+    end
+
+    it "returns empty for a class with no declared ivars" do
+      write_rbs("sig/view.rbs", "class View\n  def render: () -> void\nend\n")
+
+      expect(lookup.lookup_ivar_types("View")).to be_empty
+    end
+
+    it "does not inherit a superclass's ivar declaration" do
+      # An ivar is the class's own slot; attributing the parent's declaration to
+      # the child would hand out a type the child may not hold.
+      write_rbs("sig/parent.rbs", "class Parent\n  @post: Post\nend\n")
+      write_rbs("sig/child.rbs", "class Child < Parent\nend\n")
+
+      expect(lookup.lookup_ivar_types("Child")).to be_empty
+    end
+  end
+
   # Run-wide caches shared across instances (felixefelip/rbs_infer#47). Each
   # example runs in its own tmpdir (a distinct Dir.pwd), so the pwd-scoped
   # cache is naturally isolated; reset! is belt-and-suspenders.


### PR DESCRIPTION
Unblocks **#109** (view-runtime pseudo-code). Fixture: `example11`.

## Problem

An ivar passed as an argument at a `.new` call site resolved to `untyped` unless it had been assigned from a `CallNode`:

```ruby
class View
  def initialize(post:)
    @post = post              # assigned from a PARAMETER
  end

  def render
    Partial.new(post: @post)  # => (post: untyped)
  end
end
```

`NewCallCollector#collect_class_ivar_types` recognizes only `@x = Foo.new` and `@x = Foo.bar`, so storing a constructor argument — the commonest shape there is — left the ivar unknown.

Isolated by experiment: swapping the assignment to `@post = Post.new` makes the argument infer `Post`, which pins the cause to the assignment **shape**, not to anything about the call site.

## Fix

The fact was never missing, only discarded: an earlier stabilization pass already wrote `@post: Post` into the class's own RBS. Read it back, rather than teaching the syntactic collector one more assignment shape — which would have to be repeated for every future shape and would still miss whatever the pipeline knows but the syntax does not show.

| layer | change |
|---|---|
| `RbsParserUtil#extract_members` | collects `RBS::AST::Members::InstanceVariable` into a new `RbsClassInfo#ivar_types`, keyed **with** the `@` (matching Prism's `InstanceVariableReadNode`). These members were parsed and dropped. |
| `RbsTypeLookup#lookup_ivar_types` | merges them per class, same two-phase file search as `lookup_rbs_types`, so a nested class the filename does not name is still found |
| `NewCallCollector#declared_ivar_type` | consults it as a last resort, after the existing local/ivar tables |

### Two deliberate restrictions

- **Resolved against the lexically enclosing class** (`@class_name_stack`), not `@caller_class_name`. The latter is per **file**, so in a file of nested classes it names the outer one — which declares none of the inner `@x`, and may declare one at a *different type*. This was the actual reason the first attempt still returned `untyped` for `example11`. A spec pins it.
- **Ivars are not inherited.** An ivar is the class's own slot; attributing a parent's declaration to the child would hand out a type the child may not hold.

## Result

`example11` flips from `(post: untyped)` to `(post: Example11::Post)` — the diff in its expectation *is* the fix landing.

The gap was invisible to `steep check` (`untyped` absorbs every call), which is why the fixture is pinned by an integration expectation rather than the steep baseline.

## Verification

- **10 new specs**: 3 parser (ivar members captured, `untyped` skipped, not confused with a same-named `attr_reader`), 4 lookup (by path, nested class, none declared, no inheritance), 3 analyzer end-to-end (typed from the declaration, lexical class wins over the file's outer one, `untyped` when nothing is declared).
- Unit suite **693 examples, 0 failures**; integration **62, 0 failures**.
- The dummy's generated RBS changes **only** in example11 — no collateral drift.
- `steep check` error set is byte-identical with and without this change (verified by reverting the four lib files and diffing). The 3 errors outside the baseline are pre-existing on `main`, from the hand-written skeleton that #109 replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)