### PR TITLE
feat(controllers): route the implicit render through the render dispatch

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -282,6 +282,11 @@ module RbsInfer
     # param types and ivar types (ivar getters/setters — rbs_infer#19)
     type_merger.resolve_method_return_types_from_attrs(target_members, attr_types, method_type_resolver: method_type_resolver, parsed_target: @parsed_target, method_param_types: method_param_types, ivar_types: ivar_types)
 
+    # A body with an early `return` can return nil however its tail was typed. Runs
+    # AFTER every pass that sets a return type — each used to widen (or forget to) on
+    # its own, so which passes a method took decided whether the `?` appeared.
+    return_type_resolver.apply_early_return_nilability(target_members, parsed_target: @parsed_target)
+
     # Resolver tipos das constantes de classe/módulo (NOME = ...).
     # Feito aqui, no Analyzer, porque a inferência de cadeias usa o
     # SteepBridge e o new→classe-alvo precisa do target_class

--- a/lib/rbs_infer/extensions/rails/controllers/pseudo_code_builder.rb
+++ b/lib/rbs_infer/extensions/rails/controllers/pseudo_code_builder.rb
@@ -204,21 +204,34 @@ module RbsInfer
             RUBY
           end
 
-          # A per-controller override of `render` modelling an explicit
-          # `render :view` (e.g. `create` falling through to `render :new` on a
-          # validation failure). It marks the response performed via the SHARED
-          # halt marker (`PERFORMED_IVAR`, same one the framework `render` sets),
-          # and dispatches on the rendered target to that view's compiled body
-          # (`__rbs_infer__body`, felixefelip/steep#85) — so the render's own
-          # call-site facts (here, `@post` after a failed `save`) narrow reads in
-          # the rendered view.
+          # A per-controller override of `render`: the ONE place a view of this
+          # controller is constructed. It marks the response performed via the
+          # SHARED halt marker (`PERFORMED_IVAR`, same one the framework `render`
+          # sets), and dispatches on the rendered target to that view's compiled
+          # body (`__rbs_infer__body`, felixefelip/steep#85) — so the render's
+          # own call-site facts (`@post` after `set_post`, or after a failed
+          # `save`) narrow reads in the rendered view.
+          #
+          # It covers EVERY view of the controller, not only the targets an
+          # explicit `render :view` names, because both renders route through
+          # here: the implicit convention render at the end of an action is
+          # emitted as `render(:show)` (see `view_render_lines`), exactly as
+          # Rails ends an action with `render action_name`. A `case` carrying
+          # only the explicit targets would leave that call dispatching to no
+          # branch, and the view would lose every argument that types it.
+          #
+          # Routing both through one dispatcher is what makes the two renders of
+          # a view meet: `render :edit` from `update`'s failure branch and an
+          # implicit `render(:edit)` are two call sites of the SAME method, so
+          # the fork's argument-sensitive entry facts key both partitions on
+          # `target == :edit` and the view sees what holds on both paths.
           #
           # The dispatch lives PER CONTROLLER, not on `ActionController::Base`,
           # on purpose: a view's entry facts are the meet over its call sites, so
           # a single shared dispatch on `Base` would meet EVERY render in the app
           # into every view — the global-collapse we avoid. Each override carries
-          # only the targets its own controller renders (its symbols plus any
-          # foreign `render "posts/new"` paths), keeping the meet scoped.
+          # only its own controller's views plus any foreign `render "posts/new"`
+          # path it names, keeping the meet scoped.
           #
           # It cannot `super` into the framework `render`: `super` binds to the
           # REAL Rails `ActionController::Base#render` (returns `String`, and
@@ -227,23 +240,10 @@ module RbsInfer
           # though two bodies write it.
           #
           # Emitted PUBLIC (before `private`), matching the framework `render` it
-          # overrides. Only views whose template exists get a `when`, and the
-          # whole method is omitted when none do — the inherited framework
-          # `render` then applies unchanged.
-          #
-          # NOTE: fully consuming this needs the fork to record the render's
-          # facts from inside the branch it sits in — a full `if/else` (where the
-          # `render :new` lives) and this `case/when` — not just a modifier `if`.
-          # That branch-sensitive flow extraction is tracked separately; the
-          # pseudo-code is correct regardless — without it the dispatch is inert
-          # rather than wrong.
+          # overrides. The whole method is omitted when the controller has no
+          # view at all — the inherited framework `render` then applies unchanged.
           def render_override(class_name)
-            branches = @scanner.render_targets_for(class_name).filter_map do |form, value|
-              erb_class, key, view_relative = resolve_render_target(class_name, form, value)
-              next unless erb_class
-
-              "    when #{key} then #{view_constructor(erb_class, view_relative)}.__rbs_infer__body"
-            end
+            branches = render_branches(class_name)
             return nil if branches.empty?
 
             [
@@ -255,6 +255,52 @@ module RbsInfer
               "    true",
               "  end"
             ].join("\n") + "\n"
