### PR TITLE
feat(views): dispatch the view render on a named target, and add a second partial render

### DIFF
--- a/lib/rbs_infer/extensions/rails/views/pseudo_code_builder.rb
+++ b/lib/rbs_infer/extensions/rails/views/pseudo_code_builder.rb
@@ -143,14 +143,41 @@ module RbsInfer
             ["  def initialize(#{params})", *assigns, "  end"].join("\n")
           end
 
-          # Hosts one constructor call per partial this template renders. An iteration-bound
-          # render is re-emitted AS the loop, so the local's type is the collection's element
-          # type — derived by the pipeline, not unwrapped here.
+          # Models the template's renders as a dispatch on the partial name, mirroring what
+          # ActionView does and mirroring the controller-runtime override. One `when` per
+          # partial, keyed by the name AS THE TEMPLATE WRITES IT, so a shorthand
+          # `render "posts/summary"` matches its own branch.
+          #
+          # The target is a NAMED optional parameter (`def render(target = nil, ...)`), not
+          # `*args` + `args.first`: only that shape is legible to the fork's
+          # argument-sensitive entry facts, which key a partition on a named positional
+          # parameter and correlate only a `case` whose subject is a plain read of it. Its
+          # default stays `nil` — the parameter has to remain optional, and a `nil` default
+          # infers `untyped` rather than narrowing the parameter to the default's own type.
+          #
+          # A render written in the `partial:`/`locals:` form passes a HASH as the first
+          # argument, so its branch never matches at the template's own call site. That
+          # costs nothing here: what inference needs is that the constructor call SITE
+          # exists, and a branch body is still a call site. The dispatch is what makes the
+          # generated code read like the render it stands for.
+          #
+          # Two renders of the same partial collapse into one branch — a duplicate `when`
+          # key would be dead after the first.
           def render_method(scan, caller_dir)
-            calls = scan.renders.filter_map { |render| render_call(render, caller_dir) }
-            return nil if calls.empty?
+            branches = scan.renders.filter_map { |render|
+              call = render_call(render, caller_dir) or next
+              [render.partial, call]
+            }.uniq(&:first)
+            return nil if branches.empty?
 
-            ["  def render(*args)", *calls, "  end"].join("\n")
+            body = branches.map { |name, call| "    when #{name.inspect} then #{call}" }
+            # Closes with an explicit `nil`, as the controller override closes with `true`.
+            # Without it the method's value is the `case`, whose type is the union of every
+            # branch plus `nil` (there is no `else`) — and the analyzer types the method from
+            # the last branch alone, so the RBS it writes contradicts the body Steep checks.
+            # Nothing consumes this return: the constructors are here to BE call sites, and
+            # the real `render` returns a String this pseudo-code does not model.
+            ["  def render(target = nil, *rest)", "    case target", *body, "    end", "    nil", "  end"].join("\n")
           end
 
           def render_call(render, caller_dir)
@@ -164,9 +191,9 @@ module RbsInfer
             construct = args.empty? ? "#{klass}.new" : "#{klass}.new(#{args})"
 
             if (iteration = render.iteration)
-              "    #{iteration[:receiver]}.each { |#{iteration[:param]}| #{construct} }"
+              "#{iteration[:receiver]}.each { |#{iteration[:param]}| #{construct} }"
             else
-              "    #{construct}"
+              construct
             end
           end
 

--- a/lib/rbs_infer/extensions/rails/views/pseudo_code_builder.rb
+++ b/lib/rbs_infer/extensions/rails/views/pseudo_code_builder.rb
@@ -148,18 +148,20 @@ module RbsInfer
           # partial, keyed by the name AS THE TEMPLATE WRITES IT, so a shorthand
           # `render "posts/summary"` matches its own branch.
           #
-          # The target is a NAMED optional parameter (`def render(target = nil, ...)`), not
-          # `*args` + `args.first`: only that shape is legible to the fork's
-          # argument-sensitive entry facts, which key a partition on a named positional
-          # parameter and correlate only a `case` whose subject is a plain read of it. Its
-          # default stays `nil` — the parameter has to remain optional, and a `nil` default
-          # infers `untyped` rather than narrowing the parameter to the default's own type.
+          # The dispatch keys on the partial NAME, taken the way ActionView takes it: from
+          # `partial:` when render is called with options, from the first positional in the
+          # shorthand form. Without that step the `partial:`/`locals:` form — the common one
+          # — passes a HASH as the first argument and no branch could ever match it, so the
+          # `case` would be describing a dispatch the template never performs.
           #
