### PR TITLE
test(dummy): steep#100 lands — a populated Current reaches the action and its view

### DIFF
--- a/spec/dummy/app/controllers/dashboard_controller.rb
+++ b/spec/dummy/app/controllers/dashboard_controller.rb
@@ -13,12 +13,14 @@
 # `Current.user` read in the view needs a nil check.
 #
 # `set_current_account` runs AFTER the guard, so `current_account` is proven present at its
-# entry and `Current.account` SHOULD be proven populated from there on — including inside
-# the view `show` renders. It is not, and that is deliberate: the marker sidecar that used
-# to assert it is gone (felixefelip/rbs_infer#125), so the read in dashboard/show.html.erb
-# sits in the steep baseline as the open gap. What is missing is one link — a plain handler
-# writing another class's constant attribute gets no establishing postcondition, unlike a
-# handler that halts (`authenticate_user`) or a setter writing its own (`Current#user=`).
+# entry, and since the handler cannot halt it establishes `Current.account` on every exit
+# (felixefelip/steep#100). That fact reaches the action and the view `show` renders, which
+# is why `Current.account.label` in dashboard/show.html.erb needs no nil check.
+#
+# Nothing asserts any of that. A sidecar used to (`Rails::CurrentAttributesCallbacks
+# Generator`, removed in felixefelip/rbs_infer#125) by re-deriving the callback chain and
+# scanning for a `Validated` marker; now the guard's own body, the finder's signature and
+# the handler's own write are what prove it.
 class DashboardController < ApplicationController
   before_action :authenticate_account!
   before_action :set_current_account

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -137,6 +137,11 @@ postconditions:
     may_write:
     - "@__rbs_infer__performed"
 - class: DashboardController
+  method: set_current_account
+  unconditional:
+    consts:
+      Current.account: "(::Account & ::Account::Validated)"
+- class: DashboardController
   method: show
   unconditional:
     ivars:
@@ -215,6 +220,11 @@ postconditions:
     may_write:
     - "@delivery_method"
     - "@from_address"
+- class: Example10
+  method: run
+  unconditional:
+    consts:
+      Example10::Foo.name: "::String"
 - class: Example10::Foo
   method: name
   effects:
@@ -271,6 +281,31 @@ postconditions:
   effects:
     may_write:
     - "@name"
+- class: Example3
+  method: gap_alias_read
+  unconditional:
+    consts:
+      Foo.user: "::Example3::User"
+- class: Example3
+  method: gap_alias_write
+  unconditional:
+    consts:
+      Foo.user: "::Example3::User"
+- class: Example3
+  method: gap_callee_mutation
+  unconditional:
+    consts:
+      Foo.user: "::Example3::User"
+- class: Example3
+  method: gap_conditional
+  unconditional:
+    consts:
+      Foo.user: "::Example3::User"
+- class: Example3
+  method: run
+  unconditional:
+    consts:
+      Foo.user: "::Example3::User"
 - class: Example3::Foo
   method: user=
   unconditional:
@@ -287,6 +322,11 @@ postconditions:
   effects:
     may_write:
     - "@name"
+- class: Example4
+  method: run
+  unconditional:
+    consts:
+      Example4::Foo.name: "::String"
 - class: Example4::Foo
   method: name
   effects:
@@ -299,6 +339,11 @@ postconditions:
   effects:
     may_write:
     - "@name"
+- class: Example5
+  method: run
+  unconditional:
+    consts:
+      Example5::Foo.name: "::String"
 - class: Example5::Foo
   method: name
   effects:
@@ -313,6 +358,11 @@ postconditions:
   effects:
     may_write:
     - "@name"
+- class: Example6
+  method: run
+  unconditional:
+    consts:
+      Example6::Foo.name: "::String"
 - class: Example6::Foo
   method: name
   effects:
@@ -327,6 +377,16 @@ postconditions:
   effects:
     may_write:
     - "@name"
+- class: Example7
+  method: run_age
+  unconditional:
+    consts:
+      Example7::Age.value: "::Integer"
+- class: Example7
+  method: run_name
+  unconditional:
+    consts:
+      Example7::Foo.name: "::String"
 - class: Example7::Age
   method: value
   effects:
