### PR TITLE
feat(inference): resolve an ivar argument from an argument-sensitive partition

### DIFF
--- a/lib/rbs_infer/inference/caller_file_analyzer.rb
+++ b/lib/rbs_infer/inference/caller_file_analyzer.rb
@@ -83,6 +83,15 @@ module RbsInfer::Inference
           {}
         end
 
+      # Argument-sensitive partitions: inside a `when :edit` branch of a `case <param>`,
+      # the facts the callers passing `:edit` established hold.
+      argument_partitions_by_method =
+        if @steep_bridge && caller_visitor.class_name
+          @steep_bridge.argument_entry_partitions(caller_visitor.class_name)
+        else
+          {}
+        end
+
       visitor = NewCallCollector.new(
         target_class: @target_class,
         method_return_types: method_return_types,
@@ -94,6 +103,7 @@ module RbsInfer::Inference
         match_bare_calls: match_bare,
         self_types_by_method: self_types_by_method,
         established_ivars_by_method: established_ivars_by_method,
+        argument_partitions_by_method: argument_partitions_by_method,
         constant_arg_resolver: constant_arg_resolver,
         defined_class_names: NewCallCollector.collect_defined_class_names(result.value)
       )

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -28,7 +28,7 @@ module RbsInfer::Inference
       names
     end
 
-    def initialize(target_class:, method_return_types:, local_var_types:, constant_arg_resolver:, defined_class_names:, method_type_resolver: nil, caller_class_name: nil, init_positional_params: [], target_methods: {}, match_bare_calls: false, self_types_by_method: {}, established_ivars_by_method: {})
+    def initialize(target_class:, method_return_types:, local_var_types:, constant_arg_resolver:, defined_class_names:, method_type_resolver: nil, caller_class_name: nil, init_positional_params: [], target_methods: {}, match_bare_calls: false, self_types_by_method: {}, established_ivars_by_method: {}, argument_partitions_by_method: {})
       @target_class = target_class
       # FQNs of classes/modules defined in the file being scanned; disambiguates
       # a relative receiver from a same-simple-name class elsewhere (see
@@ -55,6 +55,9 @@ module RbsInfer::Inference
       # in source order by `visit_call_node`, so only call sites AFTER the establishing
       # call see the narrowed type (felixefelip/rbs_infer#109).
       @established_ivars_by_method = established_ivars_by_method
+      # `{ "render" => [{ param:, pattern:, ivars: }] }` — argument-sensitive partitions
+      # (felixefelip/steep#89, #91, #95). Applied per `when` branch by `visit_case_node`.
+      @argument_partitions_by_method = argument_partitions_by_method
       @usages = []
       @method_call_usages = Hash.new { |h, k| h[k] = [] }
       # Lexically-enclosing class names (fully qualified) and whether the
@@ -92,6 +95,39 @@ module RbsInfer::Inference
       @current_method = old_method
       @in_singleton_method = old_singleton
       @local_var_types = old_vars
+    end
+
+    # A `case <param> ... when <literal>` branch is reachable only for callers who passed
+    # that literal, so the facts the fork recorded for that (param, literal) partition hold
+    # inside it — and only inside it. Each branch body is visited with those ivars merged
+    # in, then the table is restored, so a sibling branch and everything after the `case`
+    # are unaffected.
+    #
+    # This is what lets a shared dispatcher stay precise: a controller's `render` override
+    # is one method reached from every action, so its ivars are the meet over all of them;
+    # the partition is what says "on the :edit path, `@post` was established".
+    def visit_case_node(node)
+      partitions = partitions_for_case(node)
+      return super if partitions.empty?
+
+      node.conditions.each do |clause|
+        next unless clause.is_a?(Prism::WhenNode)
+
+        ivars = clause.conditions.filter_map { |c| partitions[literal_key(c)] }.reduce({}, :merge)
+        if ivars.empty?
+          clause.statements&.accept(self)
+          next
+        end
+
+        saved = @local_var_types.dup
+        ivars.each { |name, type| @local_var_types[name] = type }
+        clause.statements&.accept(self)
+        @local_var_types = saved
+      end
+
+      node.else_clause&.accept(self)
+      node.predicate&.accept(self)
+      nil
     end
 
     def visit_call_node(node)