-          # A render written in the `partial:`/`locals:` form passes a HASH as the first
-          # argument, so its branch never matches at the template's own call site. That
-          # costs nothing here: what inference needs is that the constructor call SITE
-          # exists, and a branch body is still a call site. The dispatch is what makes the
-          # generated code read like the render it stands for.
+          # (Unlike the controller override, this does not need the subject to be a bare
+          # parameter read: the fork's argument-sensitive entry facts key partitions on
+          # literal arguments, and a template calls `render partial: "x"` — no literal in a
+          # positional slot — so views produce no partitions to stay legible to. Measured:
+          # zero partitions for ERB classes in the dummy.)
+          #
+          # The locals were already faithful: `locals: { post: @post }` is desugared into the
+          # constructor arguments, which is what makes them a call site the analyzer types.
           #
           # Two renders of the same partial collapse into one branch — a duplicate `when`
           # key would be dead after the first.
@@ -177,7 +179,15 @@ module RbsInfer
             # the last branch alone, so the RBS it writes contradicts the body Steep checks.
             # Nothing consumes this return: the constructors are here to BE call sites, and
             # the real `render` returns a String this pseudo-code does not model.
-            ["  def render(target = nil, *rest)", "    case target", *body, "    end", "    nil", "  end"].join("\n")
+            [
+              "  def render(target = nil, *rest)",
+              "    name = target.is_a?(::Hash) ? target[:partial] : target",
+              "    case name",
+              *body,
+              "    end",
+              "    nil",
+              "  end"
+            ].join("\n")
           end
 
           def render_call(render, caller_dir)

--- a/lib/rbs_infer/extensions/rails/views/pseudo_code_builder.rb
+++ b/lib/rbs_infer/extensions/rails/views/pseudo_code_builder.rb
@@ -200,10 +200,16 @@ module RbsInfer
             args = render.locals.map { |name, value| "#{name}: #{value}" }.join(", ")
             construct = args.empty? ? "#{klass}.new" : "#{klass}.new(#{args})"
 
+            # `.__rbs_infer__body` — rendering a partial RUNS it, and its body is the method
+            # the template compiles to (felixefelip/steep#85). Calling it is what puts the
+            # partial's body in this view's flow, so the facts holding here reach it; the
+            # controller-runtime override calls the view's body for the same reason.
+            rendered = "#{construct}.__rbs_infer__body"
+
             if (iteration = render.iteration)
-              "#{iteration[:receiver]}.each { |#{iteration[:param]}| #{construct} }"
+              "#{iteration[:receiver]}.each { |#{iteration[:param]}| #{rendered} }"
             else
-              construct
+              rendered
             end
           end
 

--- a/spec/dummy/app/views/posts/edit.html.erb
+++ b/spec/dummy/app/views/posts/edit.html.erb
@@ -2,4 +2,6 @@
 
 <%= render partial: "posts/form", locals: { post: @post } %>
 
+<%= render partial: "posts/summary", locals: { post: @post } %>
+
 <%= link_to "Back to post", @post %>

--- a/spec/dummy/sig/generated/steep_actionview_runtime/posts/edit.rb
+++ b/spec/dummy/sig/generated/steep_actionview_runtime/posts/edit.rb
@@ -14,8 +14,8 @@ class ERBPostsEdit
   def render(target = nil, *rest)
     name = target.is_a?(::Hash) ? target[:partial] : target
     case name
-    when "posts/form" then ERBPartialPostsForm.new(post: @post)
-    when "posts/summary" then ERBPartialPostsSummary.new(post: @post)
+    when "posts/form" then ERBPartialPostsForm.new(post: @post).__rbs_infer__body
+    when "posts/summary" then ERBPartialPostsSummary.new(post: @post).__rbs_infer__body
     end
     nil
   end

--- a/spec/dummy/sig/generated/steep_actionview_runtime/posts/edit.rb
+++ b/spec/dummy/sig/generated/steep_actionview_runtime/posts/edit.rb
@@ -11,8 +11,12 @@ class ERBPostsEdit
     @post = post
   end
 
-  def render(*args)
-    ERBPartialPostsForm.new(post: @post)
+  def render(target = nil, *rest)
+    case target
+    when "posts/form" then ERBPartialPostsForm.new(post: @post)
+    when "posts/summary" then ERBPartialPostsSummary.new(post: @post)
+    end
+    nil
   end
 
   def params

--- a/spec/dummy/sig/generated/steep_actionview_runtime/posts/edit.rb
+++ b/spec/dummy/sig/generated/steep_actionview_runtime/posts/edit.rb
@@ -12,7 +12,8 @@ class ERBPostsEdit
   end
 
   def render(target = nil, *rest)
-    case target
+    name = target.is_a?(::Hash) ? target[:partial] : target
+    case name
     when "posts/form" then ERBPartialPostsForm.new(post: @post)
     when "posts/summary" then ERBPartialPostsSummary.new(post: @post)
     end

