### PR TITLE
perf(spec): run the suite as two concurrent lanes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,12 @@ rbs_generators_all:
 test:
 	bundle exec rspec
 
+## Mesma suíte em dois processos concorrentes (~114s -> ~75s).
+## Não use para regravar snapshots — bin/rspec-parallel recusa UPDATE_* e
+## explica o porquê.
+test_parallel:
+	./bin/rspec-parallel
+
 ## Análise de tipos com Steep no dummy
 steep:
 	cd $(DUMMY_DIR) && STEEP_ERB_CONVENTION=1 STEEP_MODULE_CONVENTION=1 bundle exec steep check

--- a/bin/rspec-parallel
+++ b/bin/rspec-parallel
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Runs the spec suite as two concurrent RSpec processes, split by what they
+# WRITE rather than by how long they take.
+#
+#   lane "dummy"    spec/integration/rails_dummy_spec.rb
+#                   spec/integration/steep_dummy_spec.rb
+#   lane "isolated" spec/lib  spec/bin  spec/integration/steep_scenarios_spec.rb
+#
+# The two dummy specs run generators (`rake rbs_rails:all`, `rbs collection
+# install`, the rbs_infer sidecar tasks) that write into spec/dummy/sig/. They
+# write the SAME files, so running them against each other risks a torn read —
+# they share a lane and stay serial within it. Everything else builds its own
+# tmpdir per example (`Dir.mktmpdir`, `in_app`, TempFileHelpers) and only ever
+# READS spec/dummy, so it is safe alongside them.
+#
+# That is also why the split is not "integration vs unit", the obvious cut:
+# spec/lib is ~9s against ~87s of integration, so that split saves almost
+# nothing. Moving the isolated integration file across is what balances it.
+#
+#     bin/rspec-parallel                 # whole suite, two lanes
+#     bin/rspec-parallel --seed 1234     # extra args go to BOTH lanes
+#
+# Exit status is non-zero if either lane fails. Output is buffered per lane and
+# printed when that lane finishes, so the two processes never interleave
+# mid-line; the summary at the end says which lane failed.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1
+
+# Snapshot-refreshing runs write to spec/expectations/ from BOTH lanes (the
+# dummy specs and the unit generator specs each own part of that tree), so a
+# parallel refresh is a race on the deliverable itself. Refuse loudly rather
+# than produce a half-updated tree that looks fine.
+for var in UPDATE_EXPECTATIONS UPDATE_STEEP_BASELINE UPDATE_STEEP_CONTRACTS; do
+  if [[ -n "${!var:-}" ]]; then
+    echo "error: $var is set — refreshing snapshots must run serially." >&2
+    echo "       use: $var=1 bundle exec rspec" >&2
+    exit 2
+  fi
+done
+
+DUMMY_SPECS=(
+  spec/integration/rails_dummy_spec.rb
+  spec/integration/steep_dummy_spec.rb
+)
+ISOLATED_SPECS=(
+  spec/lib
+  spec/bin
+  spec/integration/steep_scenarios_spec.rb
+)
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+run_lane() {
+  local name="$1"; shift
+  local start
+  start=$(date +%s)
+  bundle exec rspec "$@" >"$tmp/$name.out" 2>&1
+  echo "$?" >"$tmp/$name.status"
+  echo "$(($(date +%s) - start))" >"$tmp/$name.time"
+}
+
+run_lane dummy "${DUMMY_SPECS[@]}" "$@" &
+dummy_pid=$!
+run_lane isolated "${ISOLATED_SPECS[@]}" "$@" &
+isolated_pid=$!
+
+wait "$dummy_pid"
+wait "$isolated_pid"
+
+overall=0
+for lane in dummy isolated; do
+  status="$(cat "$tmp/$lane.status")"
+  echo "════════ lane: $lane (${status/0/ok} — $(cat "$tmp/$lane.time")s) ════════"
+  cat "$tmp/$lane.out"
+  echo
+  if [[ "$status" -ne 0 ]]; then overall="$status"; fi
+done
+
+echo "════════ summary ════════"
+for lane in dummy isolated; do
+  status="$(cat "$tmp/$lane.status")"
+  if [[ "$status" -eq 0 ]]; then
+    printf '  %-10s passed  (%ss)\n' "$lane" "$(cat "$tmp/$lane.time")"
+  else
+    printf '  %-10s FAILED (exit %s, %ss)\n' "$lane" "$status" "$(cat "$tmp/$lane.time")"
+  fi
+done
+
+exit "$overall"


### PR DESCRIPTION
```
bundle exec rspec    114s
bin/rspec-parallel    75s
```

## The split is by what each spec WRITES

```
lane "dummy"     rails_dummy_spec + steep_dummy_spec
lane "isolated"  spec/lib + spec/bin + steep_scenarios_spec
```

The two dummy specs run generators in `before(:all)` — `rake rbs_rails:all`, `rbs collection install`, the rbs_infer sidecar tasks — that write into `spec/dummy/sig/`. They write the **same files**, so running them against each other risks a torn read. They share a lane and stay serial within it.

Everything else builds a tmpdir per example (`Dir.mktmpdir`, `in_app`, `TempFileHelpers`) and only **reads** `spec/dummy` — verified by grepping every `File.write` / `mkpath` in `spec/lib` and `spec/bin`, not assumed.

**Not** the obvious "integration vs unit" cut: `spec/lib` is ~9s against ~87s of integration, so that split saves almost nothing. Moving the one isolated *integration* file across is what balances the lanes.

## Snapshot refreshes are refused, not silently allowed

Both lanes write into `spec/expectations/` — the dummy specs and the unit generator specs each own part of that tree. A parallel refresh would race on the deliverable itself and could leave a half-updated tree that looks fine. The script exits 2 and prints the serial command:

```
$ UPDATE_EXPECTATIONS=1 ./bin/rspec-parallel
error: UPDATE_EXPECTATIONS is set — refreshing snapshots must run serially.
       use: UPDATE_EXPECTATIONS=1 bundle exec rspec
```

## Why not 2x

`steep check` already runs 10 workers on a 12-core box, and **both** lanes invoke steep (`steep_scenarios` runs it 7 times), so the lanes contend for CPU. The isolated lane takes 54s in parallel against 28s alone.

Two alternatives were measured and rejected:

- putting the two dummy specs in **separate** lanes → 73s, 2s better in exchange for a race on shared files. Not taken.
- sharing the duplicated generator setup between the two dummy specs → the duplicated work is only 5s, not worth the coupling.

## Verification

- **816 examples** across the two lanes (56 + 760), matching the serial suite exactly — so the hand-written file lists don't silently drop a spec, which is the main hazard of splitting by path.
- a deliberately corrupted baseline entry fails the run with **exit 1** and names the failing lane in the summary.
- the `UPDATE_*` guard fires for all three vars.
- output is buffered per lane and printed on completion, so the two processes never interleave mid-line.

## Usage

```bash
bin/rspec-parallel              # whole suite, two lanes
bin/rspec-parallel --seed 1234  # extra args go to both lanes
make test_parallel
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)