### PR TITLE
feat(inference): type a hash argument as a record, not Hash[K, V]

### DIFF
--- a/lib/rbs_infer/inference/caller_file_analyzer.rb
+++ b/lib/rbs_infer/inference/caller_file_analyzer.rb
@@ -39,8 +39,14 @@ module RbsInfer::Inference
       # (infere attrs sem anotação via keyword defaults e call-sites)
       caller_visitor = RbsInfer::AST::ClassNameExtractor.new(file_path: file)
       result.value.accept(caller_visitor)
-      if caller_visitor.class_name
-        caller_types = @method_type_resolver.resolve_all(caller_visitor.class_name)
+      # A source that does not NAME its class still belongs to one: an ERB template is the
+      # body of `ERBPostsEdit`. Everything below is keyed on the caller's class — its
+      # methods, its ivar declarations, its callback/postcondition facts — so with no name
+      # a template resolved none of them, and `@post` in `locals: { post: @post }` came out
+      # `untyped` while the class's own RBS declared it `Post & Post::Validated`.
+      caller_class_name = caller_visitor.class_name || RbsInfer::Project::SourceOwners.owner_class(file)
+      if caller_class_name
+        caller_types = @method_type_resolver.resolve_all(caller_class_name)
         caller_types.each do |name, type|
           method_return_types[name] ||= type
         end
@@ -88,8 +94,8 @@ module RbsInfer::Inference
       # `self` types from the callback sidecar (felixefelip/steep#27) — the
       # narrowing isn't readable from Steep's per-node typing.
       self_types_by_method =
-        if @steep_bridge && caller_visitor.class_name
-          @steep_bridge.callback_self_types(caller_visitor.class_name)
+        if @steep_bridge && caller_class_name
+          @steep_bridge.callback_self_types(caller_class_name)
         else
           {}
         end
@@ -99,8 +105,8 @@ module RbsInfer::Inference
       # resolve `@post` to the narrowed type instead of the class-wide declared
       # one, which is nilable because the ivar is never assigned in `initialize`.
       established_ivars_by_method =
-        if @steep_bridge && caller_visitor.class_name
-          @steep_bridge.postcondition_established_ivars(caller_visitor.class_name)
+        if @steep_bridge && caller_class_name
+          @steep_bridge.postcondition_established_ivars(caller_class_name)
         else
           {}
         end
@@ -108,8 +114,8 @@ module RbsInfer::Inference
       # Argument-sensitive partitions: inside a `when :edit` branch of a `case <param>`,
       # the facts the callers passing `:edit` established hold.
       argument_partitions_by_method =
-        if @steep_bridge && caller_visitor.class_name
-          @steep_bridge.argument_entry_partitions(caller_visitor.class_name)
+        if @steep_bridge && caller_class_name
+          @steep_bridge.argument_entry_partitions(caller_class_name)
         else
           {}
         end
@@ -119,7 +125,7 @@ module RbsInfer::Inference
         method_return_types: method_return_types,
         local_var_types: local_var_types,
         method_type_resolver: @method_type_resolver,
-        caller_class_name: caller_visitor.class_name,
+        caller_class_name: caller_class_name,
         init_positional_params: @init_positional_params,
         target_methods: @target_methods,
         match_bare_calls: match_bare,

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -493,6 +493,12 @@ module RbsInfer::Inference
     end
 
     def resolve_value_type(node)
+      # A hash literal is handled here, ahead of the generic literal inferrer, so its VALUES
+      # resolve with what this collector knows — ivars, locals, method returns. The generic
+      # inferrer builds the same record shape but sees none of that, so `{ post: @post }`
+      # came out `{ post: untyped }` even where `@post` is a known `Post & Post::Validated`.
+      return hash_literal_type(node) if record_shaped?(node)
+
       literal = RbsInfer::AST::NodeTypeInferrer.infer_literal_node_type(node, constant_resolver: @constant_arg_resolver)
       return literal if literal
 
@@ -684,17 +690,27 @@ module RbsInfer::Inference
       keys.none? { |k| param_names.include?(k) }
     end
 
-    # `Hash[Symbol, <union of the value types>]` for a literal keyword hash.
+    # A non-empty hash literal whose keys are ALL plain symbols — the only shape a record
+    # type can describe. Anything else (string/dynamic keys, `**splat`) keeps the generic
+    # inferrer's `Hash[K, V]`, which handles those.
+    def record_shaped?(node)
+      return false unless node.is_a?(Prism::HashNode) || node.is_a?(Prism::KeywordHashNode)
+      return false if node.elements.empty?
+
+      node.elements.all? { |e| e.is_a?(Prism::AssocNode) && extract_symbol_key(e.key) }
+    end
+
+    # `{ key: Type, ... }` for a literal keyword hash.
     def hash_literal_type(node)