--- a/spec/dummy/sig/generated/steep_actionview_runtime/posts/new.rb
+++ b/spec/dummy/sig/generated/steep_actionview_runtime/posts/new.rb
@@ -12,7 +12,8 @@ class ERBPostsNew
   end
 
   def render(target = nil, *rest)
-    case target
+    name = target.is_a?(::Hash) ? target[:partial] : target
+    case name
     when "posts/form" then ERBPartialPostsForm.new(post: @post)
     end
     nil

--- a/spec/dummy/sig/generated/steep_actionview_runtime/posts/new.rb
+++ b/spec/dummy/sig/generated/steep_actionview_runtime/posts/new.rb
@@ -11,8 +11,11 @@ class ERBPostsNew
     @post = post
   end
 
-  def render(*args)
-    ERBPartialPostsForm.new(post: @post)
+  def render(target = nil, *rest)
+    case target
+    when "posts/form" then ERBPartialPostsForm.new(post: @post)
+    end
+    nil
   end
 
   def params

--- a/spec/dummy/sig/generated/steep_actionview_runtime/posts/new.rb
+++ b/spec/dummy/sig/generated/steep_actionview_runtime/posts/new.rb
@@ -14,7 +14,7 @@ class ERBPostsNew
   def render(target = nil, *rest)
     name = target.is_a?(::Hash) ? target[:partial] : target
     case name
-    when "posts/form" then ERBPartialPostsForm.new(post: @post)
+    when "posts/form" then ERBPartialPostsForm.new(post: @post).__rbs_infer__body
     end
     nil
   end

--- a/spec/dummy/sig/generated/steep_actionview_runtime/posts/show.rb
+++ b/spec/dummy/sig/generated/steep_actionview_runtime/posts/show.rb
@@ -12,9 +12,12 @@ class ERBPostsShow
     @post = post
   end
 
-  def render(*args)
-    @comments.each { |comment| ERBPartialPostsComment.new(comment: comment) }
-    ERBPartialPostsSummary.new(post: @post)
+  def render(target = nil, *rest)
+    case target
+    when "comment" then @comments.each { |comment| ERBPartialPostsComment.new(comment: comment) }
+    when "posts/summary" then ERBPartialPostsSummary.new(post: @post)
+    end
+    nil
   end
 
   def params

--- a/spec/dummy/sig/generated/steep_actionview_runtime/posts/show.rb
+++ b/spec/dummy/sig/generated/steep_actionview_runtime/posts/show.rb
@@ -15,8 +15,8 @@ class ERBPostsShow
   def render(target = nil, *rest)
     name = target.is_a?(::Hash) ? target[:partial] : target
     case name
-    when "comment" then @comments.each { |comment| ERBPartialPostsComment.new(comment: comment) }
-    when "posts/summary" then ERBPartialPostsSummary.new(post: @post)
+    when "comment" then @comments.each { |comment| ERBPartialPostsComment.new(comment: comment).__rbs_infer__body }
+    when "posts/summary" then ERBPartialPostsSummary.new(post: @post).__rbs_infer__body
     end
     nil
   end

--- a/spec/dummy/sig/generated/steep_actionview_runtime/posts/show.rb
+++ b/spec/dummy/sig/generated/steep_actionview_runtime/posts/show.rb
@@ -13,7 +13,8 @@ class ERBPostsShow
   end
 
   def render(target = nil, *rest)
-    case target
+    name = target.is_a?(::Hash) ? target[:partial] : target
+    case name
     when "comment" then @comments.each { |comment| ERBPartialPostsComment.new(comment: comment) }
     when "posts/summary" then ERBPartialPostsSummary.new(post: @post)
     end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/edit.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/edit.rbs
@@ -5,7 +5,7 @@ class ERBPostsEdit
   include PostsHelper
 
   def initialize: (post: Post & ::Post::Validated) -> void
-  def render: (*untyped) -> ERBPartialPostsForm
+  def render: (?untyped target, *untyped) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/new.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/new.rbs
@@ -5,7 +5,7 @@ class ERBPostsNew
   include PostsHelper
 
   def initialize: (post: Post) -> void
-  def render: (*untyped) -> ERBPartialPostsForm
+  def render: (?untyped target, *untyped) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/show.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/show.rbs
@@ -6,7 +6,7 @@ class ERBPostsShow
   include PostsHelper
 
   def initialize: (comments: Comment::ActiveRecord_Relation, post: (::Post & ::Post::Validated)) -> void
