### PR TITLE
fix: resolve a written constant from the enclosing namespace outward, once (#129)

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -1025,6 +1025,7 @@ end
 require_relative "project/parse_cache"
 require_relative "project/file_index"
 require_relative "project/caller_file_cache"
+require_relative "ast/lexical_constant_resolver"
 require_relative "ast/node_type_inferrer"
 require_relative "ast/constructor_type_inferrer"
 require_relative "inference/known_return_types_builder"

--- a/lib/rbs_infer/ast/lexical_constant_resolver.rb
+++ b/lib/rbs_infer/ast/lexical_constant_resolver.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Nested (rather than the `RbsInfer::AST` shorthand the rest of `ast/` uses) so
+# an extension can require this file on its own, before the core is loaded.
+module RbsInfer
+module AST
+  # Ruby's constant lookup, as far as static analysis can follow it.
+  #
+  # A constant written bare inside `A::B` does NOT mean the top-level constant of
+  # that name: Ruby searches the lexical scope from the inside out, so `Foo` means
+  # `A::B::Foo`, then `A::Foo`, then `::Foo` — first one that exists wins. Matching
+  # the bare name against the top level alone silently misses the nested class the
+  # code actually refers to, and the miss is invisible: the type just comes out
+  # `untyped` (felixefelip/rbs_infer#129).
+  #
+  # That bug was fixed pointwise three times — in `RbsTypeLookup` (#124, an
+  # `include` recorded with its lexical prefix), in the AR runtime's
+  # `PseudoCodeBuilder` (#128, a `has_many` element under the owner's namespace),
+  # and in the call-return path (`TypeMerger` / `MethodTypeResolver`, a namespaced
+  # service called by its bare name) — before being centralized here.
+  #
+  # Deliberately knows nothing about WHERE constants live: callers supply the
+  # existence oracle (a source-file index, an RBS declaration index, a hash of
+  # scanned models). This module only decides the ORDER to try.
+  module LexicalConstantResolver
+    module_function
+
+    # The candidate constant paths for `name` written inside `enclosing`, in
+    # Ruby's search order (innermost scope first).
+    #
+    #   candidates(name: "Foo", enclosing: "A::B")  # => ["A::B::Foo", "A::Foo", "Foo"]
+    #
+    # A leading `::` is absolute — Ruby skips the lexical walk entirely — so the
+    # only candidate is the name itself, normalized without the prefix (every
+    # index in this project keys classes unprefixed).
+    #
+    # `enclosing` may be nil or empty (top-level code), which yields just `name`.
+    # A qualified `name` (`Foo::Bar`) walks the same way: `A::B::Foo::Bar`,
+    # `A::Foo::Bar`, `Foo::Bar` — Ruby resolves the FIRST segment lexically and
+    # the rest relative to it.
+    def candidates(name:, enclosing:)
+      return [] if name.nil? || name.empty?
+      return [name.delete_prefix("::")] if name.start_with?("::")
+
+      scopes = (enclosing || "").delete_prefix("::").split("::").reject(&:empty?)
+      scopes.length.downto(0).map { |i| (scopes.first(i) + [name]).join("::") }.uniq
+    end
+
+    # The same walk for a path that ALREADY carries its lexical prefix joined onto
+    # the written name — the shape a collector records when it concatenates the
+    # enclosing scope at parse time and only the joined string survives.
+    #
+    #   candidates_for("A::B::Foo")  # => ["A::B::Foo", "A::Foo", "Foo"]
+    #
+    # The written name is taken to be the LAST segment. A written `Foo::Bar` is
+    # therefore under-approximated (`A::Foo::Bar` is not generated) — the joined
+    # form has genuinely lost the boundary, which is why a caller that still has
+    # both parts should use `candidates` instead.
+    def candidates_for(path)
+      return [] if path.nil? || path.empty?
+
+      parts = path.delete_prefix("::").split("::")
+      candidates(name: parts.last, enclosing: parts[0..-2].join("::"))
+    end
+
+    # The first candidate the block accepts, or nil when none does. The block is
+    # the existence oracle — it receives each candidate path in search order and
+    # returns truthy for one that exists.
+    def resolve(name:, enclosing:, &exists)
+      candidates(name: name, enclosing: enclosing).find(&exists)
+    end
+  end
+end
+end

--- a/lib/rbs_infer/extensions/rails/active_record/runtime/pseudo_code_builder.rb
+++ b/lib/rbs_infer/extensions/rails/active_record/runtime/pseudo_code_builder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/string/inflections"
+require_relative "../../../../ast/lexical_constant_resolver"
 
 module RbsInfer
   module Extensions
@@ -239,17 +240,15 @@ module RbsInfer
             # Matching on the bare `classify` alone silently dropped the association: the
             # element was not among the scanned models under that name, so neither the
             # reader nor the proxy reopen was emitted, and `caderneta.recomendacao_vacinas`
-            # had no type at all.
+            # had no type at all. The walk itself lives in `LexicalConstantResolver` —
+            # shared with every other site that turns a written constant into a class
+            # (felixefelip/rbs_infer#129); the scanned-model table is the oracle.
             def resolve_element(owner_class, element_class)
-              return @by_class[element_class] if element_class.start_with?("::")
+              found = RbsInfer::AST::LexicalConstantResolver.resolve(
+                name: element_class, enclosing: owner_class
+              ) { |candidate| @by_class.key?(candidate) }
 
-              parts = owner_class.split("::")
-              parts.length.downto(0) do |i|
-                candidate = (parts.first(i) + [element_class]).join("::")
-                found = @by_class[candidate]
-                return found if found
-              end
-              nil
+              found && @by_class[found]
             end
 
             # `<Owner>_<Element>` — matches rbs_rails' owner-specific proxy

--- a/lib/rbs_infer/inference/type_merger.rb
+++ b/lib/rbs_infer/inference/type_merger.rb
@@ -156,7 +156,7 @@ module RbsInfer::Inference
 
         # 2. Klass.new(...) na última expressão
         if last_stmt.is_a?(Prism::CallNode) && last_stmt.name == :new && last_stmt.receiver
-          class_name = RbsInfer::Analyzer.extract_constant_path(last_stmt.receiver)
+          class_name = constant_receiver_class(last_stmt.receiver, method_type_resolver)
           if class_name
             member.signature = member.signature.sub(/-> untyped\z/, "-> #{RbsInfer::Signatures::RbsParserUtil.parenthesize_union(class_name)}")
             own_return_types[method_name] = class_name
@@ -281,6 +281,17 @@ module RbsInfer::Inference
       return node.name.to_s if node.receiver.nil? || node.receiver.is_a?(Prism::SelfNode)
     end
 
+    # The class a constant receiver names, resolved the way Ruby resolves it:
+    # from the enclosing class outward, so `Archiver.new(...)` written inside
+    # `Post` is `Post::Archiver` when that exists (felixefelip/rbs_infer#129).
+    # `@target_class` IS the lexical scope of every body this merger walks.
+    def constant_receiver_class(node, method_type_resolver)
+      name = RbsInfer::Analyzer.extract_constant_path(node) or return nil
+      return name unless method_type_resolver
+
+      method_type_resolver.qualify_constant(name, enclosing: @target_class)
+    end
+
     # Resolve return type de receiver.method() ou method() com args
     def infer_call_return_type(call_node, self_ctx, method_type_resolver, local_types: {})
       result = if call_node.attribute_write?
@@ -302,7 +313,7 @@ module RbsInfer::Inference
       elsif call_node.name == :new && call_node.receiver
         # `Foo.new` → instance of Foo; `self.new` → instance of the class
         # being generated (felixefelip/rbs_infer#35).
-        RbsInfer::Analyzer.extract_constant_path(call_node.receiver) ||
+        constant_receiver_class(call_node.receiver, method_type_resolver) ||
           (call_node.receiver.is_a?(Prism::SelfNode) ? self_ctx.target_class : nil)
       else
         # receiver.method → resolver tipo do receiver, depois do method
@@ -347,7 +358,7 @@ module RbsInfer::Inference
         elsif node.name == :new && node.receiver
           # `Foo.new` → instance of Foo; `self.new` → instance of the class
           # being generated (felixefelip/rbs_infer#35).
-          RbsInfer::Analyzer.extract_constant_path(node.receiver) ||
+          constant_receiver_class(node.receiver, method_type_resolver) ||
             (node.receiver.is_a?(Prism::SelfNode) ? self_ctx.target_class : nil)
         else
           parent_type = resolve_receiver_type(node.receiver, self_ctx, method_type_resolver, local_types: local_types)
@@ -365,7 +376,7 @@ module RbsInfer::Inference
       when Prism::SelfNode
         nil
       when Prism::ConstantReadNode, Prism::ConstantPathNode
-        RbsInfer::Analyzer.extract_constant_path(node)
+        constant_receiver_class(node, method_type_resolver)
       when Prism::LocalVariableReadNode
         local_types[node.name.to_s] || self_ctx.own_types[node.name.to_s]
       end

--- a/lib/rbs_infer/signatures/method_type_resolver.rb
+++ b/lib/rbs_infer/signatures/method_type_resolver.rb
@@ -35,6 +35,27 @@ module RbsInfer::Signatures
       @rbs_definition_resolver.type_param_string(class_name)
     end
 
+    # A constant as WRITTEN in source, resolved to the class it actually names.
+    # Ruby searches the lexical scope from the inside out, so `Archiver` written
+    # inside `Post` is `Post::Archiver` when that exists (felixefelip/rbs_infer#129).
+    #
+    # `enclosing` is required, not defaulted: a call site that forgets to pass its
+    # lexical context does not fail — it resolves the bare name against the top
+    # level, finds nothing, and yields `untyped`. That silent degradation is
+    # exactly how this bug survived three pointwise fixes
+    # (docs/engineering/required-threaded-deps.md).
+    #
+    # Returns `name` unchanged when no candidate is known, so a constant this
+    # project cannot see (stdlib, a gem, a dynamically defined class) keeps
+    # flowing to the resolvers that can.
+    def qualify_constant(name, enclosing:)
+      return name unless name
+
+      RbsInfer::AST::LexicalConstantResolver.resolve(name: name, enclosing: enclosing) do |candidate|
+        known_class?(candidate)
+      end || name
+    end
+
     def resolve(class_name, method_name, block_body_type: nil)
       return nil unless class_name && class_name != "untyped"
 
@@ -428,6 +449,18 @@ module RbsInfer::Signatures
     def find_class_file(class_name)
       class_path = RbsInfer.class_name_to_path(class_name)
       @file_index.find(class_path)
+    end
+
+    # Existence oracle for `qualify_constant`: a class this project can see, either
+    # as a source file or as an RBS declaration (rbs_rails output, a gem shim, a
+    # previous pass's `sig/`). Memoized — the walk asks about the same candidates
+    # repeatedly across a file's methods.
+    def known_class?(candidate)
+      @known_class_cache ||= {}
+      return @known_class_cache[candidate] if @known_class_cache.key?(candidate)
+
+      @known_class_cache[candidate] =
+        !find_class_file(candidate).nil? || RbsTypeLookup.files_declaring(candidate).any?
     end
 
     # Inferir return type a partir de literais ou Klass.new na última expressão

--- a/lib/rbs_infer/signatures/rbs_type_lookup.rb
+++ b/lib/rbs_infer/signatures/rbs_type_lookup.rb
@@ -1,4 +1,5 @@
 require_relative "rbs_parser_util"
+require_relative "../ast/lexical_constant_resolver"
 
 module RbsInfer::Signatures
   # Busca e parseia arquivos RBS para resolver tipos de classes,
@@ -268,14 +269,18 @@ module RbsInfer::Signatures
       # 2c. Lexical outward lookup, the way Ruby resolves a constant. An `include Foo`
       #     written inside `module A` is recorded with its lexical prefix (`A::Foo`) —
       #     correct, but `A::Foo` usually does not exist and the constant IS the
-      #     top-level `::Foo`. Peel the enclosing scopes off and take the first that
-      #     resolves, which is exactly Ruby's rule (felixefelip/rbs_infer#124: the Devise
-      #     sidecar's `module ActionController; class Base; include DeviseScopedHelpers`).
+      #     top-level `::Foo`. Drop the enclosing scopes from the inside out and take
+      #     the first that resolves, which is exactly Ruby's rule (felixefelip/rbs_infer
+      #     #124: the Devise sidecar's `module ActionController; class Base; include
+      #     DeviseScopedHelpers`).
+      #
+      #     Shared with every other site that resolves a written constant
+      #     (felixefelip/rbs_infer#129). The hand-rolled version here peeled segments off
+      #     the FRONT (`A::B::Foo` → `B::Foo` → `Foo`), which is not Ruby's order:
+      #     `B::Foo` is not a candidate at all, and a real `A::Foo` was never tried.
       if types.empty? && parent_superclass.nil? && all_includes.empty?
-        parts = normalized.split("::")
-        (1...parts.size).each do |i|
-          candidate = parts[i..].join("::")
-          next if visited.include?(candidate)
+        RbsInfer::AST::LexicalConstantResolver.candidates_for(normalized).each do |candidate|
+          next if candidate == normalized || visited.include?(candidate)
 
           outer = lookup_inherited_types(candidate, visited)
           next if outer.empty?

--- a/spec/dummy/app/models/post.rb
+++ b/spec/dummy/app/models/post.rb
@@ -92,6 +92,19 @@ class Post < ApplicationRecord
     end
   end
 
+  # `Archiver` is `Post::Archiver` — written bare, as Ruby resolves it from the
+  # enclosing namespace outward. Both the instance path (`.new(...).call`, a
+  # CHAINED call) and the singleton path (`.run`, a direct constant receiver)
+  # have to find it; matching the bare name against top-level `Archiver` finds
+  # nothing and silently yields `untyped` (felixefelip/rbs_infer#129).
+  def archive
+    Archiver.new(self).call
+  end
+
+  def archive_via_singleton
+    Archiver.run(self)
+  end
+
   def test_enumerize_status
     Post.status
   end

--- a/spec/dummy/app/models/post/archiver.rb
+++ b/spec/dummy/app/models/post/archiver.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# A namespaced service object, the shape Rails apps write it in: the class lives
+# under the model's namespace (`app/models/post/archiver.rb`) and the model calls
+# it by its BARE name, because Ruby resolves a constant from the enclosing
+# namespace outward (felixefelip/rbs_infer#129).
+class Post
+  class Archiver
+    def initialize(post)
+      @post = post
+    end
+
+    # Mirrors the real shape this was found in: the service reaches back through
+    # the model into an association, so the return type is the owner-specific
+    # collection proxy — a type that only exists because the association was itself
+    # resolved from the owner's namespace (felixefelip/rbs_infer#128).
+    def call
+      @post.comments.each(&:touch)
+    end
+
+    def self.run(post)
+      new(post).call
+    end
+  end
+end

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -8,6 +8,10 @@ app/models/coupon/code.rb:
   anchor: Code
   annotations:
   - "# @type instance: Coupon & Coupon::Code"
+app/models/post/archiver.rb:
+  anchor: Archiver
+  annotations:
+  - "# @type instance: Post & Post::Archiver"
 app/models/post/notifiable.rb:
   anchor: Notifiable
   annotations:

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -487,6 +487,11 @@ postconditions:
   effects:
     may_write:
     - "@xml"
+- class: Post::Archiver
+  method: initialize
+  effects:
+    may_write:
+    - "@post"
 - class: PostPublisher
   method: initialize
   effects:

--- a/spec/dummy/sig/rbs_infer/app/models/post.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/post.rbs
@@ -16,6 +16,8 @@ class Post < ApplicationRecord
   def was_priority_high: () -> bool?
   def publish_in_transaction: () -> self
   def iterate_tags: () -> Post_Tag::ActiveRecord_Associations_CollectionProxy
+  def archive: () -> Post_Comment::ActiveRecord_Associations_CollectionProxy
+  def archive_via_singleton: () -> Post_Comment::ActiveRecord_Associations_CollectionProxy
   def test_enumerize_status: () -> Post::EnumerizeStatusAttribute
   def test_enumerize_status_options: () -> Array[Array[untyped]]
   def user_email: () -> String?

--- a/spec/dummy/sig/rbs_infer/app/models/post/archiver.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/post/archiver.rbs
@@ -1,0 +1,10 @@
+class Post
+  class Archiver
+    @post: Post
+
+    def self.run: (Post post) -> Post_Comment::ActiveRecord_Associations_CollectionProxy
+
+    def initialize: (Post post) -> void
+    def call: () -> Post_Comment::ActiveRecord_Associations_CollectionProxy
+  end
+end

--- a/spec/expectations/models/post.rbs
+++ b/spec/expectations/models/post.rbs
@@ -16,6 +16,8 @@ class Post < ApplicationRecord
   def was_priority_high: () -> bool?
   def publish_in_transaction: () -> self
   def iterate_tags: () -> Post_Tag::ActiveRecord_Associations_CollectionProxy
+  def archive: () -> Post_Comment::ActiveRecord_Associations_CollectionProxy
+  def archive_via_singleton: () -> Post_Comment::ActiveRecord_Associations_CollectionProxy
   def test_enumerize_status: () -> Post::EnumerizeStatusAttribute
   def test_enumerize_status_options: () -> Array[Array[untyped]]
   def user_email: () -> String?

--- a/spec/expectations/models/post/archiver.rbs
+++ b/spec/expectations/models/post/archiver.rbs
@@ -1,0 +1,10 @@
+class Post
+  class Archiver
+    @post: Post
+
+    def self.run: (Post post) -> Post_Comment::ActiveRecord_Associations_CollectionProxy
+
+    def initialize: (Post post) -> void
+    def call: () -> Post_Comment::ActiveRecord_Associations_CollectionProxy
+  end
+end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -89,6 +89,14 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     assert_snapshot("models/palette", target_class: "Palette", target_file: "app/models/palette.rb")
   end
 
+  # A namespaced service object called by its BARE name from the model that
+  # encloses it (felixefelip/rbs_infer#129). The interesting half is `Post#archive` /
+  # `#archive_via_singleton` in the Post snapshot above: `Archiver` there is
+  # `Post::Archiver`, resolved from the enclosing namespace outward.
+  it "Post::Archiver (namespaced service) matches expected RBS" do
+    assert_snapshot("models/post/archiver", target_class: "Post::Archiver", target_file: "app/models/post/archiver.rb")
+  end
+
   it "Coupon::Code (constant argument) matches expected RBS" do
     assert_snapshot("models/coupon/code", target_class: "Coupon::Code", target_file: "app/models/coupon/code.rb")
   end

--- a/spec/lib/rbs_infer/ast/lexical_constant_resolver_spec.rb
+++ b/spec/lib/rbs_infer/ast/lexical_constant_resolver_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# felixefelip/rbs_infer#129. The ORDER is the whole contract: three components had
+# each hand-rolled their own walk, and one of them (RbsTypeLookup's step 2c) peeled
+# segments off the wrong end, generating candidates Ruby would never try while
+# skipping ones it would.
+RSpec.describe RbsInfer::AST::LexicalConstantResolver do
+  describe ".candidates" do
+    it "walks the enclosing scopes from the inside out" do
+      expect(described_class.candidates(name: "Foo", enclosing: "A::B"))
+        .to eq(["A::B::Foo", "A::Foo", "Foo"])
+    end
+
+    it "yields only the name at top level" do
+      expect(described_class.candidates(name: "Foo", enclosing: nil)).to eq(["Foo"])
+      expect(described_class.candidates(name: "Foo", enclosing: "")).to eq(["Foo"])
+    end
+
+    it "skips the walk for an absolute reference" do
+      # `::Foo` inside `A::B` is the top-level constant, full stop — Ruby does not
+      # consider `A::B::Foo` at all, so neither may we.
+      expect(described_class.candidates(name: "::Foo", enclosing: "A::B")).to eq(["Foo"])
+    end
+
+    it "resolves the first segment of a qualified name lexically" do
+      expect(described_class.candidates(name: "Foo::Bar", enclosing: "A"))
+        .to eq(["A::Foo::Bar", "Foo::Bar"])
+    end
+
+    it "returns nothing for an absent name" do
+      expect(described_class.candidates(name: nil, enclosing: "A")).to eq([])
+      expect(described_class.candidates(name: "", enclosing: "A")).to eq([])
+    end
+  end
+
+  describe ".candidates_for" do
+    it "drops the joined prefix from the inside out" do
+      # NOT `B::Foo` — that is what the front-peeling version produced, and it is
+      # not a candidate under Ruby's rule.
+      expect(described_class.candidates_for("A::B::Foo")).to eq(["A::B::Foo", "A::Foo", "Foo"])
+    end
+
+    it "leaves a bare name alone" do
+      expect(described_class.candidates_for("Foo")).to eq(["Foo"])
+    end
+  end
+
+  describe ".resolve" do
+    it "takes the innermost candidate the oracle accepts" do
+      known = ["A::Foo", "Foo"].to_set
+
+      expect(described_class.resolve(name: "Foo", enclosing: "A::B") { |c| known.include?(c) })
+        .to eq("A::Foo")
+    end
+
+    it "is nil when no candidate exists, so the caller can keep the written name" do
+      expect(described_class.resolve(name: "Foo", enclosing: "A") { false }).to be_nil
+    end
+  end
+end

--- a/spec/lib/rbs_infer/signatures/method_type_resolver_spec.rb
+++ b/spec/lib/rbs_infer/signatures/method_type_resolver_spec.rb
@@ -210,4 +210,91 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
       expect(resolver.resolve("(LeftClass & RightClass)", "shared")).to eq("Symbol")
     end
   end
+
+  # felixefelip/rbs_infer#129: a namespaced service called by its bare name from
+  # the model that encloses it — `Archiver.new(self).call` inside `class Post`,
+  # where the class is `Post::Archiver`.
+  describe "#qualify_constant" do
+    let(:namespaced_service) do
+      {
+        "post.rb" => <<~RUBY,
+          class Post
+            def archive
+              Archiver.new(self).call
+            end
+          end
+        RUBY
+        "post/archiver.rb" => <<~RUBY
+          class Post
+            class Archiver
+              #: -> String
+              def call
+                "archived"
+              end
+            end
+          end
+        RUBY
+      }
+    end
+
+    it "resolves a bare constant against the enclosing namespace" do
+      with_temp_files(namespaced_service) do |dir, paths|
+        resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
+        expect(resolver.qualify_constant("Archiver", enclosing: "Post")).to eq("Post::Archiver")
+      end
+    end
+
+    # The sharp case: a top-level class shares the short name, so the SAME written
+    # constant names two different classes depending on where it is written. Without
+    # the enclosing scope there is no answer to give — only a coin flip.
+    it "gives the same written name two answers, one per enclosing scope" do
+      files = namespaced_service.merge(
+        "archiver.rb" => <<~RUBY,
+          class Archiver
+            #: -> Integer
+            def call
+              0
+            end
+          end
+        RUBY
+        "comment.rb" => <<~RUBY
+          class Comment
+            def archive
+              Archiver.new.call
+            end
+          end
+        RUBY
+      )
+
+      with_temp_files(files) do |dir, paths|
+        resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
+
+        expect(resolver.qualify_constant("Archiver", enclosing: "Post")).to eq("Post::Archiver")
+        expect(resolver.qualify_constant("Archiver", enclosing: "Comment")).to eq("Archiver")
+
+        # Only the qualified name reaches the RBS declaration, which is where a
+        # real project's types come from (rbs_rails output, a previous pass's
+        # `sig/`). The source fallback is more forgiving — `FileIndex` matches on a
+        # path SUFFIX, so even a bare `Archiver` finds `post/archiver.rb` — which is
+        # precisely why this miss went unnoticed: it degraded only on the RBS path.
+        expect(resolver.resolve("Post::Archiver", "call")).to eq("String")
+      end
+    end
+
+    it "keeps a constant that is not the enclosing namespace's" do
+      with_temp_files(namespaced_service) do |dir, paths|
+        resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
+        expect(resolver.qualify_constant("Post", enclosing: "Post")).to eq("Post")
+      end
+    end
+
+    # An unknown constant (stdlib, a gem, something generated at runtime) has to
+    # flow through untouched, so the resolvers that CAN see it still get a chance.
+    it "returns the written name when no candidate is known" do
+      with_temp_files(namespaced_service) do |dir, paths|
+        resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
+        expect(resolver.qualify_constant("Time", enclosing: "Post")).to eq("Time")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #129.

Ruby searches the lexical scope from the inside out: `Archiver` written inside `class Post` means `Post::Archiver` before it means the top-level `::Archiver`. Three components each matched the bare name instead, and each was fixed on its own — #124 (`RbsTypeLookup`, an `include` recorded with its lexical prefix), #128 (`PseudoCodeBuilder`, a `has_many` element under the owner's namespace), and the call-return path (a namespaced service called bare).

## The shared resolver

`AST::LexicalConstantResolver` decides only the **order** to try:

```ruby
candidates(name: "Foo", enclosing: "A::B")  # => ["A::B::Foo", "A::Foo", "Foo"]
candidates_for("A::B::Foo")                 # => ["A::B::Foo", "A::Foo", "Foo"]
resolve(name:, enclosing:) { |candidate| ... }
```

Each caller supplies its own existence oracle — the scanned-model table, the source+RBS index, the RBS declaration walk — so the resolver never learns where classes live. A leading `::` skips the walk, as Ruby does.

Routed through it:

| site | oracle |
|---|---|
| `RbsTypeLookup#lookup_inherited_types` (2c) | recursive RBS lookup |
| `PseudoCodeBuilder#resolve_element` | scanned models |
| `TypeMerger` constant receivers (4 sites) | `MethodTypeResolver#qualify_constant` |

### A latent bug in the copy that was "already fixed"

`RbsTypeLookup`'s hand-rolled walk peeled segments off the **front** — `A::B::Foo` → `B::Foo` → `Foo`. `B::Foo` is not a candidate Ruby would ever try, and a real `A::Foo` was never tried at all. It happened to work for #124 only because that name was two segments deep, where both orders coincide.

### Required, not defaulted

`qualify_constant(name, enclosing:)` takes `enclosing:` as a required kwarg. A site that forgets it does not fail — it looks the bare name up at the top level, finds nothing, and yields `untyped`. That silent degradation is exactly how this survived three pointwise fixes (`docs/engineering/required-threaded-deps.md`).

## Fixture

`spec/dummy/app/models/post/archiver.rb` — a namespaced service called bare from the model and reaching back through an association, mirroring the shape all three were found in. Both call forms are covered: `Archiver.new(self).call` (a chained call) and `Archiver.run(self)` (a direct constant receiver).

**The snapshot does not pin the fix, and I want to be explicit about that.** Measured by stashing `lib/` and regenerating: in the dummy, Steep's return-type oracle resolves this shape on its own, so `models/post.rbs` converges either way. What pins the fix is the unit specs — `resolve` reaches the RBS declaration only under the qualified name, and the same written constant gets two different answers depending on the scope it is written in.

Related, and worth knowing: `FileIndex` matches on a path **suffix**, so a bare `Archiver` still finds `post/archiver.rb` through the source fallback. Only the RBS path — where a real project's types actually come from — degraded. That asymmetry is why the miss stayed invisible.

## Verification

783 examples, 0 failures (unit + integration, including the Steep baseline over the dummy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)