-      values = node.elements.filter_map do |e|
+      pairs = node.elements.filter_map do |e|
         next unless e.is_a?(Prism::AssocNode)
-        t = resolve_value_type(e.value)
-        t unless t.nil? || t == "untyped"
-      end.uniq
+        key = extract_symbol_key(e.key) or next
+        "#{key}: #{resolve_value_type(e.value) || "untyped"}"
+      end
 
-      return "Hash[Symbol, untyped]" if values.empty?
+      return "Hash[Symbol, untyped]" if pairs.empty?
 
-      "Hash[Symbol, #{values.size == 1 ? values.first : values.join(" | ")}]"
+      "{ #{pairs.join(", ")} }"
     end
   end
 end

--- a/lib/rbs_infer/inference/type_merger.rb
+++ b/lib/rbs_infer/inference/type_merger.rb
@@ -31,18 +31,31 @@ module RbsInfer::Inference
       resolved = flat.reject { |t| t == "untyped" }
       resolved = flat if resolved.empty?
 
-      # Dedup by the normalized form (no leading `::`), keeping the original
-      # form of the first occurrence — a single type is emitted verbatim, so
-      # absolute names (`::MyApp::Entity`) stay intact.
+      # Dedup by the canonical form, keeping the original spelling of the first
+      # occurrence — a single type is emitted verbatim, so absolute names
+      # (`::MyApp::Entity`) stay intact.
       seen = {}
       unique = []
       resolved.each do |type|
-        key = type.sub(/\A::/, "")
+        key = canonical_key(type)
         next if seen[key]
         seen[key] = true
         unique << type
       end
       unique.size == 1 ? unique.first : "(#{unique.join(" | ")})"
+    end
+
+    # The identity of a type for dedup purposes, so two SPELLINGS of one type collapse.
+    # A textual key does not: the same intersection reaches the merger as
+    # `(Post & Post::Validated)` when read back from an RBS declaration and as
+    # `Post & Post::Validated` from Steep, and unioning them yielded
+    # `((Post & Post::Validated) | Post & Post::Validated)`. The RBS parser already
+    # canonicalizes redundant parens; the `::` strip stays because it is a naming
+    # convention (cross-class output omits the prefix), not something the parser touches.
+    def self.canonical_key(type)
+      RBS::Parser.parse_type(type).to_s.sub(/\A::/, "")
+    rescue RBS::ParsingError, RBS::BaseError
+      type.sub(/\A::/, "")
     end
 
     # Flattens a type into its set of top-level union members.

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/edit.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/edit.rbs
@@ -5,7 +5,7 @@ class ERBPostsEdit
   include PostsHelper
 
   def initialize: (post: Post & ::Post::Validated) -> void
-  def render: (?Hash[Symbol, String | { post: untyped }] target, *untyped) -> nil
+  def render: (?{ partial: String, locals: { post: Post & Post::Validated } } target, *untyped) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/new.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/new.rbs
@@ -5,7 +5,7 @@ class ERBPostsNew
   include PostsHelper
 
   def initialize: (post: Post) -> void
-  def render: (?Hash[Symbol, String | { post: untyped }] target, *untyped) -> nil
+  def render: (?{ partial: String, locals: { post: Post } } target, *untyped) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/show.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/show.rbs
@@ -6,7 +6,7 @@ class ERBPostsShow
   include PostsHelper
 
   def initialize: (comments: Comment::ActiveRecord_Relation, post: (::Post & ::Post::Validated)) -> void
-  def render: (?(Hash[Symbol, String | { comment: untyped }] | String) target, *untyped) -> nil
+  def render: (?({ partial: String, locals: { comment: (Comment & Comment::Validated) } } | String) target, *untyped) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/users/avatars/edit.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/users/avatars/edit.rbs
@@ -3,7 +3,7 @@ class ERBUsersAvatarsEdit
 
   include ActionViewContext
 
-  def initialize: (user: (User & ::User::Validated | (::User & ::User::Validated))) -> void
+  def initialize: (user: User & ::User::Validated) -> void
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/expectations/steep_actionview_runtime/posts/edit.rbs
+++ b/spec/expectations/steep_actionview_runtime/posts/edit.rbs
@@ -5,7 +5,7 @@ class ERBPostsEdit
   include PostsHelper
 
   def initialize: (post: Post & ::Post::Validated) -> void
