### PR TITLE
fix(ar_runtime): resolve a has_many element from the owner's namespace outward

### DIFF
--- a/lib/rbs_infer/extensions/rails/active_record/runtime/pseudo_code_builder.rb
+++ b/lib/rbs_infer/extensions/rails/active_record/runtime/pseudo_code_builder.rb
@@ -85,7 +85,7 @@ module RbsInfer
                   # emitting it), so `owner.<assoc>` types via this pseudo-code.
                   # An element outside the scanned models can't be modeled
                   # (its class/proxy may not exist), so it's skipped.
-                  element = @by_class[assoc.class_name]
+                  element = resolve_element(model.class_name, assoc.class_name)
                   next unless element
 
                   plan[model.class_name][:getters] << {
@@ -154,7 +154,7 @@ module RbsInfer
               seen = {}
               @models.flat_map do |owner|
                 owner.has_many.filter_map do |assoc|
-                  element = @by_class[assoc.class_name]
+                  element = resolve_element(owner.class_name, assoc.class_name)
                   next unless element
 
                   ns = proxy_namespace(owner.class_name, element.class_name)
@@ -228,6 +228,28 @@ module RbsInfer
                 ""
               ]
               "#{(header + lines).join("\n")}\n"
+            end
+
+            # The model an association names, resolved the way Ruby (and therefore
+            # `ActiveRecord::Base.compute_type`) resolves the constant: from the owner's
+            # namespace outward. `has_many :recomendacao_vacinas` inside `Caderneta` is
+            # `Caderneta::RecomendacaoVacina` when that exists, and only then the top-level
+            # `RecomendacaoVacina` (felixefelip/rbs_infer#128).
+            #
+            # Matching on the bare `classify` alone silently dropped the association: the
+            # element was not among the scanned models under that name, so neither the
+            # reader nor the proxy reopen was emitted, and `caderneta.recomendacao_vacinas`
+            # had no type at all.
+            def resolve_element(owner_class, element_class)
+              return @by_class[element_class] if element_class.start_with?("::")
+
+              parts = owner_class.split("::")
+              parts.length.downto(0) do |i|
+                candidate = (parts.first(i) + [element_class]).join("::")
+                found = @by_class[candidate]
+                return found if found
+              end
+              nil
             end
 
             # `<Owner>_<Element>` — matches rbs_rails' owner-specific proxy

--- a/spec/lib/rbs_infer/extensions/rails/active_record/runtime_generator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/active_record/runtime_generator_spec.rb
@@ -122,6 +122,46 @@ RSpec.describe RbsInfer::Extensions::Rails::ActiveRecord::RuntimeGenerator do
     end
   end
 
+    # felixefelip/rbs_infer#128. `has_many :recomendacao_vacinas` inside `Caderneta`
+    # resolves to `Caderneta::RecomendacaoVacina` when that exists — Ruby looks a constant
+    # up from the enclosing namespace outward, and `compute_type` follows suit. Matching on
+    # the bare `classify` (`RecomendacaoVacina`) found no scanned model under that name and
+    # dropped the association entirely: no getter, no proxy reopen, and
+    # `caderneta.recomendacao_vacinas` had no type at all.
+    it "resolves a namespaced element from the owner's namespace outward" do
+      in_app(
+        "app/models/caderneta.rb" => <<~RUBY,
+          class Caderneta < ApplicationRecord
+            has_many :recomendacao_vacinas, dependent: :destroy, inverse_of: :caderneta
+          end
+        RUBY
+        "app/models/caderneta/recomendacao_vacina.rb" => <<~RUBY
+          class Caderneta::RecomendacaoVacina < ApplicationRecord
+            belongs_to :caderneta
+          end
+        RUBY
+      ) do |dir|
+        owner = source_of(described_class.new(app_dir: dir).build, "caderneta.rb")
+
+        expect(owner).to match(
+          /def recomendacao_vacinas\n\s*Caderneta_Caderneta_RecomendacaoVacina::ActiveRecord_Associations_CollectionProxy\.new\(Caderneta::RecomendacaoVacina, self\)/
+        )
+      end
+    end
+
+    # The outward walk must not shadow a top-level element with a same-named nested one
+    # that does not exist — `has_many :posts` in `Caderneta` is still `::Post`.
+    it "falls through to the top-level element when the owner has no nested one" do
+      in_app(
+        "app/models/caderneta.rb" => "class Caderneta < ApplicationRecord\n  has_many :posts\nend\n",
+        "app/models/post.rb" => "class Post < ApplicationRecord\n  belongs_to :caderneta\nend\n"
+      ) do |dir|
+        owner = source_of(described_class.new(app_dir: dir).build, "caderneta.rb")
+
+        expect(owner).to match(/Caderneta_Post::ActiveRecord_Associations_CollectionProxy\.new\(Post, self\)/)
+      end
+    end
+
   describe "proxy reopen (construction flow)" do
     it "captures the owner and reopens with build/new/create/create!" do
       in_app("app/models/assignment.rb" => ASSIGNMENT, "app/models/post.rb" => POST) do |dir|


### PR DESCRIPTION
Reported on a real app: `caderneta.recomendacao_vacinas` had no type at all, and the AR runtime pseudo-code simply had no such method.

## Why

```ruby
class Caderneta < ApplicationRecord
  has_many :doses, dependent: :destroy, inverse_of: :caderneta               # emitted
  has_many :recomendacao_vacinas, dependent: :destroy, inverse_of: :caderneta # NOT emitted
end
```

Identical option shapes, so it was never about the options. The model is **namespaced** — `app/models/caderneta/recomendacao_vacina.rb`, i.e. `Caderneta::RecomendacaoVacina`.

The scanner derives the element name with `classify` alone:

```ruby
string_kwarg(call, "class_name") || name.singularize.camelize   # => "RecomendacaoVacina"
```

and the builder looks it up by that exact string:

```ruby
element = @by_class[assoc.class_name]
next unless element                       # ← dropped here, silently
```

Nothing is registered under `RecomendacaoVacina`, so the association produced no getter and no proxy reopen. rbs_rails resolved it correctly — `::Caderneta::RecomendacaoVacina::ActiveRecord_Associations_CollectionProxy`, namespace `Caderneta_Caderneta_RecomendacaoVacina` — which is why that proxy sat there with nothing reopening it.

Ruby resolves a constant from the enclosing namespace outward, and `ActiveRecord::Base.compute_type` follows suit; the generator was the only party matching on the bare name.

## The fix

`resolve_element(owner_class, element_class)` walks the owner's namespace outward, so `Caderneta` + `RecomendacaoVacina` tries `Caderneta::RecomendacaoVacina` first and the top-level name second. A leading `::` is taken literally. Applied at both lookup sites (the getter plan and the proxy reopens).

Same shape as the lexical fallback added to `RbsTypeLookup#lookup_inherited_types` in #124 — constants written inside a namespace mean the nested one when it exists.

## Tests

Both directions, since the risk is symmetric:

- a nested element resolves to the owner's namespace (`Caderneta_Caderneta_RecomendacaoVacina`, constructed with `Caderneta::RecomendacaoVacina`);
- a top-level element still resolves when the owner has no nested one (`has_many :posts` in `Caderneta` stays `::Post`), so the walk cannot shadow.

The dummy has no namespaced `has_many`, so no expectation moves. `bin/rspec-parallel` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)