@@ -373,6 +433,16 @@ postconditions:
   effects:
     may_write:
     - "@name"
+- class: Example9
+  method: run_age
+  unconditional:
+    consts:
+      Example9::Age.value: "::Integer"
+- class: Example9
+  method: run_name
+  unconditional:
+    consts:
+      Example9::Foo.name: "::String"
 - class: Example9::Age
   method: value
   effects:
@@ -570,6 +640,9 @@ postconditions:
     - "@post"
 - class: PostsController
   method: publish
+  unconditional:
+    consts:
+      Current.user: "(::User & ::User::Validated)"
   effects:
     may_write:
     - "@__rbs_infer__performed"
@@ -821,6 +894,7 @@ method_entry_facts:
 - class: Account
   method: label
   consts:
+    Current.account: "(::Account & ::Account::Validated)"
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
 - class: ApplicationController
@@ -862,6 +936,7 @@ method_entry_facts:
 - class: Current
   method: account
   consts:
+    Current.account: "(::Account & ::Account::Validated)"
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
 - class: Current
@@ -875,6 +950,7 @@ method_entry_facts:
     current_account: "(::Account & ::Account::Validated)"
     current_user: "(::User & ::User::Validated)"
   consts:
+    Current.account: "(::Account & ::Account::Validated)"
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
   ivars:
@@ -894,6 +970,7 @@ method_entry_facts:
     current_account: "(::Account & ::Account::Validated)"
     current_user: "(::User & ::User::Validated)"
   consts:
+    Current.account: "(::Account & ::Account::Validated)"
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
 - class: DeviseScopedHelpers
@@ -913,6 +990,7 @@ method_entry_facts:
 - class: ERBDashboardShow
   method: __rbs_infer__body
   consts:
+    Current.account: "(::Account & ::Account::Validated)"
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
 - class: ERBPartialPostsComment

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -28,4 +28,3 @@ app/services/profile_formatter.rb:31:4: [error] `format_nickname` requires `self
 app/services/profile_formatter.rb:37:13: [error] Type `(::String | nil)` does not have method `upcase`
 app/services/tag_destroy.rb:110:6: [error] Cannot allow method body have type `(void | ::String)` because declared as type `(::String | nil)`
 app/services/tag_destroy.rb:98:7: [error] Type `::TagDestroy` does not have method `untyped`
-app/views/dashboard/show.html.erb:17:49: [error] Type `((::Account & ::Account::Validated) | nil)` does not have method `label`

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -635,44 +635,54 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
       end
     end
 
-    # The gap that remains once the marker sidecar is gone (felixefelip/rbs_infer#125).
+    # The whole chain, with nothing pre-derived anywhere in it.
     # `DashboardController#set_current_account` writes `Current.account = current_account`
-    # under the Devise guard, and two of the three links hold on their own:
+    # under the Devise guard, and every link is now inferred:
     #
     #   1. `current_account` resolves from DashboardController — the helpers are included
-    #      into ActionController::Base by the Devise sidecar, a reopening the resolver now
-    #      unions (felixefelip/rbs_infer#124), so
-    #   2. the attribute is typed from that call site and `Current.account=` establishes
-    #      the const, but
-    #   3. `set_current_account` gets NO postcondition, so the fact never reaches `show`.
-    #      The inferrer records a const establishment for a method that halts
-    #      (`authenticate_user` -> `conditional_const_returns`) or that writes its OWN
-    #      attribute (`Current#user=`), not for a plain handler writing another class's.
+    #      into ActionController::Base by the Devise sidecar, a reopening the resolver
+    #      unions (felixefelip/rbs_infer#124);
+    #   2. the attribute is typed from that call site, so `Current.account=` establishes
+    #      the const;
+    #   3. `set_current_account` cannot halt, so it establishes `Current.account`
+    #      unconditionally (felixefelip/steep#100) and the fact reaches the action AND the
+    #      view it renders.
     #