@@ -181,6 +217,39 @@ module RbsInfer::Inference
 
       established = @established_ivars_by_method[node.name.to_s] or return
       established.each { |ivar, type| @local_var_types[ivar] = type }
+    end
+
+    # `{ literal_key => ivars }` for the partitions keyed on this `case`'s subject, or `{}`.
+    # Only a bare read of a METHOD PARAMETER qualifies: the correlation is between the
+    # caller's argument and the branch, and a `case` on anything else says nothing about
+    # what the caller passed.
+    def partitions_for_case(node)
+      return {} if @argument_partitions_by_method.empty?
+      return {} unless @current_method
+
+      predicate = node.predicate
+      return {} unless predicate.is_a?(Prism::LocalVariableReadNode)
+
+      param = predicate.name.to_s
+      (@argument_partitions_by_method[@current_method] || []).each_with_object({}) do |partition, acc|
+        next unless partition[:param] == param
+
+        acc[partition[:pattern]] = partition[:ivars]
+      end
+    end
+
+    # The canonical literal string the fork's `Postconditions::LiteralKey` produces, so a
+    # `when` pattern here matches the `pattern` recorded there. Both sides must spell the
+    # same literal the same way or nothing correlates.
+    def literal_key(node)
+      case node
+      when Prism::SymbolNode then ":#{node.value}"
+      when Prism::StringNode then node.unescaped.inspect
+      when Prism::IntegerNode, Prism::FloatNode then node.slice
+      when Prism::TrueNode then "true"
+      when Prism::FalseNode then "false"
+      when Prism::NilNode then "nil"
+      end
     end
 
     def collect_class_ivar_types(class_node)

--- a/lib/rbs_infer/signatures/steep_bridge.rb
+++ b/lib/rbs_infer/signatures/steep_bridge.rb
@@ -605,6 +605,41 @@ module RbsInfer::Signatures
       result
     end
 
+    # `{ "render" => [{ param: "target", pattern: ":edit", ivars: { "@post" => "..." } }] }`
+    # — the argument-sensitive partitions of `class_name`'s methods
+    # (felixefelip/steep#89, #91, #95).
+    #
+    # The fork records, per (method, parameter, literal), what the callers passing that
+    # literal had established. Inside a `when :edit` branch the facts of the `:edit`
+    # partition hold, which is how a shared dispatcher like a controller's `render`
+    # override stays precise instead of collapsing to the meet over all its callers.
+    # rbs_infer needs it for the same reason it needs `postcondition_established_ivars`:
+    # the narrowing is a flow fact and the analyzer has no flow analysis.
+    def argument_entry_partitions(class_name)
+      return {} unless class_name
+
+      store = postconditions_store
+      return {} if store.nil? || store.empty?
+
+      key = class_name.to_s.sub(/\A::/, "")
+      result = Hash.new { |h, k| h[k] = [] }
+      store.argument_entry_facts.each do |(entry_class, method_name), partitions|
+        next unless entry_class == key
+
+        partitions.each do |partition|
+          ivars = partition[:ivars]
+          next if ivars.nil? || ivars.empty?
+
+          result[method_name.to_s] << {
+            param: partition[:param_name].to_s,
+            pattern: partition[:pattern].to_s,
+            ivars: ivars.transform_keys(&:to_s).transform_values(&:to_s)
+          }
+        end
+      end
+      result
+    end
+
     private
 
     # Renders a whitequark `:const` node into a dotted class-path string:

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/_form.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/_form.rbs
@@ -1,11 +1,15 @@
 class ERBPartialPostsForm
   include ActionViewContext
 
-  def initialize: (post: (Post | (Post & Post::Validated))?) -> void
+  def initialize: (post: (Post & Post::Validated | Post)) -> void
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 
   private
 