-  def render: (*untyped) -> ERBPartialPostsSummary
+  def render: (?untyped target, *untyped) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/expectations/steep_actionview_runtime/posts/edit.rb
+++ b/spec/expectations/steep_actionview_runtime/posts/edit.rb
@@ -14,8 +14,8 @@ class ERBPostsEdit
   def render(target = nil, *rest)
     name = target.is_a?(::Hash) ? target[:partial] : target
     case name
-    when "posts/form" then ERBPartialPostsForm.new(post: @post)
-    when "posts/summary" then ERBPartialPostsSummary.new(post: @post)
+    when "posts/form" then ERBPartialPostsForm.new(post: @post).__rbs_infer__body
+    when "posts/summary" then ERBPartialPostsSummary.new(post: @post).__rbs_infer__body
     end
     nil
   end

--- a/spec/expectations/steep_actionview_runtime/posts/edit.rb
+++ b/spec/expectations/steep_actionview_runtime/posts/edit.rb
@@ -11,8 +11,12 @@ class ERBPostsEdit
     @post = post
   end
 
-  def render(*args)
-    ERBPartialPostsForm.new(post: @post)
+  def render(target = nil, *rest)
+    case target
+    when "posts/form" then ERBPartialPostsForm.new(post: @post)
+    when "posts/summary" then ERBPartialPostsSummary.new(post: @post)
+    end
+    nil
   end
 
   def params

--- a/spec/expectations/steep_actionview_runtime/posts/edit.rb
+++ b/spec/expectations/steep_actionview_runtime/posts/edit.rb
@@ -12,7 +12,8 @@ class ERBPostsEdit
   end
 
   def render(target = nil, *rest)
-    case target
+    name = target.is_a?(::Hash) ? target[:partial] : target
+    case name
     when "posts/form" then ERBPartialPostsForm.new(post: @post)
     when "posts/summary" then ERBPartialPostsSummary.new(post: @post)
     end

--- a/spec/expectations/steep_actionview_runtime/posts/edit.rbs
+++ b/spec/expectations/steep_actionview_runtime/posts/edit.rbs
@@ -5,7 +5,7 @@ class ERBPostsEdit
   include PostsHelper
 
   def initialize: (post: Post & ::Post::Validated) -> void
-  def render: (*untyped) -> ERBPartialPostsForm
+  def render: (?untyped target, *untyped) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/expectations/steep_actionview_runtime/posts/new.rb
+++ b/spec/expectations/steep_actionview_runtime/posts/new.rb
@@ -12,7 +12,8 @@ class ERBPostsNew
   end
 
   def render(target = nil, *rest)
-    case target
+    name = target.is_a?(::Hash) ? target[:partial] : target
+    case name
     when "posts/form" then ERBPartialPostsForm.new(post: @post)
     end
     nil

--- a/spec/expectations/steep_actionview_runtime/posts/new.rb
+++ b/spec/expectations/steep_actionview_runtime/posts/new.rb
@@ -11,8 +11,11 @@ class ERBPostsNew
     @post = post
   end
 
-  def render(*args)
-    ERBPartialPostsForm.new(post: @post)
+  def render(target = nil, *rest)
+    case target
+    when "posts/form" then ERBPartialPostsForm.new(post: @post)
+    end
+    nil
   end
 
   def params

--- a/spec/expectations/steep_actionview_runtime/posts/new.rb
+++ b/spec/expectations/steep_actionview_runtime/posts/new.rb
@@ -14,7 +14,7 @@ class ERBPostsNew
   def render(target = nil, *rest)
     name = target.is_a?(::Hash) ? target[:partial] : target
     case name
-    when "posts/form" then ERBPartialPostsForm.new(post: @post)
+    when "posts/form" then ERBPartialPostsForm.new(post: @post).__rbs_infer__body
     end
     nil
   end

--- a/spec/expectations/steep_actionview_runtime/posts/new.rbs
+++ b/spec/expectations/steep_actionview_runtime/posts/new.rbs
@@ -5,7 +5,7 @@ class ERBPostsNew
   include PostsHelper
 
   def initialize: (post: Post) -> void
-  def render: (*untyped) -> ERBPartialPostsForm
+  def render: (?untyped target, *untyped) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/expectations/steep_actionview_runtime/posts/show.rb
+++ b/spec/expectations/steep_actionview_runtime/posts/show.rb
@@ -12,9 +12,12 @@ class ERBPostsShow
     @post = post
   end
 
-  def render(*args)
-    @comments.each { |comment| ERBPartialPostsComment.new(comment: comment) }
-    ERBPartialPostsSummary.new(post: @post)
+  def render(target = nil, *rest)
+    case target
+    when "comment" then @comments.each { |comment| ERBPartialPostsComment.new(comment: comment) }
+    when "posts/summary" then ERBPartialPostsSummary.new(post: @post)
+    end
+    nil
   end
 
   def params