-    # Link 3 is why `Current.account.label` in dashboard/show.html.erb is in the steep
-    # baseline. When it lands in the Steep fork, that entry leaves the baseline and this
-    # expectation flips — check the FACTS, not just that `steep check` is clean: while the
-    # attribute was still `untyped` the same read type-checked vacuously.
-    it "types Current.account from the call site, but carries the fact nowhere" do
+    # Link 3 is what `Rails::CurrentAttributesCallbacksGenerator` used to assert by hand,
+    # and #125 removed it to leave the gap in the steep baseline. That entry is gone now,
+    # which is what makes this the regression guard for all three at once.
+    #
+    # Asserted on the FACTS, not on `steep check` being clean: while the attribute was
+    # still `untyped` the same read type-checked vacuously, and that read a clean run as
+    # proof once already.
+    it "carries a populated Current from the handler into the action and its view" do
       current_rbs = Pathname.new("sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs").read
       postconditions = YAML.safe_load(Pathname.new("sig/generated/.steep_postconditions.yml").read)
+      account_type = "(::Account & ::Account::Validated)"
 
       # Links 1 + 2.
       expect(current_rbs).to include("def self.account: () -> (Account & Account::Validated)?")
       expect(postconditions["postconditions"]).to include(
         a_hash_including("class" => "Current", "method" => "account=",
                          "unconditional" => a_hash_including(
-                           "establishes_consts" => { "account" => "(::Account & ::Account::Validated)" }
+                           "establishes_consts" => { "account" => account_type }
                          ))
       )
 
-      # Link 3, missing: no method establishes the populated constant, and no entry fact
-      # carries it.
-      expect(postconditions["postconditions"]).not_to include(
-        a_hash_including("class" => "DashboardController", "method" => "set_current_account")
+      # Link 3: the handler establishes it, with no gate to key it on...
+      expect(postconditions["postconditions"]).to include(
+        a_hash_including("class" => "DashboardController", "method" => "set_current_account",
+                         "unconditional" => { "consts" => { "Current.account" => account_type } })
       )
-      carriers = (postconditions["method_entry_facts"] || []).select { |e| (e["consts"] || {}).key?("Current.account") }
-      expect(carriers).to be_empty
+
+      # ...and it lands at the action, at the render dispatch, and in the template body —
+      # the last one being why `Current.account.label` in dashboard/show.html.erb needs no
+      # nil check.
+      carriers = (postconditions["method_entry_facts"] || [])
+                   .select { |e| (e["consts"] || {})["Current.account"] == account_type }
+                   .map { |e| "#{e["class"]}##{e["method"]}" }
+      expect(carriers).to include("DashboardController#show", "DashboardController#render",
+                                  "ERBDashboardShow#__rbs_infer__body")
     end
   end
 


### PR DESCRIPTION
Consumes felixefelip/steep#100, which closes the last link of the chain #125 removed the hand-written sidecar to expose.

## Baseline 31 → 30

Exactly the entry #125 planted, nothing else moves:

```diff
-app/views/dashboard/show.html.erb:17:49: [error] Type `((::Account & ::Account::Validated) | nil)` does not have method `label`
```

## What now proves it

```yaml
class: DashboardController
method: set_current_account
unconditional:
  consts:
    Current.account: "(::Account & ::Account::Validated)"
```

`set_current_account` cannot halt, so there is no gate to key the fact on — which is exactly why it used to prove nothing. The establishment lands at:

```
DashboardController#show            -> (::Account & ::Account::Validated)
DashboardController#render          -> (::Account & ::Account::Validated)
ERBDashboardShow#__rbs_infer__body  -> (::Account & ::Account::Validated)
```

The last one is why `Current.account.label` in `dashboard/show.html.erb` needs no nil check.

## The expectation flips into a whole-chain guard

It went from asserting "carries the fact nowhere" to asserting all three links, so one test now covers the lot:

1. the resolver unions the Devise sidecar's `ActionController::Base` reopen (#124), so `current_account` resolves from `DashboardController`;
2. the attribute is typed from that one call site, so `Current.account=` establishes the const;
3. the handler establishes it unconditionally, and it propagates.

It keeps asserting on the **facts** rather than on `steep check` being clean. That distinction is not cosmetic here: while `Current.account` was still `untyped` the same read type-checked vacuously, and a clean run got mistaken for proof once already.

## Verification

`bin/rspec-parallel` green (706 + 68 integration). Regeneration looped to its fixed point before the refresh — the establishment only appears once the entry fact making the RHS non-nil exists, so a single pass would have understated it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)