### PR TITLE
test(dummy): the two Current-narrowing shapes a real app writes

### DIFF
--- a/spec/dummy/app/controllers/dashboard_controller.rb
+++ b/spec/dummy/app/controllers/dashboard_controller.rb
@@ -24,6 +24,7 @@
 class DashboardController < ApplicationController
   before_action :authenticate_account!
   before_action :set_current_account
+  before_action :set_current_viewer
 
   def show
     @account = current_account
@@ -34,5 +35,14 @@ class DashboardController < ApplicationController
 
   def set_current_account
     Current.account = current_account
+  end
+
+  # Mirrors the shape a real app writes: a plain `before_action` (no halt) whose write
+  # must ALSO prove what `Current#user=`'s override establishes transitively —
+  # `author_name` and `viewer_name`. Under a HALTING guard that expansion already
+  # happened, so the same write proved more or less depending on its neighbour
+  # (felixefelip/steep#103).
+  def set_current_viewer
+    Current.user = current_user
   end
 end

--- a/spec/dummy/app/models/current.rb
+++ b/spec/dummy/app/models/current.rb
@@ -6,7 +6,7 @@
 # `Current.with(user: ...)` in ProfileFormatterJob), unlocking the type
 # of the derived method `self.author_full_name`.
 class Current < ActiveSupport::CurrentAttributes
-  attribute :user, :author_name, :account
+  attribute :user, :author_name, :account, :viewer_name
 
   # Rails-guides pattern: accessor override calling `super` and deriving
   # another attribute. The expander skips generating this accessor and
@@ -16,6 +16,15 @@ class Current < ActiveSupport::CurrentAttributes
   def user=(value)
     super(value)
     self.author_name = value&.full_name
+
+    # Same transitive establishment as `author_name`, in the shape a real app writes it:
+    # guarded by `unless value.nil?` instead of `&.`, and reading an attribute that is
+    # nilable on a plain `User` but PROVEN on `User::Validated` (rbs_rails emits both).
+    # The param is `(User & User::Validated)?`, so answering `name` from the first member
+    # of the intersection alone loses the marker's stronger type.
+    unless value.nil?
+      self.viewer_name = value.name
+    end
   end
 
   # `&.` because the attribute is honestly nilable (per-request reset);

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -48,6 +48,9 @@ postconditions:
     Current.user:
       gate_ivar: "@__rbs_infer__performed"
       type: "(::User & ::User::Validated)"
+    Current.viewer_name:
+      gate_ivar: "@__rbs_infer__performed"
+      type: "::String"
 - class: Board
   method: initialize
   effects:
@@ -71,6 +74,7 @@ postconditions:
     establishes_consts:
       author_name: "::String"
       user: "((::User & ::User::Validated) | ::User)"
+      viewer_name: "::String"
 - class: Current
   method: __rbs_infer_instance
   effects:
@@ -141,6 +145,13 @@ postconditions:
   unconditional:
     consts:
       Current.account: "(::Account & ::Account::Validated)"
+- class: DashboardController
+  method: set_current_viewer
+  unconditional:
+    consts:
+      Current.author_name: "::String"
+      Current.user: "(::User & ::User::Validated)"
+      Current.viewer_name: "::String"
 - class: DashboardController
   method: show
   unconditional:
@@ -642,7 +653,9 @@ postconditions:
   method: publish
   unconditional:
     consts:
+      Current.author_name: "::String"
       Current.user: "(::User & ::User::Validated)"
+      Current.viewer_name: "::String"
   effects:
     may_write:
     - "@__rbs_infer__performed"
@@ -897,6 +910,7 @@ method_entry_facts:
     Current.account: "(::Account & ::Account::Validated)"
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: ApplicationController
   method: current_user
   ivars:
@@ -908,42 +922,50 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: Assignment
   method: log_post_user_name
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: Assignment
   method: run_before_validation_callbacks
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: Assignment
   method: run_belongs_to_default_callbacks
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: Assignment
   method: run_belongs_to_default_owner
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: Assignment
   method: save
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: Current
   method: account
   consts:
     Current.account: "(::Account & ::Account::Validated)"
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: Current
   method: author_name
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: DashboardController
   method: render
   self_methods:
@@ -953,6 +975,7 @@ method_entry_facts:
     Current.account: "(::Account & ::Account::Validated)"
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
   ivars:
     "@account": "(::Account & ::Account::Validated)"
     "@recent_posts": "::Post::ActiveRecord_Relation"
@@ -964,6 +987,17 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
+- class: DashboardController
+  method: set_current_viewer
+  self_methods:
+    current_account: "(::Account & ::Account::Validated)"
+    current_user: "(::User & ::User::Validated)"
+  consts:
+    Current.account: "(::Account & ::Account::Validated)"
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: DashboardController
   method: show
   self_methods:
@@ -973,6 +1007,7 @@ method_entry_facts:
     Current.account: "(::Account & ::Account::Validated)"
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: DeviseScopedHelpers
   method: authenticate_account!
   self_methods:
@@ -980,6 +1015,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: DeviseScopedHelpers
   method: current_account
   self_methods:
@@ -987,72 +1023,86 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: ERBDashboardShow
   method: __rbs_infer__body
   consts:
     Current.account: "(::Account & ::Account::Validated)"
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: ERBPartialPostsComment
   method: __rbs_infer__body
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: ERBPartialPostsForm
   method: __rbs_infer__body
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: ERBPartialPostsSummary
   method: __rbs_infer__body
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: ERBPostsEdit
   method: __rbs_infer__body
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: ERBPostsEdit
   method: render
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: ERBPostsIndex
   method: __rbs_infer__body
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: ERBPostsNew
   method: __rbs_infer__body
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: ERBPostsNew
   method: render
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: ERBPostsShow
   method: __rbs_infer__body
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: ERBPostsShow
   method: render
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: ERBUsersAvatarsEdit
   method: __rbs_infer__body
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: ERBUsersShow
   method: __rbs_infer__body
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: Example12
   method: dispatch_age
   ivars:
@@ -1096,6 +1146,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: FilterConfiguration
   method: sanitize_filter
   self_methods:
@@ -1103,31 +1154,37 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: Post
   method: assignments
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: Post
   method: summary
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: Post_Assignment::ActiveRecord_Associations_CollectionProxy
   method: build
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: Post_Assignment::ActiveRecord_Associations_CollectionProxy
   method: create
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: Post_Assignment::ActiveRecord_Associations_CollectionProxy
   method: create!
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: Posts::AssignmentsController
   method: assignment_params
   self_methods:
@@ -1135,6 +1192,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
   ivars:
     "@post": "(::Post & ::Post::Validated)"
 - class: Posts::AssignmentsController
@@ -1144,6 +1202,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
   ivars:
     "@post": "(::Post & ::Post::Validated)"
 - class: Posts::AssignmentsController
@@ -1153,6 +1212,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: PostsController
   method: create
   self_methods:
@@ -1160,6 +1220,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: PostsController
   method: destroy
   self_methods:
@@ -1167,6 +1228,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
   ivars:
     "@post": "(::Post & ::Post::Validated)"
 - class: PostsController
@@ -1176,6 +1238,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: PostsController
   method: new
   self_methods:
@@ -1183,6 +1246,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: PostsController
   method: post_params
   self_methods:
@@ -1190,6 +1254,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: PostsController
   method: publish
   self_methods:
@@ -1197,6 +1262,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
   ivars:
     "@post": "(::Post & ::Post::Validated)"
 - class: PostsController
@@ -1206,6 +1272,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: PostsController
   method: set_post
   self_methods:
@@ -1213,6 +1280,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: PostsController
   method: show
   self_methods:
@@ -1220,6 +1288,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
   ivars:
     "@post": "(::Post & ::Post::Validated)"
 - class: PostsController
@@ -1229,6 +1298,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
   ivars:
     "@post": "(::Post & ::Post::Validated)"
 - class: PostsHelper
@@ -1236,16 +1306,19 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: PostsHelper
   method: post_status_badge
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: PostsHelper
   method: post_summary
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: TagDestroy
   method: atribui_user
   ivars:
@@ -1280,6 +1353,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: Users::AvatarsController
   method: edit
   self_methods:
@@ -1287,6 +1361,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
   ivars:
     "@user": "(::User & ::User::Validated)"
 - class: Users::AvatarsController
@@ -1296,6 +1371,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
   ivars:
     "@user": "(::User & ::User::Validated)"
 - class: Users::AvatarsController