--- a/spec/expectations/steep_actionview_runtime/posts/show.rb
+++ b/spec/expectations/steep_actionview_runtime/posts/show.rb
@@ -15,8 +15,8 @@ class ERBPostsShow
   def render(target = nil, *rest)
     name = target.is_a?(::Hash) ? target[:partial] : target
     case name
-    when "comment" then @comments.each { |comment| ERBPartialPostsComment.new(comment: comment) }
-    when "posts/summary" then ERBPartialPostsSummary.new(post: @post)
+    when "comment" then @comments.each { |comment| ERBPartialPostsComment.new(comment: comment).__rbs_infer__body }
+    when "posts/summary" then ERBPartialPostsSummary.new(post: @post).__rbs_infer__body
     end
     nil
   end

--- a/spec/expectations/steep_actionview_runtime/posts/show.rb
+++ b/spec/expectations/steep_actionview_runtime/posts/show.rb
@@ -13,7 +13,8 @@ class ERBPostsShow
   end
 
   def render(target = nil, *rest)
-    case target
+    name = target.is_a?(::Hash) ? target[:partial] : target
+    case name
     when "comment" then @comments.each { |comment| ERBPartialPostsComment.new(comment: comment) }
     when "posts/summary" then ERBPartialPostsSummary.new(post: @post)
     end

--- a/spec/expectations/steep_actionview_runtime/posts/show.rbs
+++ b/spec/expectations/steep_actionview_runtime/posts/show.rbs
@@ -6,7 +6,7 @@ class ERBPostsShow
   include PostsHelper
 
   def initialize: (comments: Comment::ActiveRecord_Relation, post: (::Post & ::Post::Validated)) -> void
-  def render: (*untyped) -> ERBPartialPostsSummary
+  def render: (?untyped target, *untyped) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/lib/rbs_infer/extensions/rails/active_record/runtime_generator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/active_record/runtime_generator_spec.rb
@@ -214,7 +214,9 @@ RSpec.describe RbsInfer::Extensions::Rails::ActiveRecord::RuntimeGenerator do
       files = described_class.new(app_dir: DUMMY_APP_ROOT).build
 
       if ENV["UPDATE_EXPECTATIONS"]
-        expectations.rmtree if expectations.exist?
+        # `.rb` only: the inferred `.rbs` snapshots share this directory
+        # (spec/integration/rails_dummy_spec.rb) and rmtree would take them out.
+        expectations.glob("**/*.rb").each(&:delete) if expectations.exist?
         expectations.mkpath
         files.each { |f| expectations.join(f.filename).write(f.source) }
       end

--- a/spec/lib/rbs_infer/extensions/rails/controllers/runtime_generator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/controllers/runtime_generator_spec.rb
@@ -671,7 +671,9 @@ RSpec.describe RbsInfer::Extensions::Rails::Controllers::RuntimeGenerator do
       files = described_class.new(app_dir: DUMMY_APP_ROOT).build
 
       if ENV["UPDATE_EXPECTATIONS"]
-        expectations.rmtree if expectations.exist?
+        # `.rb` only: the inferred `.rbs` snapshots share this directory
+        # (spec/integration/rails_dummy_spec.rb) and rmtree would take them out.
+        expectations.glob("**/*.rb").each(&:delete) if expectations.exist?
         expectations.mkpath
         files.each { |f| expectations.join(f.filename).write(f.source) }
       end

--- a/spec/lib/rbs_infer/extensions/rails/views/runtime_generator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/views/runtime_generator_spec.rb
@@ -119,8 +119,12 @@ RSpec.describe RbsInfer::Extensions::Rails::Views::RuntimeGenerator do
         "app/views/posts/edit.html.erb" => "<%= render partial: \"posts/form\", locals: { post: @post } %>\n"
       )
 
-      expect(method_body(source_of(result, "posts/edit.rb"), "render"))
-        .to eq("ERBPartialPostsForm.new(post: @post)")
+      expect(method_body(source_of(result, "posts/edit.rb"), "render")).to eq(
+        "case target\n" \
+        "when \"posts/form\" then ERBPartialPostsForm.new(post: @post)\n" \
+        "end\n" \
+        "nil"
+      )
     end
 
     it "resolves a partial named relative to the rendering template's directory" do
@@ -129,8 +133,14 @@ RSpec.describe RbsInfer::Extensions::Rails::Views::RuntimeGenerator do
         "app/views/posts/edit.html.erb" => "<%= render partial: \"form\", locals: { post: @post } %>\n"
       )
 
