### PR TITLE
perf(spec): share one `steep check` run across both dummy examples

### DIFF
--- a/spec/integration/steep_dummy_spec.rb
+++ b/spec/integration/steep_dummy_spec.rb
@@ -54,18 +54,36 @@ RSpec.describe "Steep type check on dummy app", :dummy_app do
   # and the trailing "Detected N problems" summary.
   STEEP_ERROR_LINE = /\A(?<path>[^\s:]+\.[a-z]+):(?<line>\d+):(?<col>\d+):\s+\[(?<severity>error|warning)\]\s+(?<message>.+)\z/.freeze
 
-  def run_steep
-    env = {
-      "STEEP_ERB_CONVENTION" => "1",
-      "STEEP_MODULE_CONVENTION" => "1"
-    }
+  # `steep check` on the dummy takes ~35s and BOTH examples need its result — one reads
+  # the sidecar it regenerates, the other its diagnostics. Run once and share.
+  #
+  # Memoized on the example GROUP, not in a `let` (per-example, so it would run twice) and
+  # not in `before(:all)` (which would tie the two examples to one hook and re-run the
+  # check for any future example that doesn't need it). Both examples observe the same
+  # process, which is also more faithful than two runs: the sidecar checked below is
+  # exactly the one the diagnostics were produced with.
+  #
+  # Safe to share because the run has no inputs either example varies — the dummy's files
+  # are fixed by the `before(:all)` generator sweep above, and neither example writes to
+  # them. `UPDATE_*` env vars only change what is done with the OUTPUT.
+  def self.steep_output
+    @steep_output ||= begin
+      env = {
+        "STEEP_ERB_CONVENTION" => "1",
+        "STEEP_MODULE_CONVENTION" => "1"
+      }
 
-    Bundler.with_unbundled_env do
-      Dir.chdir(DUMMY_APP_ROOT) do
-        stdout, _stderr, _status = Open3.capture3(env, "bundle", "exec", "steep", "check")
-        stdout
+      Bundler.with_unbundled_env do
+        Dir.chdir(DUMMY_APP_ROOT) do
+          stdout, _stderr, _status = Open3.capture3(env, "bundle", "exec", "steep", "check")
+          stdout
+        end
       end
     end
+  end
+
+  def run_steep
+    self.class.steep_output
   end
 
   def parse_errors(steep_output)


### PR DESCRIPTION
Both examples in `steep_dummy_spec.rb` called `run_steep`, so the ~35s check ran twice for one set of results.

```
spec/integration/steep_dummy_spec.rb   1m45s -> 1m10s
```

(Combines with felixefelip/steep#98, which took the `steep check` itself from 1m22 to 36s — together these two files went from ~3m20 to 1m10.)

## Where the memo lives

On the example **group**, not in a `let` and not in `before(:all)`:

```ruby
def self.steep_output
  @steep_output ||= begin
    ...
  end
end

def run_steep
  self.class.steep_output
end
```

- a `let` is per-example — it would still run twice;
- a `before(:all)` hook would tie the two examples to one hook and re-run the check for any future example that doesn't need it.

## Why sharing is safe here

The run has no input either example varies: the dummy's files are fixed by the generator sweep already in `before(:all)`, neither example writes to them, and the `UPDATE_*` env vars only change what is done with the **output**.

It is also *more faithful* than two runs — the sidecar the contracts example checks is now exactly the one the diagnostics were produced with, rather than a second run's.

## Verification

Beyond "the two examples pass":

- **both orderings** — RSpec randomizes, and the memo must not depend on which example runs first. Three seeds, both orders observed, green.
- **`UPDATE_STEEP_BASELINE=1`** and **`UPDATE_STEEP_CONTRACTS=1`** still refresh and skip; the refreshed files come out byte-identical.
- **regression detection still fires** — appended a fabricated entry to the baseline and confirmed the example fails on it. A shared run that silently stopped detecting drift would be a bad trade, so this one is worth checking rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)