### PR TITLE
fix: read call sites that reach a class through a value, not its name (#131)

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -792,7 +792,15 @@ module RbsInfer
     # constant-reference index misses them. For a module target, fold in the
     # mixin graph and force bare-call matching on those files (#64).
     reaching = @is_module ? mixin_index.files_reaching(@target_class).to_set : Set.new
-    (referencing.to_set | reaching).each do |file|
+
+    # A caller that reaches the target through a VALUE — an ivar, a local, a
+    # `Current.<attr>` — never spells the class name, so the constant index above
+    # does not return it. Add the files that call one of the target's own methods
+    # on some receiver; `match_class?` still has to prove that receiver is the
+    # target before the call site is used (felixefelip/rbs_infer#131).
+    calling = target_methods.keys.flat_map { |m| @source_index.files_calling(m) }.to_set
+
+    (referencing.to_set | reaching | calling).each do |file|
       analyzer.analyze(file, force_bare: reaching.include?(file))
     end
 

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -277,12 +277,45 @@ module RbsInfer::Inference
 
     def match_class?(name)
       normalized_target = @target_class.sub(/\A::/, "")
-      # A marker-decorated receiver is an intersection (`Caderneta &
-      # Caderneta::Validated`); match if any component is the target.
-      intersection_components(name).any? do |component|
+      receiver_components(name).any? do |component|
         normalized_name = component.sub(/\A::/, "")
         next true if normalized_name == normalized_target
         relative_receiver_matches_target?(normalized_name, normalized_target)
+      end
+    end
+
+    # Every nominal type the receiver could hold at the moment of the call.
+    #
+    # An intersection is the marker-decorated shape (`Caderneta &
+    # Caderneta::Validated`) — any component identifies the receiver. A union is
+    # every branch the ivar was written with. And `T?` is `T`: the call is being
+    # MADE on it, so at runtime it is a `T` or the program raises — the same
+    # optimism `MethodTypeResolver#resolve` already applies when it drops the `?`
+    # before looking a method up.
+    #
+    # Decomposing only the intersection is what silently dropped every
+    # `Current.<attr>.method(arg)` call site: a CurrentAttributes reader is
+    # honestly nilable (per-request reset), so its type arrives as
+    # `(Caderneta & Caderneta::Validated)?` and the whole string was compared
+    # against `Caderneta` (felixefelip/rbs_infer#131).
+    def receiver_components(type_str)
+      flatten_receiver_type(RBS::Parser.parse_type(type_str))
+    rescue RBS::ParsingError, RBS::BaseError
+      # A spelling RBS cannot parse still gets the legacy intersection split, so
+      # nothing that matched before stops matching.
+      intersection_components(type_str)
+    end
+
+    def flatten_receiver_type(type)
+      case type
+      when RBS::Types::Union, RBS::Types::Intersection
+        type.types.flat_map { |t| flatten_receiver_type(t) }
+      when RBS::Types::Optional
+        flatten_receiver_type(type.type)
+      when RBS::Types::Bases::Nil
+        []
+      else
+        [type.to_s]
       end
     end
 

--- a/lib/rbs_infer/project/source_index.rb
+++ b/lib/rbs_infer/project/source_index.rb
@@ -10,13 +10,24 @@ module RbsInfer::Project
   #
   # O lookup por classe é O(1) em vez de O(n).
   class SourceIndex
+    # A method name as written after a dot — `Current.caderneta.qtde_por_vacina(v)`
+    # contributes `caderneta` and `qtde_por_vacina`. Only explicit-receiver calls,
+    # which is exactly the shape the constant index cannot see (see
+    # `files_calling`); bare calls are covered by the mixin graph.
+    RECEIVER_CALL = /\.\s*([a-z_][a-zA-Z0-9_]*[?!]?)/
+
     def initialize(source_files)
       @index = Hash.new { |h, k| h[k] = [] }
+      @call_index = Hash.new { |h, k| h[k] = [] }
       source_files.each do |file|
         begin
           content = File.read(file)
         rescue Errno::ENOENT, Errno::EACCES
           next
+        end
+
+        content.scan(RECEIVER_CALL).flatten.uniq.each do |method_name|
+          @call_index[method_name] << file
         end
         # `_` faz parte do nome da constante: proxies de associação do
         # rbs_rails (`Post_Assignment`, `ActiveRecord_Associations_CollectionProxy`)
@@ -37,6 +48,7 @@ module RbsInfer::Project
         end
       end
       @index.each_value(&:freeze)
+      @call_index.each_value(&:freeze)
     end
 
     # Retorna arquivos que provavelmente referenciam a classe.
@@ -44,6 +56,25 @@ module RbsInfer::Project
     def files_referencing(class_name)
       short_name = class_name.split("::").last
       @index[short_name] || EMPTY_ARRAY
+    end
+
+    # Files that call `method_name` on SOME receiver.
+    #
+    # `files_referencing` asks "does this file spell the class name?", which is the
+    # wrong question for a call whose receiver is a value rather than the constant:
+    # `Current.caderneta.qtde_por_fabricante_vacina(fabricante_vacina)` never writes
+    # `Caderneta`, so the file was not a candidate caller and the argument's type was
+    # never read — the parameter stayed `untyped` with no diagnostic
+    # (felixefelip/rbs_infer#131). Views hit this constantly (an ERB template rarely
+    # names a model), but it is not ERB-specific: any file reaching the target through
+    # an ivar, a local, or a CurrentAttributes reader is invisible the same way.
+    #
+    # This is a CANDIDATE filter, not a match: `NewCallCollector#match_class?` still
+    # has to resolve the receiver's type to the target before the call site counts.
+    # Callers only ask about methods that TAKE parameters, which keeps the query off
+    # the high-cardinality accessor names (`name`, `id`, `to_s`).
+    def files_calling(method_name)
+      @call_index[method_name] || EMPTY_ARRAY
     end
 
     EMPTY_ARRAY = [].freeze

--- a/spec/dummy/app/models/account.rb
+++ b/spec/dummy/app/models/account.rb
@@ -19,4 +19,11 @@ class Account < ApplicationRecord
   def label
     "#{display_name} <#{email}>"
   end
+
+  # The other half of the same gap, isolated: the receiver here is a plain view ivar
+  # (`@account`), so the nilable-receiver fix is not what this needs — only the
+  # candidate-caller one. The template still never writes `Account`.
+  def matches?(post)
+    display_name == post.title
+  end
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -32,4 +32,13 @@ class User < ApplicationRecord
   def recent_posts(limit = 5)
     posts.order(created_at: :desc).limit(limit)
   end
+
+  # Called from ONE place: dashboard/show.html.erb, on a `Current.user` receiver,
+  # inside `@recent_posts.each do |post|`. Both halves of that call site used to be
+  # invisible (felixefelip/rbs_infer#131) — the template never spells `User`, so it
+  # was not a candidate caller, and `Current.user` is nilable, so its type never
+  # matched the target. `post` is typed here only because both were fixed.
+  def posts_titled_like(post)
+    posts.where(title: post.title).count
+  end
 end

--- a/spec/dummy/app/views/dashboard/show.html.erb
+++ b/spec/dummy/app/views/dashboard/show.html.erb
@@ -21,5 +21,12 @@
   <% @recent_posts.each do |post| %>
     <h3><%= link_to post.title, post %></h3>
     <span><%= post.author_name %></span>
+
+    <%# Two call sites into models that this template never names. `post` is the block
+        parameter of the iteration above, so its type comes from the collection element
+        — the argument side always worked; what did not was the template being read as
+        a caller at all (felixefelip/rbs_infer#131). %>
+    <span><%= Current.user.posts_titled_like(post) %></span>
+    <span><%= @account.matches?(post) %></span>
   <% end %>
 </div>

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -916,6 +916,13 @@ method_entry_facts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
     Current.viewer_name: "::String"
+- class: Account
+  method: matches?
+  consts:
+    Current.account: "(::Account & ::Account::Validated)"
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: ApplicationController
   method: current_user
   ivars:
@@ -1353,6 +1360,13 @@ method_entry_facts:
   method: test_hash
   ivars:
     "@xml": "::Nokogiri::XML::Document"
+- class: User
+  method: posts_titled_like
+  consts:
+    Current.account: "(::Account & ::Account::Validated)"
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: User
   method: recent_posts
   consts:

--- a/spec/dummy/sig/rbs_infer/app/models/account.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/account.rbs
@@ -1,3 +1,4 @@
 class Account < ApplicationRecord
   def label: () -> String
+  def matches?: ((Post & Post::Validated) post) -> bool
 end

--- a/spec/dummy/sig/rbs_infer/app/models/user.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/user.rbs
@@ -8,4 +8,5 @@ class User < ApplicationRecord
   def active?: () -> bool?
   def posts_count: () -> Integer
   def recent_posts: (?Integer limit) -> User_Post::ActiveRecord_Associations_CollectionProxy
+  def posts_titled_like: ((Post & Post::Validated) post) -> Integer
 end

--- a/spec/expectations/models/account.rbs
+++ b/spec/expectations/models/account.rbs
@@ -1,3 +1,4 @@
 class Account < ApplicationRecord
   def label: () -> String
+  def matches?: ((Post & Post::Validated) post) -> bool
 end

--- a/spec/expectations/models/user.rbs
+++ b/spec/expectations/models/user.rbs
@@ -8,4 +8,5 @@ class User < ApplicationRecord
   def active?: () -> bool?
   def posts_count: () -> Integer
   def recent_posts: (?Integer limit) -> User_Post::ActiveRecord_Associations_CollectionProxy
+  def posts_titled_like: ((Post & Post::Validated) post) -> Integer
 end

--- a/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
@@ -342,6 +342,66 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
       expect(visitor.method_call_usages["qtde_por_vacina"]).to eq([{ "vacina" => "Vacina" }])
     end
 
+    # felixefelip/rbs_infer#131. Decomposing only the intersection left every
+    # NILABLE receiver unmatched, and a CurrentAttributes reader is honestly nilable
+    # (per-request reset) — so `Current.<attr>.method(arg)` never contributed an
+    # argument type anywhere in the app, silently.
+    {
+      "nilable" => "(Caderneta & Caderneta::Validated)?",
+      "union of the ivar's write shapes" => "((Caderneta & Caderneta::Validated) | Caderneta)?",
+      "plain nilable, no marker" => "Caderneta?"
+    }.each do |shape, receiver_type|
+      it "matches a target call whose receiver resolves to a #{shape} type" do
+        source = "caderneta.qtde_por_vacina(v)"
+        result = Prism.parse(source)
+        visitor = described_class.new(
+          target_class: "Caderneta",
+          method_return_types: { "caderneta" => receiver_type, "v" => "Vacina" },
+          local_var_types: {},
+          target_methods: { "qtde_por_vacina" => ["vacina"] },
+          constant_arg_resolver: null_constant_resolver,
+          defined_class_names: described_class.collect_defined_class_names(result.value)
+        )
+        result.value.accept(visitor)
+
+        expect(visitor.method_call_usages["qtde_por_vacina"]).to eq([{ "vacina" => "Vacina" }])
+      end
+    end
+
+    it "still refuses a receiver that is not the target" do
+      source = "vacina.qtde_por_vacina(v)"
+      result = Prism.parse(source)
+      visitor = described_class.new(
+        target_class: "Caderneta",
+        method_return_types: { "vacina" => "(Vacina & Vacina::Validated)?", "v" => "Vacina" },
+        local_var_types: {},
+        target_methods: { "qtde_por_vacina" => ["vacina"] },
+        constant_arg_resolver: null_constant_resolver,
+        defined_class_names: described_class.collect_defined_class_names(result.value)
+      )
+      result.value.accept(visitor)
+
+      expect(visitor.method_call_usages).to be_empty
+    end
+
+    # `singleton(Caderneta)` is the CLASS, not an instance of it. A class-method
+    # call must not be read as a call on an instance.
+    it "does not match a singleton receiver against the instance target" do
+      source = "klass.qtde_por_vacina(v)"
+      result = Prism.parse(source)
+      visitor = described_class.new(
+        target_class: "Caderneta",
+        method_return_types: { "klass" => "singleton(Caderneta)", "v" => "Vacina" },
+        local_var_types: {},
+        target_methods: { "qtde_por_vacina" => ["vacina"] },
+        constant_arg_resolver: null_constant_resolver,
+        defined_class_names: described_class.collect_defined_class_names(result.value)
+      )
+      result.value.accept(visitor)
+
+      expect(visitor.method_call_usages).to be_empty
+    end
+
     # Peça A: inside a method whose `self` is callback-refined, a
     # `self.<association>` used as the receiver OR as an argument resolves
     # against that refined self (the marker-decorated reader), not the base

--- a/spec/lib/rbs_infer/project/source_index_spec.rb
+++ b/spec/lib/rbs_infer/project/source_index_spec.rb
@@ -78,6 +78,56 @@ RSpec.describe RbsInfer::Project::SourceIndex do
     ).to contain_exactly(caller)
   end
 
+  # felixefelip/rbs_infer#131: a caller that reaches the target through a value —
+  # a view ivar, a local, a `Current.<attr>` — never spells the class name, so the
+  # constant index cannot find it. The method name is the only trace left.
+  describe "#files_calling" do
+    it "encontra o caller por método chamado, sem a constante no arquivo" do
+      view = write_file("show.html.erb", "<%= Current.caderneta.qtde_por_vacina(vacina) %>")
+
+      index = described_class.new([view])
+
+      expect(index.files_referencing("Caderneta")).to be_empty
+      expect(index.files_calling("qtde_por_vacina")).to contain_exactly(view)
+    end
+
+    it "indexa cada elo de uma cadeia de chamadas" do
+      f = write_file("a.rb", "Current.user.posts_titled_like(post)")
+
+      index = described_class.new([f])
+
+      expect(index.files_calling("user")).to contain_exactly(f)
+      expect(index.files_calling("posts_titled_like")).to contain_exactly(f)
+    end
+
+    it "indexa predicados e bangs" do
+      f = write_file("a.rb", "account.matches?(post); record.save!")
+
+      index = described_class.new([f])
+
+      expect(index.files_calling("matches?")).to contain_exactly(f)
+      expect(index.files_calling("save!")).to contain_exactly(f)
+    end
+
+    # Only explicit-receiver calls. A bare call has no `.` and is covered by the
+    # mixin graph (`files_reaching`), which knows which hosts a module reaches.
+    it "não indexa chamadas sem receiver" do
+      f = write_file("a.rb", "qtde_por_vacina(vacina)")
+
+      index = described_class.new([f])
+
+      expect(index.files_calling("qtde_por_vacina")).to be_empty
+    end
+
+    it "retorna array vazio para método não chamado" do
+      f = write_file("a.rb", "puts 'hello'")
+
+      index = described_class.new([f])
+
+      expect(index.files_calling("whatever")).to be_empty
+    end
+  end
+
   it "não confunde constantes CamelCase adjacentes a underscores" do
     # `Foo_Bar` é uma constante distinta de `Foo` e de `Bar`; o lookup por
     # `Foo` não deve casar o arquivo que só referencia `Foo_Bar`.


### PR DESCRIPTION
Closes #131.

A method called on a **value** — a view ivar, a local, a `Current.<attr>` — never contributed its argument types to the callee's parameters. The parameter stayed `untyped`, with no diagnostic.

```erb
<% @fabricante_vacinas.each do |fabricante_vacina| %>
  <%= Current.caderneta.qtde_por_fabricante_vacina(fabricante_vacina) %>
<% end %>
```
```rbs
def qtde_por_fabricante_vacina: (untyped fabricante_vacina) -> Integer
```

The argument half was never broken — the block parameter resolves from the collection element correctly. Two independent gates on the **caller** side dropped the call site first.

## Gate 1 — the file was not a candidate caller

Candidates come from `SourceIndex#files_referencing`, which indexes files by the **constant tokens** they contain. A template calling `Current.caderneta.qtde_por_fabricante_vacina(fv)` never writes `Caderneta`, so it was never analyzed.

Measured in the dummy: a model method called only from `dashboard/show.html.erb` stayed `untyped`; adding a **comment** containing the class name to that template — nothing else — made the parameter resolve to `(Post & Post::Validated)`.

`SourceIndex` now also indexes method names as written after a dot, and the caller sweep adds the files calling one of the target's own methods. This is a **candidate filter only** — `match_class?` still has to prove the receiver is the target. Queries are restricted to methods that take parameters, which naturally keeps them off high-cardinality accessor names (`name`, `id`, `to_s`).

Not ERB-specific: any file reaching the target through a value is invisible the same way. Views just hit it constantly.

## Gate 2 — `match_class?` did not decompose nilable or union

It split an intersection (the marker-decorated shape from #72) but compared anything else as one string:

| receiver type | before | after |
|---|---|---|
| `User` | match | match |
| `(User & User::Validated)` | match | match |
| `((User & User::Validated) \| User)?` | **no match** | match |
| `(Account & Account::Validated)?` | **no match** | match (correctly, vs `Account`) |
| `singleton(User)` | no match | no match |

A CurrentAttributes reader is honestly nilable (per-request reset), so **every** `Current.x.method(arg)` call site in an app was silently discarded.

It now flattens through the RBS parser: union and intersection by component, `T?` as `T` — the call is being **made** on it, so at runtime it is a `T` or the program raises, the same optimism `MethodTypeResolver#resolve` already applies when it drops the `?`. A spelling RBS cannot parse still falls back to the old intersection split, so nothing that matched before stops matching.

## Why one method looked healthy

`Caderneta#qtde_por_vacina` **is** typed — from a second, plain-Ruby call site whose receiver is a non-nilable `belongs_to`. The partial that calls it was being dropped too; the two types just happened to agree, which is what kept this hidden.

## Fixtures

One per gate, both taking the block parameter of a view iteration as the argument:

- `Account#matches?` — view ivar receiver (`@account`), needs only the candidate fix;
- `User#posts_titled_like` — `Current.user` receiver, needs both.

## Cost

No measurable difference: full dummy generation is **28–32s** with or without the wider candidate set — run-to-run noise is larger than the delta.

## Verification

708 unit examples + 69 integration examples, 0 failures, including the Steep baseline over the dummy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)