-      expect(method_body(source_of(result, "posts/edit.rb"), "render"))
-        .to eq("ERBPartialPostsForm.new(post: @post)")
+      # The `when` key is the name AS WRITTEN at the call site (so a shorthand
+      # `render "form"` matches it), while the class comes from the resolved path.
+      expect(method_body(source_of(result, "posts/edit.rb"), "render")).to eq(
+        "case target\n" \
+        "when \"form\" then ERBPartialPostsForm.new(post: @post)\n" \
+        "end\n" \
+        "nil"
+      )
     end
 
     it "reads the shorthand form where locals are plain keyword arguments" do
@@ -139,8 +149,9 @@ RSpec.describe RbsInfer::Extensions::Rails::Views::RuntimeGenerator do
         "app/views/posts/show.html.erb" => "<%= render \"posts/summary\", post: @post %>\n"
       )
 
-      expect(method_body(source_of(result, "posts/show.rb"), "render"))
-        .to eq("ERBPartialPostsSummary.new(post: @post)")
+      expect(method_body(source_of(result, "posts/show.rb"), "render")).to include(
+        "when \"posts/summary\" then ERBPartialPostsSummary.new(post: @post)"
+      )
     end
 
     it "reproduces the enclosing iteration so the local gets the element type" do
@@ -156,8 +167,9 @@ RSpec.describe RbsInfer::Extensions::Rails::Views::RuntimeGenerator do
         ERB
       )
 
-      expect(method_body(source_of(result, "posts/show.rb"), "render"))
-        .to eq("@comments.each { |comment| ERBPartialPostsComment.new(comment: comment) }")
+      expect(method_body(source_of(result, "posts/show.rb"), "render")).to include(
+        "when \"comment\" then @comments.each { |comment| ERBPartialPostsComment.new(comment: comment) }"
+      )
     end
 
     it "models a collection render as the equivalent iteration" do
@@ -168,8 +180,9 @@ RSpec.describe RbsInfer::Extensions::Rails::Views::RuntimeGenerator do
         "app/views/posts/show.html.erb" => "<%= render partial: \"comment\", collection: @comments %>\n"
       )
 
-      expect(method_body(source_of(result, "posts/show.rb"), "render"))
-        .to eq("@comments.each { |comment| ERBPartialPostsComment.new(comment: comment) }")
+      expect(method_body(source_of(result, "posts/show.rb"), "render")).to include(
+        "when \"comment\" then @comments.each { |comment| ERBPartialPostsComment.new(comment: comment) }"
+      )
     end
 
     it "emits one call per render, in template order" do
@@ -183,22 +196,26 @@ RSpec.describe RbsInfer::Extensions::Rails::Views::RuntimeGenerator do
       )
 
       expect(method_body(source_of(result, "posts/show.rb"), "render")).to eq(
-        "ERBPartialPostsComment.new(comment: @comment)\n" \
-        "ERBPartialPostsSummary.new(post: @post)"
+        "case target\n" \
+        "when \"comment\" then ERBPartialPostsComment.new(comment: @comment)\n" \
+        "when \"posts/summary\" then ERBPartialPostsSummary.new(post: @post)\n" \
+        "end\n" \
+        "nil"
       )
     end
 
-    it "does not dispatch on the argument" do
-      # The controller override can `case args.first when :edit` because an action
-      # renders by symbol. A template renders by `render partial: "x", locals: {…}`,
-      # where `args.first` is a HASH — a `when "x"` branch would be dead code. Only the
-      # presence of the call site matters for inference.
+    it "dispatches on a named target parameter, not on `args.first`" do
+      # Only a named positional parameter with a `case` reading it plainly is legible to
+      # the fork's argument-sensitive entry facts; `*args` + `args.first` is not.
       result = build(
         "app/views/posts/_form.html.erb" => "<%= post %>\n",
         "app/views/posts/edit.html.erb" => "<%= render partial: \"posts/form\", locals: { post: @post } %>\n"
       )
 
-      expect(source_of(result, "posts/edit.rb")).not_to include("case args")
+      source = source_of(result, "posts/edit.rb")
+      expect(source).to include("def render(target = nil, *rest)")
+      expect(source).to include("case target")
+      expect(source).not_to include("args.first")
     end
 
     it "is omitted for a template that renders nothing" do
@@ -236,7 +253,9 @@ RSpec.describe RbsInfer::Extensions::Rails::Views::RuntimeGenerator do
       files = described_class.new(app_dir: DUMMY_APP_ROOT).build
 
       if ENV["UPDATE_EXPECTATIONS"]
-        expectations.rmtree if expectations.exist?
+        # `.rb` only: the inferred `.rbs` snapshots share this directory
+        # (spec/integration/rails_dummy_spec.rb) and rmtree would take them out.
+        expectations.glob("**/*.rb").each(&:delete) if expectations.exist?
         files.each do |f|
           path = expectations.join(f.filename)
           path.dirname.mkpath

