### PR TITLE
test(dummy): steep#96 lands — the partial's Current.user read now checks

### DIFF
--- a/spec/dummy/app/views/posts/_summary.html.erb
+++ b/spec/dummy/app/views/posts/_summary.html.erb
@@ -2,11 +2,11 @@
   <h2><%= post.title %></h2>
   <p><%= post.body %></p>
 
-  <%# felixefelip/steep#96. `authenticate_user` proves `Current.user` non-nil past its
-      halt guard, and the view that renders this partial sees that fact — the IDENTICAL
-      read in posts/show.html.erb type-checks. Here it does not: `each_method_def` walks
-      only `def` nodes, so a template contributes no flow and the facts stop at the view
-      body, never reaching the partial it renders. Expected in the steep baseline until
-      #96 lands; when it does, this line and its control in show.html.erb agree. %>
+  <%# felixefelip/steep#96 regression guard. `authenticate_user` proves `Current.user`
+      non-nil past its halt guard, and that fact reaches this partial only because the
+      view body that renders it counts as a flow — a template has no `def`, so before #96
+      the chain died at the view and this read was an error in the steep baseline. The
+      IDENTICAL read in posts/show.html.erb is the control: if only this one regresses,
+      the template-body flow broke; if both do, the guard upstream did. %>
   <p class="viewer"><%= Current.user.name %></p>
 </div>

--- a/spec/dummy/app/views/posts/show.html.erb
+++ b/spec/dummy/app/views/posts/show.html.erb
@@ -4,10 +4,10 @@
   <span>Por <%= @post.author_name %></span>
   <%= post_status_badge(@post) %>
 
-  <%# Control for the same read in posts/_summary.html.erb (felixefelip/steep#96): the
-      IDENTICAL `Current.user.name` type-checks HERE, in the view body, because the
-      controller's render call site carries `authenticate_user`'s facts into it. If this
-      line ever starts erroring, the gap is upstream of #96, not in it. %>
+  <%# Control for the same read in posts/_summary.html.erb (felixefelip/steep#96): this
+      one type-checks because the controller's render call site carries
+      `authenticate_user`'s facts into the view body directly, one hop short of the
+      partial. If this line ever starts erroring, the gap is upstream of #96, not in it. %>
   <span class="viewer"><%= Current.user.name %></span>
 </div>
 

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -803,8 +803,28 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+- class: ERBPartialPostsComment
+  method: __rbs_infer__body
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+- class: ERBPartialPostsForm
+  method: __rbs_infer__body
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+- class: ERBPartialPostsSummary
+  method: __rbs_infer__body
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
 - class: ERBPostsEdit
   method: __rbs_infer__body
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+- class: ERBPostsEdit
+  method: render
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
@@ -818,8 +838,18 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+- class: ERBPostsNew
+  method: render
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
 - class: ERBPostsShow
   method: __rbs_infer__body
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+- class: ERBPostsShow
+  method: render
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
@@ -885,6 +915,11 @@ method_entry_facts:
     Current.user: "(::User & ::User::Validated)"
 - class: Post
   method: assignments
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+- class: Post
+  method: summary
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
@@ -1006,6 +1041,21 @@ method_entry_facts:
     Current.user: "(::User & ::User::Validated)"
   ivars:
     "@post": "(::Post & ::Post::Validated)"
+- class: PostsHelper
+  method: post_index_marker
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+- class: PostsHelper
+  method: post_status_badge
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+- class: PostsHelper
+  method: post_summary
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
 - class: TagDestroy
   method: atribui_user
   ivars:

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -28,4 +28,3 @@ app/services/profile_formatter.rb:31:4: [error] `format_nickname` requires `self
 app/services/profile_formatter.rb:37:13: [error] Type `(::String | nil)` does not have method `upcase`
 app/services/tag_destroy.rb:110:6: [error] Cannot allow method body have type `(void | ::String)` because declared as type `(::String | nil)`
 app/services/tag_destroy.rb:98:7: [error] Type `::TagDestroy` does not have method `untyped`
-app/views/posts/_summary.html.erb:11:37: [error] Type `((::User & ::User::Validated) | ::User | nil)` does not have method `name`


### PR DESCRIPTION
Depends on **felixefelip/steep#99** (closes felixefelip/steep#96). Merge that first — this branch's baseline assumes it.

## What changed upstream

A `@type self_method:` body (an ERB template) is now a flow in `MethodEntryInferrer`, so facts holding at a view's entry reach the partials it renders:

```
show.html.erb  (@type self_method: ERBPostsShow#__rbs_infer__body)
  render "posts/summary", post: @post     # <= was invisible: no `def`, no flow
ERBPostsShow#render
  ERBPartialPostsSummary.new(...).__rbs_infer__body
```

## What this changes here

The fixture planted in 9c1632d flips from expected-error to regression guard.

**Baseline 31 → 30:**

```diff
-app/views/posts/_summary.html.erb:11:37: [error] Type `((::User & ::User::Validated) | ::User | nil)` does not have method `name`
```

Nothing added. Its control — the identical `Current.user.name` in `posts/show.html.erb`, which already checked — still checks, so the two now agree.

**`.steep_postconditions.yml`, purely additive** (+50 lines): entry facts for all three `ERBPartial*` bodies, for `ERBPostsShow#render` / `ERBPostsEdit#render` / `ERBPostsNew#render`, and for `Post#summary` — a helper reached only from a template body, which the same fix made visible.

`_summary` is rendered from two views (`show.html.erb` and `edit.html.erb`), so the fact survives the join over both — both parent bodies carry it. If a future view renders it from a path without `authenticate_user`, the `nil` comes back, correctly.

**Fixture comments** now say what a regression in each would mean: only the partial regressing means the template-body flow broke; both regressing means the guard upstream did.

## Regeneration

Looped `make rbs_infer` → `make steep` to a fixed point — stable after one pass, and **no generated RBS changed**; the new facts only affect narrowing, not inferred signatures. `spec/expectations/steep_contracts.yml` is unchanged too.

`bundle exec rspec spec/integration/` is green (63 examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)