### PR TITLE
feat(inference): read ERB as a source format, with the class mapping in an extension

### DIFF
--- a/bin/rbs_infer
+++ b/bin/rbs_infer
@@ -72,11 +72,22 @@ end
 # `app/`/`engines/`/`lib/` — p.ex. o pseudo-código AR-runtime sob `sig/` —
 # o call-site ficava invisível e a inferência de param/getter degradava
 # para `untyped`. Unir input + layout padrão cobre os dois casos.
-source_files = (files + Dir["app/**/*.rb", "engines/**/*.rb", "lib/**/*.rb"]).uniq
+# `.erb` sits alongside `.rb` here because ParseCache reads it as a source format,
+# not because of anything Rails: a template's calls are call sites like any other, and
+# leaving them out is what made a helper's parameters (and a view's `render`) `untyped`.
+source_files = (
+  files +
+  Dir["app/**/*.rb", "engines/**/*.rb", "lib/**/*.rb"] +
+  Dir["app/**/*.erb", "engines/**/*.erb", "lib/**/*.erb"]
+).uniq
 
 rails_project = Gem::Specification.find_by_name("rails") rescue nil
 
 if rails_project
+  # Registers the ERB path -> class convention, so a template is selected as a caller of
+  # the class it is the body of (the core reads it as Ruby either way).
+  require "rbs_infer/extensions/rails/views/erb_source_owner"
+
   require "rbs_infer/extensions/rails/erb_caller_resolver"
   erb_caller_resolver = RbsInfer::Extensions::Rails::ErbCallerResolver.new(
     app_dir: Dir.pwd,

--- a/lib/rbs_infer/extensions/rails/views/erb_source_owner.rb
+++ b/lib/rbs_infer/extensions/rails/views/erb_source_owner.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative "path_naming"
+require_relative "../../../project/source_owners"
+
+module RbsInfer
+  module Extensions
+    module Rails
+      module Views
+        # Answers the `Project::SourceOwners` question for ERB templates:
+        # `app/views/posts/edit.html.erb` is the body of `ERBPostsEdit`.
+        #
+        # This is the convention half of ERB support. Reading the template as Ruby is
+        # format knowledge and lives in the core (`ParseCache`); knowing which class it
+        # belongs to is a Rails layout convention and belongs here. It is the same mapping
+        # the view-runtime generator uses to NAME the class, and the same one Steep's ERB
+        # convention uses to attach `@type self_method:` — one convention, stated once.
+        module ErbSourceOwner
+          extend PathNaming
+          module_function
+
+          # Gate on the extension first: this is asked once per indexed file.
+          def owner_class(path)
+            path = path.to_s
+            return nil unless path.end_with?(".erb")
+
+            relative = path[%r{(?:\A|/)app/views/(.+)\z}, 1] or return nil
+            erb_class_name(relative)
+          end
+
+          RbsInfer::Project::SourceOwners.register(self)
+        end
+      end
+    end
+  end
+end

--- a/lib/rbs_infer/inference/caller_file_analyzer.rb
+++ b/lib/rbs_infer/inference/caller_file_analyzer.rb
@@ -1,3 +1,6 @@
+require_relative "../project/source_reader"
+require_relative "../project/source_owners"
+
 module RbsInfer::Inference
   class CallerFileAnalyzer
     include RbsInfer::Signatures::RbsAnnotationParser
@@ -20,7 +23,7 @@ module RbsInfer::Inference
     end
 
     def analyze(file, force_bare: false)
-      source = File.read(file)
+      source = RbsInfer::Project::SourceReader.read(file) or return []
       result = Prism.parse(source)
       comments = result.comments
       method_return_types = extract_method_return_types(source, comments, result.value)
@@ -69,7 +72,11 @@ module RbsInfer::Inference
       # lives. Without this only the `include` shape counted, so a class split across files
       # (the controller-runtime pseudo-code defines the method, the app's own file calls it)
       # left every such call site invisible and its parameters `untyped`.
-      reopens_target = caller_visitor.class_name == @target_class.sub(/\A::/, "") &&
+      target_name = @target_class.sub(/\A::/, "")
+      # A file the target OWNS is its body — an ERB template IS `ERBPostsEdit`, so the
+      # calls it makes are self-calls, exactly like a reopen.
+      owned_by_target = RbsInfer::Project::SourceOwners.owner_class(file) == target_name
+      reopens_target = (caller_visitor.class_name == target_name || owned_by_target) &&
                        File.expand_path(file.to_s) != File.expand_path(@target_file.to_s)
       match_bare = force_bare || reopens_target ||
                    source.match?(/\binclude\b.*\b#{Regexp.escape(short_name)}\b/)

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -637,11 +637,23 @@ module RbsInfer::Inference
       args = {}
       return args unless call_node.arguments
 
-      # Args posicionais
+      # Args posicionais. Um `KeywordHashNode` normalmente é keyword — mas em Ruby 3,
+      # quando o método NÃO aceita keywords, as keywords do call-site viram um Hash
+      # POSICIONAL (`render partial: "x"` chega em `def render(target = nil, *rest)` como
+      # `target = {partial: "x"}`). Reconhecemos isso quando nenhuma chave corresponde a um
+      # parâmetro e ainda há slot posicional livre: sem isso o argumento desaparece, e o
+      # parâmetro é tipado só pelos OUTROS call-sites — estreito demais, não apenas impreciso.
       index = 0
       call_node.arguments.arguments.each do |arg|
         break if index >= param_names.size
-        next if arg.is_a?(Prism::KeywordHashNode)
+
+        if arg.is_a?(Prism::KeywordHashNode)
+          next unless collapses_to_positional?(arg, param_names)
+
+          args[param_names[index]] = hash_literal_type(arg)
+          index += 1
+          next
+        end
 
         args[param_names[index]] = resolve_value_type(arg)
         index += 1
@@ -650,6 +662,7 @@ module RbsInfer::Inference
       # Args keyword
       call_node.arguments.arguments.each do |arg|
         next unless arg.is_a?(Prism::KeywordHashNode)
+        next if collapses_to_positional?(arg, param_names)
 
         arg.elements.each do |elem|
           next unless elem.is_a?(Prism::AssocNode)
@@ -660,6 +673,28 @@ module RbsInfer::Inference
       end
 
       args
+    end
+
+    # Whether a keyword hash at the call site is really a positional Hash: no key names a
+    # parameter, so the callee cannot be receiving them as keywords.
+    def collapses_to_positional?(node, param_names)
+      keys = node.elements.filter_map { |e| e.is_a?(Prism::AssocNode) ? extract_symbol_key(e.key) : nil }
+      return false if keys.empty?
+
+      keys.none? { |k| param_names.include?(k) }
+    end
+
+    # `Hash[Symbol, <union of the value types>]` for a literal keyword hash.
+    def hash_literal_type(node)
+      values = node.elements.filter_map do |e|
+        next unless e.is_a?(Prism::AssocNode)
+        t = resolve_value_type(e.value)
+        t unless t.nil? || t == "untyped"
+      end.uniq
+
+      return "Hash[Symbol, untyped]" if values.empty?
+
+      "Hash[Symbol, #{values.size == 1 ? values.first : values.join(" | ")}]"
     end
   end
 end

--- a/lib/rbs_infer/project/parse_cache.rb
+++ b/lib/rbs_infer/project/parse_cache.rb
@@ -1,3 +1,5 @@
+require_relative "source_reader"
+
 module RbsInfer::Project
   # Cache de parse compartilhado por análise.
   # Garante que cada arquivo seja lido do disco e parseado pelo Prism apenas uma vez.
@@ -13,11 +15,19 @@ module RbsInfer::Project
       return @cache[file] if @cache.key?(file)
 
       @cache[file] = begin
-        source = File.read(file)
-        Entry.new(source: source, result: Prism.parse(source))
+        source = RbsInfer::Project::SourceReader.read(file)
+        source && Entry.new(source: source, result: Prism.parse(source))
       rescue Errno::ENOENT, Errno::EACCES
         nil
       end
+    end
+
+
+    def extract_ruby(source)
+      require "herb"
+      Herb.extract_ruby(source, comments: true)
+    rescue LoadError, StandardError
+      nil
     end
   end
 end

--- a/lib/rbs_infer/project/source_index.rb
+++ b/lib/rbs_infer/project/source_index.rb
@@ -1,3 +1,5 @@
+require_relative "source_owners"
+
 module RbsInfer::Project
 
   # Índice reverso de source files para lookup eficiente por nome de classe.
@@ -24,6 +26,14 @@ module RbsInfer::Project
         # externo pra `untyped`.
         content.scan(/\b([A-Z][a-zA-Z0-9_]*)\b/).flatten.uniq.each do |name|
           @index[name] << file
+        end
+
+        # A file whose class identity is not written in it (an ERB template is the body of
+        # `ERBPostsEdit`, but never spells that) would otherwise be read and then never
+        # selected as a caller. `SourceOwners` lets an extension state the convention.
+        if (owner = RbsInfer::Project::SourceOwners.owner_class(file))
+          short = owner.split("::").last
+          @index[short] << file unless @index[short].include?(file)
         end
       end
       @index.each_value(&:freeze)

--- a/lib/rbs_infer/project/source_owners.rb
+++ b/lib/rbs_infer/project/source_owners.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module RbsInfer::Project
+  # Registry of plugins that answer "which class does this FILE belong to?", for sources
+  # whose class identity is not written in them.
+  #
+  # A `.rb` file names its class (`class Foo`), so the reverse index finds it by reading
+  # the text. An ERB template does not: `app/views/posts/edit.html.erb` is the body of
+  # `ERBPostsEdit`, but nothing in the file says so — the mapping is a convention of
+  # whatever framework owns the directory layout. Without it a template is read, parsed and
+  # then never selected as a caller of anything, so the calls it makes are invisible.
+  #
+  # The core knows no convention: extensions register at require time, and the contract is
+  # one method.
+  #
+  #   owner.owner_class(path) #=> String (fully-qualified class) | nil (not mine)
+  #
+  # Resolvers must be cheap on the no-op path (gate on the extension or a path fragment
+  # before doing real work) — this is asked once per file while indexing.
+  module SourceOwners
+    @owners = []
+
+    module_function
+
+    def register(owner)
+      @owners << owner unless @owners.include?(owner)
+      owner
+    end
+
+    def unregister(owner)
+      @owners.delete(owner)
+    end
+
+    def owners
+      @owners.dup
+    end
+
+    # The first resolver to claim the file wins, so a more specific extension can be
+    # registered ahead of a general one. Returns nil when none claims it.
+    def owner_class(path)
+      @owners.each do |owner|
+        name = owner.owner_class(path)
+        return name if name
+      end
+      nil
+    end
+  end
+end

--- a/lib/rbs_infer/project/source_reader.rb
+++ b/lib/rbs_infer/project/source_reader.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module RbsInfer::Project
+  # Reads a source file as Ruby, whatever its on-disk format.
+  #
+  # A `.erb` file is Ruby interleaved with text, so it is extracted first — the same way
+  # `Steep::Source.parse` does it, keyed on the same suffix and using the same library.
+  # This is FORMAT knowledge, not framework knowledge: ERB is not a Rails concept, and
+  # nothing here looks at where the file lives or what class it belongs to (that is
+  # `SourceOwners`, and it is an extension's business).
+  #
+  # One place, because there are two readers — `ParseCache` for the target and index, and
+  # `CallerFileAnalyzer` for caller files, which reads on its own. Teaching only one of
+  # them leaves ERB half-supported in a way that looks like a wiring bug.
+  module SourceReader
+    module_function
+
+    # The file's Ruby, or nil when it cannot be read or extracted.
+    def read(file)
+      source = File.read(file)
+      return source unless file.to_s.end_with?(".erb")
+
+      extract_ruby(source)
+    rescue Errno::ENOENT, Errno::EACCES
+      nil
+    end
+
+    def extract_ruby(source)
+      require "herb"
+      Herb.extract_ruby(source, comments: true)
+    rescue LoadError, StandardError
+      nil
+    end
+  end
+end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/edit.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/edit.rbs
@@ -5,7 +5,7 @@ class ERBPostsEdit
   include PostsHelper
 
   def initialize: (post: Post & ::Post::Validated) -> void
-  def render: (?untyped target, *untyped) -> nil
+  def render: (?Hash[Symbol, String | { post: untyped }] target, *untyped) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/new.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/new.rbs
@@ -5,7 +5,7 @@ class ERBPostsNew
   include PostsHelper
 
   def initialize: (post: Post) -> void
-  def render: (?untyped target, *untyped) -> nil
+  def render: (?Hash[Symbol, String | { post: untyped }] target, *untyped) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/show.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/show.rbs
@@ -6,7 +6,7 @@ class ERBPostsShow
   include PostsHelper
 
   def initialize: (comments: Comment::ActiveRecord_Relation, post: (::Post & ::Post::Validated)) -> void
-  def render: (?untyped target, *untyped) -> nil
+  def render: (?(Hash[Symbol, String | { comment: untyped }] | String) target, *untyped) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
@@ -703,4 +703,54 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
     end
   end
 
+
+  # Ruby 3: when the callee accepts NO keyword parameters, keywords at the call site are
+  # passed as a positional Hash. Skipping them made the argument vanish, so the parameter
+  # was typed from the OTHER call sites alone — narrow enough to reject real calls, which
+  # is worse than imprecise.
+  describe "a keyword hash that collapses to a positional argument" do
+    def collect_calls(source, target_class:, target_methods:)
+      result = Prism.parse(source)
+      visitor = described_class.new(
+        target_class: target_class,
+        method_return_types: {},
+        local_var_types: {},
+        constant_arg_resolver: null_constant_resolver,
+        defined_class_names: described_class.collect_defined_class_names(result.value),
+        target_methods: target_methods
+      )
+      result.value.accept(visitor)
+      visitor.method_call_usages
+    end
+
+    it "binds it to the free positional parameter when no key names one" do
+      usages = collect_calls(
+        'View.new.render(partial: "posts/form")',
+        target_class: "View", target_methods: { "render" => ["target"] }
+      )
+
+      expect(usages["render"].first["target"]).to eq("Hash[Symbol, String]")
+    end
+
+    it "keeps a real keyword argument as a keyword" do
+      # `partial` IS a parameter here, so the call site is passing keywords for real.
+      usages = collect_calls(
+        'View.new.render(partial: "posts/form")',
+        target_class: "View", target_methods: { "render" => ["partial"] }
+      )
+
+      expect(usages["render"].first["partial"]).to eq("String")
+      expect(usages["render"].first).not_to have_key("target")
+    end
+
+    it "does not consume a positional slot already filled" do
+      usages = collect_calls(
+        'View.new.render("posts/summary", post: 1)',
+        target_class: "View", target_methods: { "render" => ["target"] }
+      )
+
+      expect(usages["render"].first["target"]).to eq("String")
+    end
+  end
+
 end


### PR DESCRIPTION
`ErbCallerResolver` reached ERB through Rails conventions — an `app/views/**` glob, a `Helper` → controller derivation, a `layouts/` special case, and a CLI gate on `input.include?("helpers/")`. **None of that is about ERB**; it is about where Rails puts files and how it names classes. Templates were invisible to every target the gate did not cover, and a view's own `render` had `untyped` parameters because its call sites live in the template.

## Split along the seam the conventions were hiding

| layer | where | what |
|---|---|---|
| **format** | core, agnostic | `Project::SourceReader` reads `.erb` as Ruby, keyed on the suffix, with the same extraction `Steep::Source.parse` uses. ERB is not a Rails concept. |
| **identity** | extension, convention | `Project::SourceOwners` — a registry answering *"which class does this file belong to?"* for sources that do not say so. `Views::ErbSourceOwner` answers it for templates. |

`SourceIndex` indexes a file under its owner, and `CallerFileAnalyzer` treats a file its target owns as reaching it bare — a template *is* `ERBPostsShow`, so its calls are self-calls.

The identity mapping reuses the same path → class function the view-runtime generator uses to *name* the class and Steep's ERB convention uses to attach `@type self_method:`. One convention, stated once.

**Both readers go through `SourceReader`** — `ParseCache` for the target and index, and `CallerFileAnalyzer`, which reads on its own. Teaching only one leaves ERB half-supported in a way that looks like a wiring bug. It did: the first cut changed *nothing at all*, because the caller path bypassed the cache.

## The unsoundness it exposed

With templates visible, `ERBPostsShow#render` inferred `?String` from the shorthand `render "posts/summary"` — and steep then **rejected the other render in the same template**, which passes `partial:`/`locals:`.

`extract_cross_class_args` skipped a `KeywordHashNode` in the positional loop and matched keywords by name, so `partial:` matched no parameter and the argument vanished. But **Ruby 3 passes keywords as a positional Hash when the callee accepts none** — which `def render(target = nil, *rest)` does not.

The parameter was being typed from a strict *subset* of its call sites: narrow enough to reject real calls, which is worse than imprecise. Now recognised when no key names a parameter and a positional slot is free. A call whose keys *do* name parameters is still keyword-bound, and a filled slot is not consumed.

## Measured

```
edit  ?untyped -> ?Hash[Symbol, String | { post: untyped }]
new   ?untyped -> ?Hash[Symbol, String | { post: untyped }]
show  ?untyped -> ?(Hash[Symbol, String | { comment: untyped }] | String)
```

Helper types are unchanged, so nothing regressed on the path `ErbCallerResolver` still covers. Steep set-difference against the baseline empty in both directions.

## Not done here

Retiring `ErbCallerResolver`. Its conventions are now redundant for *finding* templates, but it still supplies the controller-ivar context — and whether the view-runtime classes have made that obsolete is its own measurement.

## Verification

3 new collector specs (the collapse binds the free slot; a real keyword stays a keyword; a filled slot is not consumed). Unit **732**, integration **63** — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)