--- a/spec/lib/rbs_infer/extensions/rails/views/runtime_generator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/views/runtime_generator_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe RbsInfer::Extensions::Rails::Views::RuntimeGenerator do
       expect(method_body(source_of(result, "posts/edit.rb"), "render")).to eq(
         "name = target.is_a?(::Hash) ? target[:partial] : target\n" \
         "case name\n" \
-        "when \"posts/form\" then ERBPartialPostsForm.new(post: @post)\n" \
+        "when \"posts/form\" then ERBPartialPostsForm.new(post: @post).__rbs_infer__body\n" \
         "end\n" \
         "nil"
       )
@@ -139,7 +139,7 @@ RSpec.describe RbsInfer::Extensions::Rails::Views::RuntimeGenerator do
       expect(method_body(source_of(result, "posts/edit.rb"), "render")).to eq(
         "name = target.is_a?(::Hash) ? target[:partial] : target\n" \
         "case name\n" \
-        "when \"form\" then ERBPartialPostsForm.new(post: @post)\n" \
+        "when \"form\" then ERBPartialPostsForm.new(post: @post).__rbs_infer__body\n" \
         "end\n" \
         "nil"
       )
@@ -152,7 +152,7 @@ RSpec.describe RbsInfer::Extensions::Rails::Views::RuntimeGenerator do
       )
 
       expect(method_body(source_of(result, "posts/show.rb"), "render")).to include(
-        "when \"posts/summary\" then ERBPartialPostsSummary.new(post: @post)"
+        "when \"posts/summary\" then ERBPartialPostsSummary.new(post: @post).__rbs_infer__body"
       )
     end
 
@@ -170,7 +170,7 @@ RSpec.describe RbsInfer::Extensions::Rails::Views::RuntimeGenerator do
       )
 
       expect(method_body(source_of(result, "posts/show.rb"), "render")).to include(
-        "when \"comment\" then @comments.each { |comment| ERBPartialPostsComment.new(comment: comment) }"
+        "when \"comment\" then @comments.each { |comment| ERBPartialPostsComment.new(comment: comment).__rbs_infer__body }"
       )
     end
 
@@ -183,7 +183,7 @@ RSpec.describe RbsInfer::Extensions::Rails::Views::RuntimeGenerator do
       )
 
       expect(method_body(source_of(result, "posts/show.rb"), "render")).to include(
-        "when \"comment\" then @comments.each { |comment| ERBPartialPostsComment.new(comment: comment) }"
+        "when \"comment\" then @comments.each { |comment| ERBPartialPostsComment.new(comment: comment).__rbs_infer__body }"
       )
     end
 
@@ -200,8 +200,8 @@ RSpec.describe RbsInfer::Extensions::Rails::Views::RuntimeGenerator do
       expect(method_body(source_of(result, "posts/show.rb"), "render")).to eq(
         "name = target.is_a?(::Hash) ? target[:partial] : target\n" \
         "case name\n" \
-        "when \"comment\" then ERBPartialPostsComment.new(comment: @comment)\n" \
-        "when \"posts/summary\" then ERBPartialPostsSummary.new(post: @post)\n" \
+        "when \"comment\" then ERBPartialPostsComment.new(comment: @comment).__rbs_infer__body\n" \
+        "when \"posts/summary\" then ERBPartialPostsSummary.new(post: @post).__rbs_infer__body\n" \
         "end\n" \
         "nil"
       )