+          end
+
+          # One `when` per view this controller can render: every template in its
+          # view directory (keyed by the symbol Rails would use — the action
+          # name), then any explicit target not already covered, which is how a
+          # foreign `render "posts/new"` from another controller gets a branch.
+          #
+          # Keyed by the `when` literal so the two sources dedup: an explicit
+          # `render :new` names a view the directory sweep already found, and
+          # emitting it twice would make the second branch dead.
+          def render_branches(class_name)
+            views = {}
+
+            controller_views(class_name).each do |name, erb_class, relative|
+              views[":#{name}"] ||= [erb_class, relative]
+            end
+
+            @scanner.render_targets_for(class_name).each do |form, value|
+              erb_class, key, relative = resolve_render_target(class_name, form, value)
+              next unless erb_class
+
+              views[key] ||= [erb_class, relative]
+            end
+
+            views.map do |key, (erb_class, relative)|
+              "    when #{key} then #{view_constructor(erb_class, relative)}.__rbs_infer__body"
+            end
+          end
+
+          # `[view_name, erb_class, relative_path]` for every non-partial template
+          # in the controller's own view directory, sorted so the emitted file is
+          # stable. A leading `_` is a partial: it is never a render TARGET of an
+          # action — the view that renders it constructs it, from the view-runtime
+          # pseudo-code's own `render`.
+          def controller_views(class_name)
+            view_dir = class_name.sub(/Controller\z/, "").underscore
+            return [] if view_dir.empty?
+
+            pattern = File.join(@app_dir, "app/views", view_dir, "*.{html,turbo_stream}.erb")
+            Dir[pattern].sort.filter_map do |path|
+              basename = File.basename(path)
+              next if basename.start_with?("_")
+
+              relative = "#{view_dir}/#{basename}"
+              [basename.sub(/\.(html|turbo_stream)\.erb\z/, ""), view_path_naming.erb_class_name(relative), relative]
+            end
           end
 
           # `[erb_class, case_key]` for a render target, or `[nil, _]` when no
@@ -304,17 +350,22 @@ module RbsInfer
 
           # After the action, model Rails' implicit convention render: unless the
           # action already responded (`redirect_to`/explicit `render`/`head` set
-          # `performed?`), it renders `action`'s view. Calling the view's
-          # compiled-method body (`__rbs_infer__body`, felixefelip/steep#85) at
-          # this point — where the guard chain's facts hold — lets those facts
-          # narrow reads in the view. The `return if performed?` before it makes
-          # the redirect / explicit-render case a no-op automatically. Empty when
-          # the action has no convention template.
+          # `performed?`), it renders `action`'s view. The `return if performed?`
+          # before it makes the redirect / explicit-render case a no-op
+          # automatically. Empty when the action has no convention template.
+          #
+          # Emitted as `render(:show)` — the call Rails itself makes — rather
+          # than by constructing the view here. Constructing it inline made the
+          # implicit render a SECOND, separate call site of the view's
+          # constructor, so a view reachable both implicitly and by an explicit
+          # `render :edit` was built in two places whose facts never met. Going
+          # through the dispatcher makes them two call sites of one method,
+          # which is the shape the fork's argument-sensitive entry facts read.
           def view_render_lines(class_name, action)
-            erb_class, view_relative = convention_view(class_name, action)
+            erb_class, = convention_view(class_name, action)
             return [] unless erb_class
 
-            ["", "return if #{HALTED}", "", "#{view_constructor(erb_class, view_relative)}.__rbs_infer__body"]
+            ["", "return if #{HALTED}", "", "render(:#{action})"]
           end
 
           # The ERB class of `action`'s convention template, or nil when none

--- a/lib/rbs_infer/extensions/rails/controllers/pseudo_code_builder.rb
+++ b/lib/rbs_infer/extensions/rails/controllers/pseudo_code_builder.rb
@@ -215,7 +215,7 @@ module RbsInfer
           # It covers EVERY view of the controller, not only the targets an
           # explicit `render :view` names, because both renders route through
           # here: the implicit convention render at the end of an action is
-          # emitted as `render(:show)` (see `view_render_lines`), exactly as
+          # emitted as `render :show` (see `view_render_lines`), exactly as
           # Rails ends an action with `render action_name`. A `case` carrying
           # only the explicit targets would leave that call dispatching to no
           # branch, and the view would lose every argument that types it.
@@ -354,7 +354,7 @@ module RbsInfer
           # before it makes the redirect / explicit-render case a no-op
           # automatically. Empty when the action has no convention template.
           #
-          # Emitted as `render(:show)` — the call Rails itself makes — rather
+          # Emitted as `render :show` — the call Rails itself makes — rather
           # than by constructing the view here. Constructing it inline made the
           # implicit render a SECOND, separate call site of the view's
           # constructor, so a view reachable both implicitly and by an explicit
@@ -365,7 +365,7 @@ module RbsInfer
             erb_class, = convention_view(class_name, action)
             return [] unless erb_class
 
-            ["", "return if #{HALTED}", "", "render(:#{action})"]
+            ["", "return if #{HALTED}", "", "render :#{action}"]
           end
 
           # The ERB class of `action`'s convention template, or nil when none