@@ -1305,6 +1381,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: Users::AvatarsController
   method: update
   self_methods:
@@ -1312,6 +1389,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
   ivars:
     "@user": "(::User & ::User::Validated)"
 - class: UsersController
@@ -1321,6 +1399,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: UsersController
   method: index
   self_methods:
@@ -1328,6 +1407,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: UsersController
   method: render
   self_methods:
@@ -1335,6 +1415,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: UsersController
   method: show
   self_methods:
@@ -1342,6 +1423,7 @@ method_entry_facts:
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 argument_entry_facts:
 - class: DashboardController
   method: render

--- a/spec/dummy/sig/generated/steep_controller_runtime/dashboard_controller.rb
+++ b/spec/dummy/sig/generated/steep_controller_runtime/dashboard_controller.rb
@@ -27,6 +27,9 @@ class DashboardController
     set_current_account
     return if performed?
 
+    set_current_viewer
+    return if performed?
+
     show
 
     return if performed?

--- a/spec/dummy/sig/generated/steep_current_runtime/current.rb
+++ b/spec/dummy/sig/generated/steep_current_runtime/current.rb
@@ -23,6 +23,12 @@ class Current
     def account=(value)
       @account = value
     end
+    def viewer_name
+      @viewer_name
+    end
+    def viewer_name=(value)
+      @viewer_name = value
+    end
   end
   include GeneratedAttributeMethods
 
@@ -53,21 +59,32 @@ class Current
     __rbs_infer_instance.account = value
   end
 
+  def self.viewer_name
+    @viewer_name
+  end
+
+  def self.viewer_name=(value)
+    @viewer_name = value
+    __rbs_infer_instance.viewer_name = value
+  end
+
   def self.__rbs_infer_instance
     @__rbs_infer_instance ||= Current.new
   end
 
-  def self.set(user: nil, author_name: nil, account: nil, &block)
+  def self.set(user: nil, author_name: nil, account: nil, viewer_name: nil, &block)
     @user = user
     @author_name = author_name
     @account = account
+    @viewer_name = viewer_name
     block&.call(nil)
   end
 
-  def self.with(user: nil, author_name: nil, account: nil, &block)
+  def self.with(user: nil, author_name: nil, account: nil, viewer_name: nil, &block)
     @user = user
     @author_name = author_name
     @account = account
+    @viewer_name = viewer_name
     block&.call(nil)
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/controllers/dashboard_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/app/controllers/dashboard_controller.rbs
@@ -7,4 +7,5 @@ class DashboardController < ApplicationController
   private
 
   def set_current_account: () -> (Account & Account::Validated)?
+  def set_current_viewer: () -> (User & User::Validated)?
 end

--- a/spec/dummy/sig/rbs_infer/app/models/current.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/current.rbs
@@ -1,5 +1,5 @@
 class Current < ActiveSupport::CurrentAttributes
   def self.author_full_name: () -> String?
 
-  def user=: (((User & User::Validated)? | User?) value) -> String
+  def user=: (((User & User::Validated)? | User?) value) -> untyped
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs
@@ -14,6 +14,8 @@ class Current
     def author_name=: (String? value) -> String?
     def account: () -> (Account & Account::Validated)?
     def account=: ((Account & Account::Validated)? value) -> (Account & Account::Validated)?
+    def viewer_name: () -> untyped
+    def viewer_name=: (untyped value) -> untyped
   end
 
   include GeneratedAttributeMethods
@@ -24,7 +26,9 @@ class Current
   def self.author_name=: (String? value) -> String?
   def self.account: () -> (Account & Account::Validated)?
   def self.account=: ((Account & Account::Validated)? value) -> (Account & Account::Validated)?
+  def self.viewer_name: () -> untyped
+  def self.viewer_name=: (untyped value) -> untyped
   def self.__rbs_infer_instance: () -> Current