-  attr_reader post: (Post | (Post & Post::Validated))?
+  attr_reader post: (Post & Post::Validated | Post)
+
+  class AfterInitialize
+    attr_reader post: (Post & Post::Validated) | Post
+  end
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/edit.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/edit.rbs
@@ -1,10 +1,10 @@
 class ERBPostsEdit
-  @post: (Post | (Post & Post::Validated))?
+  @post: (Post & Post::Validated)
 
   include ActionViewContext
   include PostsHelper
 
-  def initialize: (post: (Post | (Post & Post::Validated))?) -> void
+  def initialize: (post: Post & ::Post::Validated) -> void
   def render: (*untyped) -> ERBPartialPostsForm
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/new.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/new.rbs
@@ -1,10 +1,10 @@
 class ERBPostsNew
-  @post: (Post | (Post & Post::Validated))?
+  @post: Post
 
   include ActionViewContext
   include PostsHelper
 
-  def initialize: (post: ((Post | (Post & Post::Validated))? | Post)) -> void
+  def initialize: (post: Post) -> void
   def render: (*untyped) -> ERBPartialPostsForm
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/users/avatars/edit.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/users/avatars/edit.rbs
@@ -1,9 +1,9 @@
 class ERBUsersAvatarsEdit
-  @user: (User & User::Validated)?
+  @user: (User & User::Validated)
 
   include ActionViewContext
 