--- a/lib/rbs_infer/inference/return_type_resolver.rb
+++ b/lib/rbs_infer/inference/return_type_resolver.rb
@@ -65,12 +65,7 @@ module RbsInfer::Inference
         steep_returns = @steep_bridge.method_return_types_by_kind(parsed_target.source)
 
         unless steep_returns[:instance].empty? && steep_returns[:singleton].empty?
-          # Build def map for nil-return detection
-          collector = RbsInfer::AST::DefCollector.new(target_class: @target_class)
-          parsed_target.tree.accept(collector)
-          def_map = {}
-          collector.defs.each { |d| def_map[d.name.to_s] = d if d.is_a?(Prism::DefNode) }
-
+          def_map = def_map(parsed_target)
           self_types = Set.new([@target_class] + @instance_types)
 
           still_untyped.each do |m|
@@ -169,6 +164,36 @@ module RbsInfer::Inference
             m.signature = m.signature.sub(/-> #{Regexp.escape(current_type)}$/, "-> #{steep_type}")
           end
         end
+      end
+    end
+
+    # A bare `return` (or `return nil`) yields nil, so nil belongs in the return union
+    # however the rest of the body was typed. Several passes substitute a return type
+    # (chain resolution here, Steep here, TypeMerger's tail-call passes after), and only
+    # the Steep ones widened — so `return if performed?` followed by a CALL came out
+    # `-> bool`, for a body that plainly returns nil on the guard. A literal tail was
+    # right only by accident, because it happened to take the Steep path.
+    #
+    # Applied ONCE, after every pass that can set a return type, rather than at each
+    # substitution site: the widening depends only on the body, so it is a property of
+    # the finished signature, and spreading it over the passes is how three of them came
+    # to disagree in the first place.
+    def apply_early_return_nilability(members, parsed_target: nil)
+      return unless parsed_target
+
+      members.each do |m|
+        next unless method_member?(m)
+        # `initialize` is `-> void` by convention, and a setter's return is the assigned
+        # value — neither is the body's own tail type, so neither is ours to widen.
+        next if m.name == "initialize" || setter_name?(m.name)
+
+        current = m.signature[/->\s*(.+)\z/, 1]&.strip
+        next if current.nil? || current == "untyped" || current == "void" || current.end_with?("?")
+
+        defn = def_map(parsed_target)[m.name]
+        next unless defn && has_nil_return?(defn)
+
+        m.signature = m.signature.sub(/-> #{Regexp.escape(current)}\z/, "-> #{RbsInfer::Signatures::RbsParserUtil.nilablize(current)}")
       end
     end
 
@@ -450,6 +475,19 @@ module RbsInfer::Inference
     # in TypeMerger (felixefelip/rbs_infer#33/#34).
     def self_return?(member, steep_type, self_types)
       member.kind != :class_method && self_types.include?(steep_type)
+    end
+
+    # Method name → its `Prism::DefNode`, for the passes that need to read a body back
+    # (early-return detection). Memoized per target: both the chain-resolution pass and
+    # the Steep pass ask, and collecting is a full tree walk.
+    def def_map(parsed_target)
+      @def_map ||= begin
+        collector = RbsInfer::AST::DefCollector.new(target_class: @target_class)
+        parsed_target.tree.accept(collector)
+        collector.defs.each_with_object({}) do |d, map|
+          map[d.name.to_s] = d if d.is_a?(Prism::DefNode)
+        end
+      end
     end
 
     # Verifica se o corpo do método contém `return nil` ou `return` (implícito nil)

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -723,6 +723,15 @@ postconditions:
     may_write:
     - "@users"
 - class: UsersController
+  method: render
+  unconditional:
+    ivars:
+      "@__rbs_infer__performed": 'true'
+    self: "::UsersController & ::UsersController::AfterRender"
+  effects:
+    may_write:
+    - "@__rbs_infer__performed"
+- class: UsersController
   method: show
   unconditional:
     ivars:
@@ -953,8 +962,6 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
-  ivars:
-    "@__rbs_infer__performed": 'true'
 - class: PostsController
   method: set_post
   self_methods:
@@ -1031,7 +1038,6 @@ method_entry_facts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
   ivars:
-    "@__rbs_infer__performed": 'true'
     "@user": "(::User & ::User::Validated)"
 - class: Users::AvatarsController
   method: set_user
@@ -1056,6 +1062,16 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+- class: UsersController
+  method: render
+  self_methods:
+    current_user: "(::User & ::User::Validated)"
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+  ivars:
+    "@posts": "::User_Post::ActiveRecord_Associations_CollectionProxy"
+    "@user": "(::User & ::User::Validated)"
 - class: UsersController
   method: show
   self_methods:
@@ -1122,14 +1138,32 @@ argument_entry_facts:
 - class: PostsController
   method: render
   param: target
+  pattern: ":index"
+  ivars:
+    "@posts": "::Post::ActiveRecord_Relation"
+- class: PostsController
+  method: render
+  param: target
   pattern: ":new"
   ivars:
-    "@__rbs_infer__performed": 'true'
     "@post": "::Post"
+- class: PostsController
+  method: render
+  param: target
+  pattern: ":show"
+  ivars:
+    "@comments": "::Comment::ActiveRecord_Relation"
+    "@post": "(::Post & ::Post::Validated)"
 - class: Users::AvatarsController
   method: render
   param: target
   pattern: ":edit"
   ivars:
-    "@__rbs_infer__performed": 'true'
+    "@user": "(::User & ::User::Validated)"
+- class: UsersController
+  method: render
+  param: target
+  pattern: ":show"
+  ivars:
+    "@posts": "::User_Post::ActiveRecord_Associations_CollectionProxy"
     "@user": "(::User & ::User::Validated)"

--- a/spec/dummy/sig/generated/steep_controller_runtime/posts_controller.rb
+++ b/spec/dummy/sig/generated/steep_controller_runtime/posts_controller.rb
@@ -28,7 +28,7 @@ class PostsController
 
     return if performed?
 
-    render(:index)
+    render :index
   end
 
   def __rbs_infer__run_show
@@ -45,7 +45,7 @@ class PostsController
 
     return if performed?
 
-    render(:show)
+    render :show
   end
 
   def __rbs_infer__run_new
@@ -59,7 +59,7 @@ class PostsController
 
     return if performed?
 
-    render(:new)
+    render :new
   end
 
   def __rbs_infer__run_create

--- a/spec/dummy/sig/generated/steep_controller_runtime/posts_controller.rb
+++ b/spec/dummy/sig/generated/steep_controller_runtime/posts_controller.rb
@@ -8,7 +8,9 @@ class PostsController
     @__rbs_infer__performed = true
     case target
     when :edit then ERBPostsEdit.new(post: @post).__rbs_infer__body
+    when :index then ERBPostsIndex.new(posts: @posts).__rbs_infer__body
     when :new then ERBPostsNew.new(post: @post).__rbs_infer__body
+    when :show then ERBPostsShow.new(comments: @comments, post: @post).__rbs_infer__body
     end
     true
   end
@@ -26,7 +28,7 @@ class PostsController
 
     return if performed?
 
-    ERBPostsIndex.new(posts: @posts).__rbs_infer__body
+    render(:index)
   end
 
   def __rbs_infer__run_show
@@ -43,7 +45,7 @@ class PostsController
 
     return if performed?
 
-    ERBPostsShow.new(comments: @comments, post: @post).__rbs_infer__body
+    render(:show)
   end
 
   def __rbs_infer__run_new
@@ -57,7 +59,7 @@ class PostsController
 
     return if performed?
 
-    ERBPostsNew.new(post: @post).__rbs_infer__body
+    render(:new)
   end
 
   def __rbs_infer__run_create

--- a/spec/dummy/sig/generated/steep_controller_runtime/users_avatars_controller.rb
+++ b/spec/dummy/sig/generated/steep_controller_runtime/users_avatars_controller.rb
@@ -28,7 +28,7 @@ class Users::AvatarsController
 
     return if performed?
 
-    render(:edit)
+    render :edit
   end
 
   def __rbs_infer__run_update

--- a/spec/dummy/sig/generated/steep_controller_runtime/users_avatars_controller.rb
+++ b/spec/dummy/sig/generated/steep_controller_runtime/users_avatars_controller.rb
@@ -28,7 +28,7 @@ class Users::AvatarsController
 
     return if performed?
 
-    ERBUsersAvatarsEdit.new(user: @user).__rbs_infer__body
+    render(:edit)
   end
 
   def __rbs_infer__run_update

--- a/spec/dummy/sig/generated/steep_controller_runtime/users_controller.rb
+++ b/spec/dummy/sig/generated/steep_controller_runtime/users_controller.rb
@@ -35,6 +35,6 @@ class UsersController
 
     return if performed?
 
-    render(:show)
+    render :show
   end
 end

--- a/spec/dummy/sig/generated/steep_controller_runtime/users_controller.rb
+++ b/spec/dummy/sig/generated/steep_controller_runtime/users_controller.rb
@@ -4,6 +4,14 @@
 # Regenerated on every run; do not edit.
 
 class UsersController
+  def render(target = nil, *rest)
+    @__rbs_infer__performed = true
+    case target
+    when :show then ERBUsersShow.new(posts: @posts, user: @user).__rbs_infer__body
+    end
+    true
+  end
+
   private
 
   def __rbs_infer__run_index
@@ -27,6 +35,6 @@ class UsersController
 
     return if performed?
 
-    ERBUsersShow.new(posts: @posts, user: @user).__rbs_infer__body
+    render(:show)
   end
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/show.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/show.rbs
@@ -5,7 +5,7 @@ class ERBPostsShow
   include ActionViewContext
   include PostsHelper
 
-  def initialize: (comments: Comment::ActiveRecord_Relation, post: (::Post & ::Post::Validated)) -> void
+  def initialize: (comments: Comment::ActiveRecord_Relation, post: Post & ::Post::Validated) -> void
   def render: (?({ partial: String, locals: { comment: (Comment & Comment::Validated) } } | String) target, *untyped) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/users/show.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/users/show.rbs
@@ -4,7 +4,7 @@ class ERBUsersShow
 
   include ActionViewContext
 
-  def initialize: (posts: User_Post::ActiveRecord_Associations_CollectionProxy, user: (::User & ::User::Validated)) -> void
+  def initialize: (posts: User_Post::ActiveRecord_Associations_CollectionProxy, user: User & ::User::Validated) -> void
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/posts_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/posts_controller.rbs
@@ -5,9 +5,9 @@ class PostsController
 
   private
 
-  def __rbs_infer__run_index: () -> nil
-  def __rbs_infer__run_show: () -> nil
-  def __rbs_infer__run_new: () -> nil
+  def __rbs_infer__run_index: () -> bool?
+  def __rbs_infer__run_show: () -> bool?
+  def __rbs_infer__run_new: () -> bool?
   def __rbs_infer__run_create: () -> void
   def __rbs_infer__run_update: () -> void
   def __rbs_infer__run_destroy: () -> void

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/users_avatars_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/users_avatars_controller.rbs
@@ -6,7 +6,7 @@ module Users
 
     private
 
-    def __rbs_infer__run_edit: () -> nil
+    def __rbs_infer__run_edit: () -> bool?
     def __rbs_infer__run_update: () -> void
   end
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/users_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/users_controller.rbs
@@ -1,6 +1,10 @@
 class UsersController
+  @__rbs_infer__performed: true?
+
+  def render: (?Symbol target, *untyped) -> bool
+
   private
 
   def __rbs_infer__run_index: () -> void
-  def __rbs_infer__run_show: () -> nil
+  def __rbs_infer__run_show: () -> bool?
 end

--- a/spec/expectations/steep_actionview_runtime/posts/show.rbs
+++ b/spec/expectations/steep_actionview_runtime/posts/show.rbs
@@ -5,7 +5,7 @@ class ERBPostsShow
   include ActionViewContext
   include PostsHelper
 
-  def initialize: (comments: Comment::ActiveRecord_Relation, post: (::Post & ::Post::Validated)) -> void
+  def initialize: (comments: Comment::ActiveRecord_Relation, post: Post & ::Post::Validated) -> void
   def render: (?({ partial: String, locals: { comment: (Comment & Comment::Validated) } } | String) target, *untyped) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil

--- a/spec/expectations/steep_actionview_runtime/users/show.rbs
+++ b/spec/expectations/steep_actionview_runtime/users/show.rbs
@@ -4,7 +4,7 @@ class ERBUsersShow
 
   include ActionViewContext
 
-  def initialize: (posts: User_Post::ActiveRecord_Associations_CollectionProxy, user: (::User & ::User::Validated)) -> void
+  def initialize: (posts: User_Post::ActiveRecord_Associations_CollectionProxy, user: User & ::User::Validated) -> void
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/expectations/steep_controller_runtime/posts_controller.rb
+++ b/spec/expectations/steep_controller_runtime/posts_controller.rb
@@ -28,7 +28,7 @@ class PostsController
 
     return if performed?
 
-    render(:index)
+    render :index
   end
 
   def __rbs_infer__run_show
@@ -45,7 +45,7 @@ class PostsController
 
     return if performed?
 
-    render(:show)
+    render :show
   end
 
   def __rbs_infer__run_new
@@ -59,7 +59,7 @@ class PostsController
 
     return if performed?
 
-    render(:new)
+    render :new
   end
 
   def __rbs_infer__run_create

--- a/spec/expectations/steep_controller_runtime/posts_controller.rb
+++ b/spec/expectations/steep_controller_runtime/posts_controller.rb
@@ -8,7 +8,9 @@ class PostsController
     @__rbs_infer__performed = true
     case target
     when :edit then ERBPostsEdit.new(post: @post).__rbs_infer__body
+    when :index then ERBPostsIndex.new(posts: @posts).__rbs_infer__body
     when :new then ERBPostsNew.new(post: @post).__rbs_infer__body
+    when :show then ERBPostsShow.new(comments: @comments, post: @post).__rbs_infer__body
     end
     true
   end
@@ -26,7 +28,7 @@ class PostsController
 
     return if performed?
 
-    ERBPostsIndex.new(posts: @posts).__rbs_infer__body
+    render(:index)
   end
 
   def __rbs_infer__run_show
@@ -43,7 +45,7 @@ class PostsController
 
     return if performed?
 
-    ERBPostsShow.new(comments: @comments, post: @post).__rbs_infer__body
+    render(:show)
   end
 
   def __rbs_infer__run_new
@@ -57,7 +59,7 @@ class PostsController
 
     return if performed?
 
-    ERBPostsNew.new(post: @post).__rbs_infer__body
+    render(:new)
   end
 
   def __rbs_infer__run_create

--- a/spec/expectations/steep_controller_runtime/posts_controller.rbs
+++ b/spec/expectations/steep_controller_runtime/posts_controller.rbs
@@ -5,9 +5,9 @@ class PostsController
 
   private
 
-  def __rbs_infer__run_index: () -> nil
-  def __rbs_infer__run_show: () -> nil
-  def __rbs_infer__run_new: () -> nil
+  def __rbs_infer__run_index: () -> bool?
+  def __rbs_infer__run_show: () -> bool?
+  def __rbs_infer__run_new: () -> bool?
   def __rbs_infer__run_create: () -> void
   def __rbs_infer__run_update: () -> void
   def __rbs_infer__run_destroy: () -> void

--- a/spec/expectations/steep_controller_runtime/users_avatars_controller.rb
+++ b/spec/expectations/steep_controller_runtime/users_avatars_controller.rb
@@ -28,7 +28,7 @@ class Users::AvatarsController
 
     return if performed?
 
-    render(:edit)
+    render :edit
   end
 
   def __rbs_infer__run_update

--- a/spec/expectations/steep_controller_runtime/users_avatars_controller.rb
+++ b/spec/expectations/steep_controller_runtime/users_avatars_controller.rb
@@ -28,7 +28,7 @@ class Users::AvatarsController
 
     return if performed?
 
-    ERBUsersAvatarsEdit.new(user: @user).__rbs_infer__body
+    render(:edit)
   end
 
   def __rbs_infer__run_update

--- a/spec/expectations/steep_controller_runtime/users_avatars_controller.rbs
+++ b/spec/expectations/steep_controller_runtime/users_avatars_controller.rbs
@@ -6,7 +6,7 @@ module Users
 
     private
 
-    def __rbs_infer__run_edit: () -> nil
+    def __rbs_infer__run_edit: () -> bool?
     def __rbs_infer__run_update: () -> void
   end
 end

--- a/spec/expectations/steep_controller_runtime/users_controller.rb
+++ b/spec/expectations/steep_controller_runtime/users_controller.rb
@@ -35,6 +35,6 @@ class UsersController
 
     return if performed?
 
-    render(:show)
+    render :show
   end
 end

--- a/spec/expectations/steep_controller_runtime/users_controller.rb
+++ b/spec/expectations/steep_controller_runtime/users_controller.rb
@@ -4,6 +4,14 @@
 # Regenerated on every run; do not edit.
 
 class UsersController
+  def render(target = nil, *rest)
+    @__rbs_infer__performed = true
+    case target
+    when :show then ERBUsersShow.new(posts: @posts, user: @user).__rbs_infer__body
+    end
+    true
+  end
+
   private
 
   def __rbs_infer__run_index
@@ -27,6 +35,6 @@ class UsersController
 
     return if performed?
 
-    ERBUsersShow.new(posts: @posts, user: @user).__rbs_infer__body
+    render(:show)
   end
 end

--- a/spec/expectations/steep_controller_runtime/users_controller.rbs
+++ b/spec/expectations/steep_controller_runtime/users_controller.rbs
@@ -1,6 +1,10 @@
 class UsersController
+  @__rbs_infer__performed: true?
+
+  def render: (?Symbol target, *untyped) -> bool
+
   private
 
   def __rbs_infer__run_index: () -> void
-  def __rbs_infer__run_show: () -> nil
+  def __rbs_infer__run_show: () -> bool?
 end

--- a/spec/lib/rbs_infer/analyzer_spec.rb
+++ b/spec/lib/rbs_infer/analyzer_spec.rb
@@ -507,6 +507,60 @@ RSpec.describe RbsInfer::Analyzer do
       end
     end
 
+    # The `?` used to depend on WHICH pass typed the method: a literal tail fell
+    # through to the Steep pass (which widened) while a CALL tail was resolved by
+    # chain resolution or TypeMerger (which did not), so the same guard produced
+    # `-> bool?` or `-> bool` depending on the shape after it. The widening is now
+    # one pass over the finished signatures.
+    it "anota com ? um early return seguido de tail que é uma CHAMADA" do
+      files = {
+        "guard.rb" => <<~RUBY
+          class Guard
+            def tail_is_literal
+              return if performed?
+
+              true
+            end
+
+            def tail_is_call
+              return if performed?
+
+              do_render
+            end
+
+            def no_early_return
+              do_render
+            end
+
+            def value_return_only
+              return 1 if performed?
+
+              2
+            end
+
+            def performed?
+              false
+            end
+
+            def do_render
+              true
+            end
+          end
+        RUBY
+      }
+
+      with_temp_files(files) do |_dir, paths|
+        rbs = described_class.new(target_file: paths.first, source_files: paths).generate_rbs
+
+        expect(rbs).to include("def tail_is_literal: () -> bool?")
+        expect(rbs).to include("def tail_is_call: () -> bool?")
+        # No early return → no widening.
+        expect(rbs).to include("def no_early_return: () -> bool")
+        # `return 1` is not a nil return.
+        expect(rbs).to include("def value_return_only: () -> Integer")
+      end
+    end
+
     # Regression: block generic resolution (`.map { ... }`) lives in the
     # same loop that updates already-typed methods. Singleton methods
     # need that loop to fire on them too — otherwise `.map`'s

--- a/spec/lib/rbs_infer/extensions/rails/controllers/runtime_generator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/controllers/runtime_generator_spec.rb
@@ -656,6 +656,124 @@ RSpec.describe RbsInfer::Extensions::Rails::Controllers::RuntimeGenerator do
         "when :edit then ERBUsersAvatarsEdit.new.__rbs_infer__body"
       )
     end
+
+    # Every view of the controller gets a branch, not only the ones an explicit
+    # `render :view` names: the implicit convention render is emitted as
+    # `render(:show)` too, so a `case` limited to explicit targets would leave
+    # it dispatching nowhere and the view would lose the arguments that type it.
+    it "covers every view of the controller, not only the explicitly rendered ones" do
+      result = build(
+        "app/controllers/posts_controller.rb" => <<~RUBY,
+          class PostsController < ActionController::Base
+            def show; end
+
+            def create
+              render :new
+            end
+          end
+        RUBY
+        "app/views/posts/show.html.erb" => "<%= @post %>",
+        "app/views/posts/new.html.erb" => "<%= @post %>",
+        "app/views/posts/index.html.erb" => "<%= @posts %>"
+      )
+
+      expect(render_override(result, "posts_controller.rb").grep(/\Awhen/)).to eq(
+        [
+          "when :index then ERBPostsIndex.new(posts: @posts).__rbs_infer__body",
+          "when :new then ERBPostsNew.new(post: @post).__rbs_infer__body",
+          "when :show then ERBPostsShow.new(post: @post).__rbs_infer__body",
+        ]
+      )
+    end
+
+    # A partial is never an action's render target — the VIEW that renders it
+    # constructs it, from the view-runtime pseudo-code's own `render`.
+    it "skips partials when sweeping the view directory" do
+      result = build(
+        "app/controllers/posts_controller.rb" => <<~RUBY,
+          class PostsController < ActionController::Base
+            def show; end
+          end
+        RUBY
+        "app/views/posts/show.html.erb" => "x",
+        "app/views/posts/_form.html.erb" => "x"
+      )
+
+      whens = render_override(result, "posts_controller.rb").grep(/\Awhen/)
+      expect(whens).to eq(["when :show then ERBPostsShow.new.__rbs_infer__body"])
+    end
+
+    # The directory sweep and the explicit targets both name `:new`; a second
+    # branch for it would be dead code.
+    it "emits one branch when an explicit render names a view the sweep found" do
+      result = build(
+        "app/controllers/posts_controller.rb" => <<~RUBY,
+          class PostsController < ActionController::Base
+            def create
+              render :new
+            end
+          end
+        RUBY
+        "app/views/posts/new.html.erb" => "x"
+      )
+
+      whens = render_override(result, "posts_controller.rb").grep(/\Awhen/)
+      expect(whens).to eq(["when :new then ERBPostsNew.new.__rbs_infer__body"])
+    end
+
+    # A controller that renders nothing explicitly still needs the override:
+    # its actions' implicit renders go through it.
+    it "emits the override for a controller with a view but no explicit render" do
+      result = build(
+        "app/controllers/posts_controller.rb" => <<~RUBY,
+          class PostsController < ActionController::Base
+            def show; end
+          end
+        RUBY
+        "app/views/posts/show.html.erb" => "x"
+      )
+
+      expect(render_override(result, "posts_controller.rb")).to include(
+        "when :show then ERBPostsShow.new.__rbs_infer__body"
+      )
+    end
+  end
+
+  # Rails ends an action with `render action_name`. Emitting that call — rather
+  # than constructing the view inline — makes the implicit and explicit renders
+  # of a view two call sites of ONE method, which is the shape the fork's
+  # argument-sensitive entry facts read. Constructed inline they were two
+  # separate constructor call sites whose facts never met.
+  describe "the implicit convention render" do
+    it "ends the runner with `render(:action)`, not a view constructor" do
+      result = build(
+        "app/controllers/posts_controller.rb" => <<~RUBY,
+          class PostsController < ActionController::Base
+            def show; end
+          end
+        RUBY
+        "app/views/posts/show.html.erb" => "<%= @post %>"
+      )
+
+      source = source_of(result, "posts_controller.rb")
+
+      expect(source).to include("render(:show)")
+      expect(source).not_to include("ERBPostsShow.new(post: @post).__rbs_infer__body\n  end")
+    end
+
+    it "emits no implicit render when the action has no convention template" do
+      result = build(
+        "app/controllers/posts_controller.rb" => <<~RUBY,
+          class PostsController < ActionController::Base
+            def destroy; end
+          end
+        RUBY
+        "app/views/posts/show.html.erb" => "x"
+      )
+
+      body = source_of(result, "posts_controller.rb")[/def __rbs_infer__run_destroy\n(.*?)^  end$/m, 1]
+      expect(body).not_to include("render(")
+    end
   end
 
   # Snapshot of the generated pseudo-code against the real dummy app, mirroring

--- a/spec/lib/rbs_infer/extensions/rails/controllers/runtime_generator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/controllers/runtime_generator_spec.rb
@@ -745,7 +745,7 @@ RSpec.describe RbsInfer::Extensions::Rails::Controllers::RuntimeGenerator do
   # argument-sensitive entry facts read. Constructed inline they were two
   # separate constructor call sites whose facts never met.
   describe "the implicit convention render" do
-    it "ends the runner with `render(:action)`, not a view constructor" do
+    it "ends the runner with `render :action`, not a view constructor" do
       result = build(
         "app/controllers/posts_controller.rb" => <<~RUBY,
           class PostsController < ActionController::Base
@@ -757,7 +757,7 @@ RSpec.describe RbsInfer::Extensions::Rails::Controllers::RuntimeGenerator do
 
       source = source_of(result, "posts_controller.rb")
 
-      expect(source).to include("render(:show)")
+      expect(source).to include("    render :show\n  end")
       expect(source).not_to include("ERBPostsShow.new(post: @post).__rbs_infer__body\n  end")
     end
 
@@ -772,7 +772,7 @@ RSpec.describe RbsInfer::Extensions::Rails::Controllers::RuntimeGenerator do
       )
 
       body = source_of(result, "posts_controller.rb")[/def __rbs_infer__run_destroy\n(.*?)^  end$/m, 1]
-      expect(body).not_to include("render(")
+      expect(body).not_to match(/^\s*render\b/)
     end
   end
 


### PR DESCRIPTION
Both halves of "adicionar todas as views possíveis daquele controller" + "usar o render ao invés de instanciar as classes".

## The pseudo-code

```diff
   def render(target = nil, *rest)
     @__rbs_infer__performed = true
     case target
     when :edit then ERBPostsEdit.new(post: @post).__rbs_infer__body
+    when :index then ERBPostsIndex.new(posts: @posts).__rbs_infer__body
     when :new then ERBPostsNew.new(post: @post).__rbs_infer__body
+    when :show then ERBPostsShow.new(comments: @comments, post: @post).__rbs_infer__body
     end
     true
   end

   def __rbs_infer__run_show
     ...
     return if performed?

-    ERBPostsShow.new(comments: @comments, post: @post).__rbs_infer__body
+    render(:show)
   end
```

The two halves are one change: with the implicit render emitted as a call, a `case` holding only the explicit targets would leave it dispatching to no branch, and the view would lose every argument that types it.

`UsersController` gains an override it never had — it renders nothing explicitly, but its actions' implicit renders now go through one.

## Why it is worth doing

A view's constructor now has **one** call site instead of two unrelated ones. `render :edit` from `update`'s failure branch and the implicit render of `edit` were separate constructor calls whose facts never met; both are now call sites of the same method — the shape the fork's argument-sensitive entry facts read.

The sidecar picks it up immediately, one partition per view carrying exactly that action's facts:

```yaml
- class: PostsController
  method: render
  param: target
  pattern: ":show"
  ivars:
    "@comments": "::Comment::ActiveRecord_Relation"
    "@post": "(::Post & ::Post::Validated)"
- class: PostsController
  method: render
  param: target
  pattern: ":index"
  ivars:
    "@posts": "::Post::ActiveRecord_Relation"
```

That was the risk worth measuring — moving a constructor out of its runner loses the guard chain's narrowing unless the partitions carry it. They do: `ERBPostsShow#initialize` still takes `post: Post & ::Post::Validated`, unchanged.

(Measuring it needs the right order: the sidecar is Steep's output over the pseudo-code, so pseudo-code → `steep check` → `rbs_infer`. Run against a stale sidecar every view goes nilable, which is what a first pass shows.)

## An inference gap this surfaced

The runners now end in `render(...)`, so they infer `bool` — and that produced 17 Steep errors, because they also contain `return if performed?`.

The bug is not the generator's. A body with an early `return` can return nil, but the widening was applied by only **some** of the passes that set a return type: a literal tail falls through to the Steep pass (which widened), while a call tail is resolved by chain resolution or TypeMerger (which did not). Minimal repro, unrelated to controllers:

```ruby
def tail_is_literal   # -> bool?   correct
  return if performed?
  true
end

def tail_is_call      # -> bool    wrong
  return if performed?
  do_render
end
```

Which passes a method happened to take decided whether the `?` appeared. It is now **one** pass over the finished signatures (`ReturnTypeResolver#apply_early_return_nilability`), run after every pass that can set a return type, rather than repeated at each substitution site — spreading it over the passes is how three of them came to disagree. `void`, `untyped`, already-nilable, `initialize` and setters are skipped; `return 1` is not a nil return.

## Verification

- `bundle exec rspec` — 816 examples, 0 failures
- `make steep` — **unchanged at 30 problems**, set-difference against `spec/expectations/steep_baseline.txt` empty in both directions
- 6 new generator specs (directory sweep, partials excluded, dedup against explicit targets, override for a controller with no explicit render, `render(:action)` in the runner, no implicit render without a template) + 1 analyzer spec covering all four early-return shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)