-  def render: (?untyped target, *untyped) -> nil
+  def render: (?{ partial: String, locals: { post: Post & Post::Validated } } target, *untyped) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/expectations/steep_actionview_runtime/posts/new.rbs
+++ b/spec/expectations/steep_actionview_runtime/posts/new.rbs
@@ -5,7 +5,7 @@ class ERBPostsNew
   include PostsHelper
 
   def initialize: (post: Post) -> void
-  def render: (?untyped target, *untyped) -> nil
+  def render: (?{ partial: String, locals: { post: Post } } target, *untyped) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/expectations/steep_actionview_runtime/posts/show.rbs
+++ b/spec/expectations/steep_actionview_runtime/posts/show.rbs
@@ -6,7 +6,7 @@ class ERBPostsShow
   include PostsHelper
 
   def initialize: (comments: Comment::ActiveRecord_Relation, post: (::Post & ::Post::Validated)) -> void
-  def render: (?untyped target, *untyped) -> nil
+  def render: (?({ partial: String, locals: { comment: (Comment & Comment::Validated) } } | String) target, *untyped) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/expectations/steep_actionview_runtime/users/avatars/edit.rbs
+++ b/spec/expectations/steep_actionview_runtime/users/avatars/edit.rbs
@@ -3,7 +3,7 @@ class ERBUsersAvatarsEdit
 
   include ActionViewContext
 
-  def initialize: (user: (User & ::User::Validated | (::User & ::User::Validated))) -> void
+  def initialize: (user: User & ::User::Validated) -> void
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -397,9 +397,12 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
   #
   # `source_files` has to span `app/` AND `sig/`, matching how the CLI is invoked
   # (`rbs_infer app/ sig/`): the call sites that type a view live in the controller
-  # runtime under `sig/`, not in `app/`.
+  # runtime under `sig/`, not in `app/`. The `.erb` glob matters for the same reason —
+  # a view's own `render partial:` call site lives in the TEMPLATE, so without it the
+  # snapshot showed `render: (?untyped target, ...)` and was blind to the second half
+  # of the very chain it exists to guard.
   describe "runtime pseudo-code RBS" do
-    let(:source_files) { Dir["app/**/*.rb"] + Dir["sig/**/*.rb"] }
+    let(:source_files) { Dir["app/**/*.rb"] + Dir["app/**/*.erb"] + Dir["sig/**/*.rb"] }
 
     def assert_runtime_rbs(dir)
       pseudo_code = Dir["sig/generated/#{dir}/**/*.rb"].sort

--- a/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
@@ -729,7 +729,39 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
         target_class: "View", target_methods: { "render" => ["target"] }
       )
 
-      expect(usages["render"].first["target"]).to eq("Hash[Symbol, String]")
+      expect(usages["render"].first["target"]).to eq("{ partial: String }")
+    end
+
+    # A record keeps each key bound to its own value type. `Hash[Symbol, String | Post]`
+    # says only "some symbol maps to one of these", which loses which is which.
+    it "types it as a record, not a flattened key/value Hash" do
+      usages = collect_calls(
+        'View.new.render(partial: "posts/form", count: 2)',
+        target_class: "View", target_methods: { "render" => ["target"] }
+      )
+
+      expect(usages["render"].first["target"]).to eq("{ partial: String, count: Integer }")
+    end
+
+    it "builds a record for a nested hash too, so `locals:` keeps its own keys" do
+      usages = collect_calls(
+        'View.new.render(partial: "posts/form", locals: { count: 2 })',
+        target_class: "View", target_methods: { "render" => ["target"] }
+      )
+
+      expect(usages["render"].first["target"])
+        .to eq("{ partial: String, locals: { count: Integer } }")
+    end
+
+    # A record type can only describe all-symbol keys; anything else keeps `Hash[K, V]`.
+    it "falls back to a Hash when a nested key is not a symbol" do
+      usages = collect_calls(
+        'View.new.render(partial: "posts/form", locals: { "count" => 2 })',
+        target_class: "View", target_methods: { "render" => ["target"] }
+      )
+
+      expect(usages["render"].first["target"])
+        .to eq("{ partial: String, locals: Hash[String, untyped] }")
     end
 
     it "keeps a real keyword argument as a keyword" do