-  def initialize: (user: ((User & User::Validated)? | (::User & ::User::Validated))) -> void
+  def initialize: (user: (User & ::User::Validated | (::User & ::User::Validated))) -> void
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -28,12 +28,3 @@ app/services/profile_formatter.rb:31:4: [error] `format_nickname` requires `self
 app/services/profile_formatter.rb:37:13: [error] Type `(::String | nil)` does not have method `upcase`
 app/services/tag_destroy.rb:110:6: [error] Cannot allow method body have type `(void | ::String)` because declared as type `(::String | nil)`
 app/services/tag_destroy.rb:98:7: [error] Type `::TagDestroy` does not have method `untyped`
-app/views/posts/_form.html.erb:2:13: [error] Type `(::Post | (::Post & ::Post::Validated) | nil)` does not have method `errors`
-app/views/posts/_form.html.erb:4:29: [error] Type `(::Post | (::Post & ::Post::Validated) | nil)` does not have method `errors`
-app/views/posts/_form.html.erb:6:16: [error] Type `(::Post | (::Post & ::Post::Validated) | nil)` does not have method `errors`
-app/views/users/avatars/edit.html.erb:15:14: [error] Type `((::User & ::User::Validated) | nil)` does not have method `avatar`
-app/views/users/avatars/edit.html.erb:17:26: [error] Type `((::User & ::User::Validated) | nil)` does not have method `avatar`
-app/views/users/avatars/edit.html.erb:1:30: [error] Type `((::User & ::User::Validated) | nil)` does not have method `name`
-app/views/users/avatars/edit.html.erb:4:14: [error] Type `((::User & ::User::Validated) | nil)` does not have method `errors`
-app/views/users/avatars/edit.html.erb:6:30: [error] Type `((::User & ::User::Validated) | nil)` does not have method `errors`
-app/views/users/avatars/edit.html.erb:8:17: [error] Type `((::User & ::User::Validated) | nil)` does not have method `errors`

--- a/spec/expectations/steep_contracts.yml
+++ b/spec/expectations/steep_contracts.yml
@@ -197,46 +197,6 @@ methods:
           kind: self
         method: nickname
     enforced: false
-  TagDestroy#parse_xml:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: xml
-  TagDestroy#parse_xml_as_hash:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: xml
-  TagDestroy#parse_xml_as_hash_with_parse:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: xml
-  TagDestroy#test_array_with_array:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: xml
-  TagDestroy#test_array_with_array_with_elements_untyped:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: xml
   Test::Filtrable#filtrable?:
     requires:
     - kind: not_nil

--- a/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
@@ -606,4 +606,101 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
     end
   end
 
+
+  # Argument-sensitive partitions (felixefelip/steep#89, #91, #95). A `case <param>` branch
+  # is reachable only for callers who passed that literal, so the facts those callers
+  # established hold inside it — and only inside it. This is what keeps a shared dispatcher
+  # (a controller's `render` override, reached from every action) from collapsing to the
+  # meet over all its callers.
+  describe "ivars from an argument partition" do
+    def collect_with_partitions(source, target_class:, partitions:)
+      result = Prism.parse(source)
+      visitor = described_class.new(
+        target_class: target_class,
+        method_return_types: {},
+        local_var_types: {},
+        constant_arg_resolver: null_constant_resolver,
+        defined_class_names: described_class.collect_defined_class_names(result.value),
+        argument_partitions_by_method: partitions
+      )
+      result.value.accept(visitor)
+      visitor.usages
+    end
+
+    let(:partitions) do
+      {
+        "render" => [
+          { param: "target", pattern: ":edit", ivars: { "@post" => "Post & Post::Validated" } },
+          { param: "target", pattern: ":new", ivars: { "@post" => "Post" } }
+        ]
+      }
+    end
+
+    def render_source(body)
+      <<~RUBY
+        class PostsController
+          def render(target = nil, *rest)
+            #{body}
+          end
+        end
+      RUBY
+    end
+
+    it "applies the matching literal's partition inside its branch" do
+      usages = collect_with_partitions(
+        render_source("case target\nwhen :edit then View.new(post: @post)\nend"),
+        target_class: "View", partitions: partitions
+      )
+
+      expect(usages.first["post"]).to eq("Post & Post::Validated")
+    end
+
+    it "gives each branch its own partition" do
+      usages = collect_with_partitions(
+        render_source("case target\nwhen :edit then View.new(post: @post)\nwhen :new then View.new(post: @post)\nend"),
+        target_class: "View", partitions: partitions
+      )
+
+      expect(usages.map { |u| u["post"] }).to contain_exactly("Post & Post::Validated", "Post")
+    end
+
+    it "does not leak a partition past the case" do
+      usages = collect_with_partitions(
+        render_source("case target\nwhen :edit then nil\nend\nView.new(post: @post)"),
+        target_class: "View", partitions: partitions
+      )
+
+      expect(usages.first["post"]).to eq("untyped")
+    end
+
+    it "ignores a branch whose literal has no partition" do
+      usages = collect_with_partitions(
+        render_source("case target\nwhen :other then View.new(post: @post)\nend"),
+        target_class: "View", partitions: partitions
+      )
+
+      expect(usages.first["post"]).to eq("untyped")
+    end
+
+    it "ignores a case on something that is not the partitioned parameter" do
+      # The correlation is between the CALLER's argument and the branch. A `case` on
+      # anything else says nothing about what the caller passed.
+      usages = collect_with_partitions(
+        render_source("case rest\nwhen :edit then View.new(post: @post)\nend"),
+        target_class: "View", partitions: partitions
+      )
+
+      expect(usages.first["post"]).to eq("untyped")
+    end
+
+    it "leaves the else branch alone" do
+      usages = collect_with_partitions(
+        render_source("case target\nwhen :edit then nil\nelse View.new(post: @post)\nend"),
+        target_class: "View", partitions: partitions
+      )
+
+      expect(usages.first["post"]).to eq("untyped")
+    end
+  end
+
 end

--- a/spec/lib/rbs_infer/signatures/steep_bridge_spec.rb
+++ b/spec/lib/rbs_infer/signatures/steep_bridge_spec.rb
@@ -462,6 +462,40 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
     end
   end
 
+  describe "#argument_entry_partitions" do
+    # Argument-sensitive partitions (felixefelip/steep#89, #91, #95): per (method,
+    # parameter, literal), what the callers passing that literal had established. The
+    # dummy's controller-runtime `render` override dispatches `case target when :edit`.
+    it "maps a method to its per-literal partitions" do
+      result = bridge.argument_entry_partitions("PostsController")
+
+      edit = result["render"].find { |p| p[:pattern] == ":edit" }
+      expect(edit).not_to be_nil
+      expect(edit[:param]).to eq("target")
+      expect(edit[:ivars]["@post"]).to eq("::Post & ::Post::Validated")
+    end
+
+    it "keeps each literal's partition separate" do
+      result = bridge.argument_entry_partitions("PostsController")
+
+      new_partition = result["render"].find { |p| p[:pattern] == ":new" }
+      expect(new_partition[:ivars]["@post"]).to eq("::Post")
+    end
+
+    it "normalizes a leading :: in the class name" do
+      expect(bridge.argument_entry_partitions("::PostsController"))
+        .to eq(bridge.argument_entry_partitions("PostsController"))
+    end
+
+    it "returns an empty result for a class with no partitions" do
+      expect(bridge.argument_entry_partitions("Foo")).to be_empty
+    end
+
+    it "returns an empty result for nil" do
+      expect(bridge.argument_entry_partitions(nil)).to eq({})
+    end
+  end
+
   describe "#ivar_write_types" do
     # Cobertura da regra introduzida em felixefelip/rbs_infer#4:
     # coleta todas as escritas, deduplica, e adiciona `| nil` quando a


### PR DESCRIPTION
The last piece of the view-RBS reformulation. **All 9 residual view errors are gone.**

## Problem

The fork records, per (method, parameter, literal), what the callers passing that literal had established (felixefelip/steep#89, #91, #95) — but the analyzer never read those partitions. Zero references to `argument_entry_facts` in `lib/`, so the facts sat in the sidecar unused.

A controller's `render` override is one method reached from every action, so its ivars are the meet over all of them — `@post` nilable, because some path does not set it. The partition is what says *"on the `:edit` path, `@post` was established"*.

## Fix

`SteepBridge#argument_entry_partitions` exposes them, mirroring the existing `postcondition_established_ivars`. `NewCallCollector#visit_case_node` applies a partition only inside the branch that tests its literal, saving and restoring the type table around each branch body:

```ruby
case target
when :edit then ERBPostsEdit.new(post: @post)   # @post from the :edit partition
```

`literal_key` reproduces the fork's `Postconditions::LiteralKey` spelling — both sides must render the same literal identically or nothing correlates.

### Four things it deliberately does not do

Each has its own test, because over-applying a flow fact is the real risk:

- apply **past** the `case` — the branch is where the correlation holds;
- apply to a **sibling** branch, or to `else` — "not this literal" pins nothing;
- apply to a `when` whose literal has **no** partition;
- apply when the `case` subject is **not the partitioned parameter** — the correlation is between the *caller's* argument and the branch.

## Effect

```
ERBPostsEdit         @post: (Post | (Post & Post::Validated))?  ->  (Post & Post::Validated)
ERBUsersAvatarsEdit  @user: (User & User::Validated)?           ->  (User & User::Validated)
```

The partial's local becomes the union of the two paths that render it (`:edit` → Validated, `:new` → plain `Post`) rather than a nilable widening — **matching what the retired hand-rolled generator produced, now derived rather than hand-computed**.

Only the 4 views the override renders change. No new errors.

## Also in here

`spec/expectations/steep_contracts.yml` was stale on `main`: felixefelip/steep#94 discharged five `TagDestroy#*` `self.xml` preconditions by proving the ivar through the flow instead, and the sidecar was committed without its expectation. Verified pre-existing by stashing this change and re-diffing — not caused by this work.

## Tests

- **SteepBridge** (5): per-literal partitions, separation between literals, `::` normalization, two empty cases.
- **Collector** (6): the four non-applications above, plus the positive case and per-branch separation.
- Unit **740**, integration **71** — all green; steep set-difference against the baseline empty in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)