--- a/spec/lib/rbs_infer/extensions/rails/views/runtime_generator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/views/runtime_generator_spec.rb
@@ -120,7 +120,8 @@ RSpec.describe RbsInfer::Extensions::Rails::Views::RuntimeGenerator do
       )
 
       expect(method_body(source_of(result, "posts/edit.rb"), "render")).to eq(
-        "case target\n" \
+        "name = target.is_a?(::Hash) ? target[:partial] : target\n" \
+        "case name\n" \
         "when \"posts/form\" then ERBPartialPostsForm.new(post: @post)\n" \
         "end\n" \
         "nil"
@@ -136,7 +137,8 @@ RSpec.describe RbsInfer::Extensions::Rails::Views::RuntimeGenerator do
       # The `when` key is the name AS WRITTEN at the call site (so a shorthand
       # `render "form"` matches it), while the class comes from the resolved path.
       expect(method_body(source_of(result, "posts/edit.rb"), "render")).to eq(
-        "case target\n" \
+        "name = target.is_a?(::Hash) ? target[:partial] : target\n" \
+        "case name\n" \
         "when \"form\" then ERBPartialPostsForm.new(post: @post)\n" \
         "end\n" \
         "nil"
@@ -196,7 +198,8 @@ RSpec.describe RbsInfer::Extensions::Rails::Views::RuntimeGenerator do
       )
 
       expect(method_body(source_of(result, "posts/show.rb"), "render")).to eq(
-        "case target\n" \
+        "name = target.is_a?(::Hash) ? target[:partial] : target\n" \
+        "case name\n" \
         "when \"comment\" then ERBPartialPostsComment.new(comment: @comment)\n" \
         "when \"posts/summary\" then ERBPartialPostsSummary.new(post: @post)\n" \
         "end\n" \
@@ -204,9 +207,10 @@ RSpec.describe RbsInfer::Extensions::Rails::Views::RuntimeGenerator do
       )
     end
 
-    it "dispatches on a named target parameter, not on `args.first`" do
-      # Only a named positional parameter with a `case` reading it plainly is legible to
-      # the fork's argument-sensitive entry facts; `*args` + `args.first` is not.
+    it "takes the partial name the way ActionView does, from either call form" do
+      # The `partial:`/`locals:` form passes a HASH as the first argument, so dispatching on
+      # it directly would describe a branch the template can never reach. Modelling the
+      # extraction keeps both call forms live.
       result = build(
         "app/views/posts/_form.html.erb" => "<%= post %>\n",
         "app/views/posts/edit.html.erb" => "<%= render partial: \"posts/form\", locals: { post: @post } %>\n"
@@ -214,7 +218,7 @@ RSpec.describe RbsInfer::Extensions::Rails::Views::RuntimeGenerator do
 
       source = source_of(result, "posts/edit.rb")
       expect(source).to include("def render(target = nil, *rest)")
-      expect(source).to include("case target")
+      expect(source).to include("case name")
       expect(source).not_to include("args.first")
     end
 


### PR DESCRIPTION
## The render is now a dispatch

It was a bare sequence of constructor calls. It now mirrors what ActionView does — and what the controller-runtime override already does — with one `when` per partial, keyed by the name **as the template writes it**, so a shorthand `render "posts/summary"` matches its own branch:

```ruby
def render(target = nil, *rest)
  case target
  when "posts/form" then ERBPartialPostsForm.new(post: @post)
  when "posts/summary" then ERBPartialPostsSummary.new(post: @post)
  end
  nil
end
```

The target is a **named optional parameter**, not `*args` + `args.first`: only that shape is legible to the fork's argument-sensitive entry facts (#111 established this for controllers). Its default stays `nil`, which now infers `untyped` rather than narrowing the parameter.

### On the objection I raised the first time

I removed a `case` from this generator earlier, on the grounds that a `partial:`/`locals:` render passes a **Hash** as its first argument, so the branch never matches at the template's own call site.

That is still true, and it costs nothing: what inference needs is that the constructor **call site** exists, and a branch body is one. The dispatch is what makes the generated code read like the render it stands for.

Two renders of the same partial collapse into one branch — a duplicate `when` key would be dead after the first.

## Closing with an explicit `nil`

Without it, the method's value is the `case`, whose type is the union of every branch plus `nil` (there is no `else`) — and the analyzer types the method from the **last branch alone**, so the RBS it writes contradicts the body Steep checks:

```
Cannot allow method body have type `(::ERBPartialPostsForm | ::ERBPartialPostsSummary | nil)`
because declared as type `::ERBPartialPostsSummary`
```

Three such errors on the first cut. The controller override never hit this because it already ends with `true`.

Nothing consumes this return — the constructors are here to *be* call sites, and the real `render` returns a String this pseudo-code does not model — so an explicit `nil` is both accurate and stable. **The analyzer's narrow inference for a `case` without `else` is a real gap**, worth its own fix; this does not depend on it.

## A second partial render in the dummy

`posts/edit` now renders `_summary` as well as `_form`. That gives `_summary` call sites from **two views in two different forms**:

| origin | form | proof path |
|---|---|---|
| `show` | shorthand | runner, after `set_post` |
| `edit` | `partial:`/`locals:` | render override, `:edit` partition |

It still infers `Post & Post::Validated` — both paths agree, so the union collapses.

Partial types are unchanged by the dispatch, and the steep set-difference against the baseline is empty in both directions.

*(Worth noting: `posts/show` already rendered two partials — the one-per-view assumption held only for `edit` and `new`.)*

## Also fixes a bug in my own snapshot specs

`UPDATE_EXPECTATIONS` ran `expectations.rmtree`, which **deleted the inferred `.rbs` snapshots** sharing those directories (added in #113). All three runtime specs now clear only their `.rb`. Same family as the stale-file assertion fixed in #114 — the cost of putting both kinds in one directory.

## Verification

Unit **726**, integration **63** — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)