--- a/spec/lib/rbs_infer/inference/type_merger_spec.rb
+++ b/spec/lib/rbs_infer/inference/type_merger_spec.rb
@@ -58,6 +58,18 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
     it "drops untyped when at least one resolved type exists" do
       expect(described_class.union_types(["untyped", "String"])).to eq("String")
     end
+
+    # The same intersection arrives parenthesized when read back from an RBS declaration
+    # and bare from Steep. A textual key made them two members of a bogus union.
+    it "collapses two spellings of the same type" do
+      expect(described_class.union_types(["(Post & Post::Validated)", "Post & Post::Validated"]))
+        .to eq("(Post & Post::Validated)")
+    end
+
+    it "collapses spellings differing only in the absolute prefix" do
+      expect(described_class.union_types(["User & ::User::Validated", "(::User & ::User::Validated)"]))
+        .to eq("User & ::User::Validated")
+    end
   end
 
   describe "#resolve_method_return_types_from_attrs" do


### PR DESCRIPTION
Answers "no `ERBPostsEdit#render`, o tipo do parâmetro `target` não poderia ser um hash literal?" — yes, and the machinery was already half there.

## Before / after

```rbs
# posts/edit
- def render: (?Hash[Symbol, String | { post: untyped }] target, *untyped) -> nil
+ def render: (?{ partial: String, locals: { post: Post & Post::Validated } } target, *untyped) -> nil

# posts/new
- def render: (?Hash[Symbol, String | { post: untyped }] target, *untyped) -> nil
+ def render: (?{ partial: String, locals: { post: Post } } target, *untyped) -> nil

# posts/show
- def render: (?(Hash[Symbol, String | { comment: untyped }] | String) target, *untyped) -> nil
+ def render: (?({ partial: String, locals: { comment: (Comment & Comment::Validated) } } | String) target, *untyped) -> nil
```

`Hash[Symbol, String | {...}]` says only "some symbol maps to one of these" — it drops which key holds which value. `edit` and `new` were **identical** under it; they now differ (`Post & Post::Validated` vs `Post`), which is the truth: `new`'s `@post` is an unsaved `Post.new`.

## Three parts

**1. `NewCallCollector` — record instead of a flattened Hash.** `hash_literal_type` keeps each key bound to its own type. A nested hash is intercepted in `resolve_value_type` *ahead of* the generic literal inferrer, so its values resolve with what the collector knows (ivars, locals, method returns). `NodeTypeInferrer.infer_hash_type` already built record shapes — that is where `{ post: untyped }` came from — but it sees none of the collector's context. Non-symbol keys and `**splat` still fall through to `Hash[K, V]`, the only shape a record can't describe.

**2. `CallerFileAnalyzer` — a template's class identity.** `ClassNameExtractor` finds no `class` node in an ERB template, so `caller_class_name` was `nil` and *everything keyed on it* was skipped: ivar declarations, callback self-types, postcondition facts, argument partitions. That is the actual reason `@post` was `untyped` — not the record shape. `SourceOwners.owner_class(file)` already answers "which class does this file belong to?" (`MixinIndex` and `SourceIndex` consume it); this path now does too.

**3. `TypeMerger.union_types` — dedup on the parsed type.** The same intersection arrives parenthesized when read back from an RBS declaration and bare from Steep. A textual key made them two members of a bogus union:

```rbs
- ((Post & Post::Validated) | Post & Post::Validated)
+ (Post & Post::Validated)
```

This also collapses a **pre-existing** artifact unrelated to the rest:

```rbs
# ERBUsersAvatarsEdit
- def initialize: (user: (User & ::User::Validated | (::User & ::User::Validated))) -> void
+ def initialize: (user: User & ::User::Validated) -> void
```

## Snapshot blind spot fixed

`spec/integration/rails_dummy_spec.rb:402` shadowed `source_files` without the `.erb` glob the CLI (`bin/rbs_infer`) has. So the view-runtime snapshot never saw a template's own `render` call site and recorded `(?untyped target, ...)` — blind to the second half of the `action -> view ivar -> partial local` chain its own comment says it exists to guard. That is why the first `UPDATE_EXPECTATIONS` run changed nothing here.

## Verification

- `bundle exec rspec` — 809 examples, 0 failures
- `make steep` — **unchanged at 30 problems**, set-difference against `spec/expectations/steep_baseline.txt` empty in both directions
- Generated-RBS diff vs. baseline is 4 lines, all of them the improvements above

New unit specs cover the record shape, the nested record, the non-symbol-key fallback, and both merger collapses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)