-  def self.set: (?user: ((User & User::Validated) | User)?, ?author_name: String?, ?account: (Account & Account::Validated)?) ?{ (untyped) -> untyped } -> nil
-  def self.with: (?user: (User & User::Validated)?, ?author_name: String?, ?account: (Account & Account::Validated)?) ?{ (untyped) -> untyped } -> nil
+  def self.set: (?user: ((User & User::Validated) | User)?, ?author_name: String?, ?account: (Account & Account::Validated)?, ?viewer_name: untyped) ?{ (untyped) -> untyped } -> nil
+  def self.with: (?user: (User & User::Validated)?, ?author_name: String?, ?account: (Account & Account::Validated)?, ?viewer_name: untyped) ?{ (untyped) -> untyped } -> nil
 end

--- a/spec/expectations/controllers/dashboard_controller.rbs
+++ b/spec/expectations/controllers/dashboard_controller.rbs
@@ -7,4 +7,5 @@ class DashboardController < ApplicationController
   private
 
   def set_current_account: () -> (Account & Account::Validated)?
+  def set_current_viewer: () -> (User & User::Validated)?
 end

--- a/spec/expectations/models/current.rbs
+++ b/spec/expectations/models/current.rbs
@@ -1,5 +1,5 @@
 class Current < ActiveSupport::CurrentAttributes
   def self.author_full_name: () -> String?
 
-  def user=: (((User & User::Validated)? | User?) value) -> String
+  def user=: (((User & User::Validated)? | User?) value) -> untyped
 end

--- a/spec/expectations/steep_controller_runtime/dashboard_controller.rb
+++ b/spec/expectations/steep_controller_runtime/dashboard_controller.rb
@@ -27,6 +27,9 @@ class DashboardController
     set_current_account
     return if performed?
 
+    set_current_viewer
+    return if performed?
+
     show
 
     return if performed?

--- a/spec/expectations/steep_current_runtime/current.rb
+++ b/spec/expectations/steep_current_runtime/current.rb
@@ -23,6 +23,12 @@ class Current
     def account=(value)
       @account = value
     end
+    def viewer_name
+      @viewer_name
+    end
+    def viewer_name=(value)
+      @viewer_name = value
+    end
   end
   include GeneratedAttributeMethods
 
@@ -53,21 +59,32 @@ class Current
     __rbs_infer_instance.account = value
   end
 
+  def self.viewer_name
+    @viewer_name
+  end
+
+  def self.viewer_name=(value)
+    @viewer_name = value
+    __rbs_infer_instance.viewer_name = value
+  end
+
   def self.__rbs_infer_instance
     @__rbs_infer_instance ||= Current.new
   end
 
-  def self.set(user: nil, author_name: nil, account: nil, &block)
+  def self.set(user: nil, author_name: nil, account: nil, viewer_name: nil, &block)
     @user = user
     @author_name = author_name
     @account = account
+    @viewer_name = viewer_name
     block&.call(nil)
   end
 
-  def self.with(user: nil, author_name: nil, account: nil, &block)
+  def self.with(user: nil, author_name: nil, account: nil, viewer_name: nil, &block)
     @user = user
     @author_name = author_name
     @account = account
+    @viewer_name = viewer_name
     block&.call(nil)
   end
 end


### PR DESCRIPTION
Depends on **felixefelip/steep#102** (which closes steep#102 and steep#103). Merge that first.

Both fixtures came out of one regression report — `Current.caderneta` stopped narrowing in a real app after #125 removed the generator that used to assert it by hand — and each pins a different hole the dummy did not cover.

That gap is the real lesson: **#125 was validated only on the direct write** (`Current.account = current_account`), never on the transitive one that goes through the setter override. Both shapes now live in the dummy.

## `Current#user=` gains the shape apps actually write

Guarded by `unless value.nil?` rather than `&.`, reading an attribute nilable on the base and proven only on the marker:

```ruby
unless value.nil?
  self.viewer_name = value.name     # User#name: String?
end                                 # User::Validated#name: String
```

The param is `(User & User::Validated)?`, and resolving `name` from the first member of that intersection answered `String?` and refused the establishment.

## `DashboardController` gains a handler that cannot halt

```ruby
before_action :set_current_viewer

def set_current_viewer
  Current.user = current_user
end
```

The halting shape was already covered by `ApplicationController#authenticate_user` — and only the halting one got its establishments expanded through the setter override, so the identical write proved less here.

## Result

The action sees all four constants:

```
Current.account, Current.author_name, Current.user, Current.viewer_name
```

Steep baseline unchanged at 30. `bin/rspec-parallel` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)