### PR TITLE
test(dummy): the halting-guard shapes the grammar still rejects

### DIFF
--- a/spec/dummy/app/models/example13.rb
+++ b/spec/dummy/app/models/example13.rb
@@ -1,0 +1,317 @@
+class Example13
+  # ---------------------------------------------------------------------------
+  # Halting-guard gaps (felixefelip/steep#105). Every `guard_*` below is a guard
+  # a human reads as "past this line the slot is populated" — the same sentence
+  # `ApplicationController#authenticate_user` gets right today. Each varies ONE
+  # thing from that working shape, so the file reads as a bisection of what the
+  # guard grammar accepts.
+  #
+  # Each pair is the runner shape the controller pseudo-code emits: `run_*` is
+  # the flow (call the guard, check the halt, call the action) and `act_*` is the
+  # action whose ENTRY the fact has to reach. The split is not cosmetic — entry
+  # facts are attributed to the methods a flow calls after the halt check, not to
+  # the remainder of the flow's own body.
+  #
+  # `# should:` vs `# actual:` records today's behavior and flips when the fork
+  # closes the gap. Errors are pinned by spec/expectations/steep_baseline.txt.
+  # ---------------------------------------------------------------------------
+  class Guarded
+    def initialize(name:)
+      @name = name
+      @halted = false
+    end
+
+    def current_user
+      Example13Viewer.find(@name)
+    end
+
+    def halt
+      @halted = true
+    end
+
+    # A block-taking method that writes nothing itself — stands in for
+    # `respond_to`, whose block is where the real halt sits.
+    def with_format(&block)
+      block&.call(:html)
+    end
+
+    # -------------------------------------------------------------------------
+    # CONTROL. The shape the fork proves today: the condition is a bare
+    # self-send, the aborting clause contains a literal `return`, and the fact
+    # about the constant comes from a WRITE past the guard. Kept here so a
+    # failure below is attributable to the one thing that varies, not to the
+    # fixture harness.
+    # -------------------------------------------------------------------------
+    def guard_supported
+      unless current_user
+        halt
+        return
+      end
+
+      Example13Registry.user = current_user
+    end
+
+    def run_supported
+      guard_supported
+      return if @halted
+
+      act_supported
+    end
+
+    def act_supported
+      Example13Registry.user.name.upcase # should: no error; actual: no error
+    end
+
+    # -------------------------------------------------------------------------
+    # GAP 1 — the guard TESTS the constant instead of writing it.
+    #
+    # The only difference from the control is that the fact is read off the
+    # condition rather than off a subsequent assignment. `presence_condition_
+    # method` accepts only a bare self-send, so a const-rooted receiver proves
+    # nothing — and `conditional_const_returns` is populated exclusively from
+    # writes, which means there is NO path at all from a guard that tests.
+    #
+    # Testing is the far commoner shape: a guard normally asserts what someone
+    # else already populated. It is the entire proof that `Current.user` is
+    # non-nil in a real app's authorization layer.
+    # -------------------------------------------------------------------------
+    def guard_const_tested
+      unless Example13Registry.user
+        halt
+        return
+      end
+    end
+
+    def run_const_tested
+      guard_const_tested
+      return if @halted
+
+      act_const_tested
+    end
+
+    def act_const_tested
+      Example13Registry.user.name.upcase # should: no error; actual: error (gap 1)
+    end
+
+    # -------------------------------------------------------------------------
+    # GAP 1b — safe-navigation truthiness. `&.` on nil yields nil, so a truthy
+    # `Example13Registry.user&.active?` proves the receiver non-nil EXACTLY,
+    # with no knowledge of what `active?` returns. Blocked by the same
+    # `presence_condition_method` shape check as gap 1.
+    # -------------------------------------------------------------------------
+    def guard_safe_navigation
+      unless Example13Registry.user&.active?
+        halt
+        return
+      end
+    end
+
+    def run_safe_navigation
+      guard_safe_navigation
+      return if @halted
+
+      act_safe_navigation
+    end
+
+    def act_safe_navigation
+      Example13Registry.user.name.upcase # should: no error; actual: error (gap 1b)
+    end
+
+    # -------------------------------------------------------------------------
+    # GAP 1c — conjunction. `A && B` truthy proves each conjunct truthy, so both
+    # facts are available; an un-decodable conjunct should be skipped, not sink
+    # the whole condition. Today the `and` node isn't a send, so nothing is read.
+    # -------------------------------------------------------------------------
+    def guard_conjunction
+      unless Example13Registry.tenant && Example13Registry.user
+        halt
+        return
+      end
+    end
+
+    def run_conjunction
+      guard_conjunction
+      return if @halted
+
+      act_conjunction
+    end
+
+    def act_conjunction
+      Example13Registry.user.name.upcase # should: no error; actual: error (gap 1c)
+    end
+
+    # -------------------------------------------------------------------------
+    # GAP 2 — no explicit `return`. The condition is the CONTROL's bare
+    # self-send; the only change is that the guard is the method's last
+    # statement, so falling off the end is exactly a return. `clause_returns?`
+    # walks for a `:return` node and finds none.
+    #
+    # The fix has to stay narrow — "the guard is the final statement", not
+    # "returns are optional". A halting clause that is not last does NOT halt
+    # the method; execution continues past it.
+    #
+    # Because the condition tests a SELF-METHOD, the failure also surfaces one
+    # frame up, as a precondition contract error on the call to the action
+    # (`requires `self.current_user` to be non-nil here`) — the checker
+    # naming the exact fact the guard was supposed to supply.
+    # -------------------------------------------------------------------------
+    def guard_implicit_return
+      unless current_user
+        halt
+      end
+    end
+
+    def run_implicit_return
+      guard_implicit_return
+      return if @halted
+
+      act_implicit_return
+    end
+
+    def act_implicit_return
+      current_user.name.upcase # should: no error; actual: error (gap 2)
+    end
+
+    # -------------------------------------------------------------------------
+    # GAP 3 — the halt sits inside a block. Also the CONTROL's condition, also
+    # with the literal `return`; only the halt moved one block in.
+    #
+    # `walk_sends` already handles block-nested sends, so the guard IS
+    # recognized — but `halting_gate` returns the FIRST bare self-send it walks
+    # to, which here is the block-taking `with_format`, not the `halt` inside.
+    # `Runner#resolve_gates!` then looks for the ivar `with_format` writes,
+    # finds none, and drops the spec. The gate should be a list of candidates,
+    # with the runner keeping the first that resolves.
+    #
+    # Because the condition tests a SELF-METHOD, the failure also surfaces one
+    # frame up, as a precondition contract error on the call to the action
+    # (`requires `self.current_user` to be non-nil here`) — the checker
+    # naming the exact fact the guard was supposed to supply.
+    # -------------------------------------------------------------------------
+    def guard_block_halt
+      unless current_user
+        with_format do |_format|
+          halt
+        end
+        return
+      end
+    end
+
+    def run_block_halt
+      guard_block_halt
+      return if @halted
+
+      act_block_halt
+    end
+
+    def act_block_halt
+      current_user.name.upcase # should: no error; actual: error (gap 3)
+    end
+
+    # -------------------------------------------------------------------------
+    # THE COMPOSITE — all four at once, which is how the shape actually occurs.
+    # This is `Authorization#ensure_can_access_account` from a real app with the
+    # framework names removed: a conjunction of const-rooted tests, one through
+    # `&.`, halting inside a block, with no `return` because the guard is the
+    # method's last statement.
+    # -------------------------------------------------------------------------
+    def guard_composite
+      unless Example13Registry.tenant && Example13Registry.user&.active?
+        with_format do |_format|
+          halt
+        end
+      end
+    end
+
+    def run_composite
+      guard_composite
+      return if @halted
+
+      act_composite
+    end
+
+    def act_composite
+      Example13Registry.user.name.upcase # should: no error; actual: error (composite)
+    end
+  end
+
+  # The call site. Pins `name` to `String` and — exactly as example3 does — makes
+  # both `Example13Registry` slots nilable by writing nil to them, so the
+  # nilability comes from the code rather than from an annotation.
+  def self.run
+    Example13Registry.tenant = Example13Tenant.new(label: 'acme')
+
+    Example13Registry.user = nil
+    Example13Registry.tenant = nil
+
+    Guarded.new(name: 'John Doe').run_composite
+  end
+end
+
+# Byte-for-byte example3's memoized-singleton holder, which is what
+# `ActiveSupport::CurrentAttributes` amounts to: `Example13Registry.user` is a
+# constant attribute with a nilable reader, reachable by the const-path
+# machinery.
+#
+# TOP-LEVEL ON PURPOSE, unlike its example3 counterpart. Nested inside
+# `Example13`, the CONTROL below fails too — the guard's fact is written to the
+# sidecar under the SOURCE SPELLING (`Registry.user`, measured) while the read is
+# resolved to `Example13::Registry.user`, so the two never meet. That is a
+# separate gap from the ones this file is about, and a real app rarely hits it
+# because `Current` is top-level; an engine's `MyEngine::Current` would. Kept
+# out of the way here so every failure below is attributable to the guard
+# grammar and nothing else.
+class Example13Registry
+  module GeneratedAttributes
+    attr_accessor :user, :tenant
+    attr_writer :registry_instance
+  end
+
+  include GeneratedAttributes
+
+  def self.registry_instance
+    @registry_instance ||= Example13Registry.new
+  end
+
+  def self.user
+    registry_instance.user
+  end
+
+  def self.user=(value)
+    registry_instance.user = value
+  end
+
+  def self.tenant
+    registry_instance.tenant
+  end
+
+  def self.tenant=(value)
+    registry_instance.tenant = value
+  end
+end
+
+class Example13Viewer
+  attr_reader :name
+
+  def initialize(name:)
+    @name = name
+  end
+
+  def active?
+    true
+  end
+
+  # The nilable source. Mirrors the `find_by` a real app populates a
+  # CurrentAttributes slot from — the reason the slot is nilable at all.
+  def self.find(name)
+    name.empty? ? nil : Example13Viewer.new(name: name)
+  end
+end
+
+class Example13Tenant
+  attr_reader :label
+
+  def initialize(label:)
+    @label = label
+  end
+end

--- a/spec/dummy/sig/generated/.steep_contracts.yml
+++ b/spec/dummy/sig/generated/.steep_contracts.yml
@@ -124,6 +124,74 @@ methods:
         receiver:
           kind: self
         method: body
+  Example13::Guarded#act_block_halt:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: current_user
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: current_user
+        chain:
+        - name
+    enforced: false
+  Example13::Guarded#act_implicit_return:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: current_user
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: current_user
+        chain:
+        - name
+    enforced: false
+  Example13::Guarded#run_block_halt:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: current_user
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: current_user
+        chain:
+        - name
+    enforced: false
+  Example13::Guarded#run_implicit_return:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: current_user
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: current_user
+        chain:
+        - name
+    enforced: false
   Post#author_name:
     requires:
     - kind: not_nil

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -278,6 +278,124 @@ postconditions:
   effects:
     may_write:
     - "@name"
+- class: Example13
+  method: run
+  unconditional:
+    consts:
+      Example13Registry.tenant: "::Example13Tenant"
+      Example13Registry.user: nil
+- class: Example13::Guarded
+  method: guard_block_halt
+  effects:
+    may_write:
+    - "@halted"
+- class: Example13::Guarded
+  method: guard_composite
+  effects:
+    may_write:
+    - "@halted"
+- class: Example13::Guarded
+  method: guard_conjunction
+  effects:
+    may_write:
+    - "@halted"
+- class: Example13::Guarded
+  method: guard_const_tested
+  effects:
+    may_write:
+    - "@halted"
+- class: Example13::Guarded
+  method: guard_implicit_return
+  effects:
+    may_write:
+    - "@halted"
+- class: Example13::Guarded
+  method: guard_safe_navigation
+  effects:
+    may_write:
+    - "@halted"
+- class: Example13::Guarded
+  method: guard_supported
+  effects:
+    may_write:
+    - "@halted"
+  conditional_returns:
+    current_user:
+      gate_ivar: "@halted"
+      type: "::Example13Viewer"
+  conditional_const_returns:
+    Example13Registry.user:
+      gate_ivar: "@halted"
+      type: "::Example13Viewer"
+- class: Example13::Guarded
+  method: halt
+  unconditional:
+    ivars:
+      "@halted": 'true'
+    self: "::Example13::Guarded & ::Example13::Guarded::AfterHalt"
+  effects:
+    may_write:
+    - "@halted"
+- class: Example13::Guarded
+  method: initialize
+  unconditional:
+    ivars:
+      "@halted": 'false'
+    self: "::Example13::Guarded & ::Example13::Guarded::AfterInitialize"
+  effects:
+    may_write:
+    - "@halted"
+    - "@name"
+- class: Example13::Guarded
+  method: run_block_halt
+  effects:
+    may_write:
+    - "@halted"
+- class: Example13::Guarded
+  method: run_composite
+  effects:
+    may_write:
+    - "@halted"
+- class: Example13::Guarded
+  method: run_conjunction
+  effects:
+    may_write:
+    - "@halted"
+- class: Example13::Guarded
+  method: run_const_tested
+  effects:
+    may_write:
+    - "@halted"
+- class: Example13::Guarded
+  method: run_implicit_return
+  effects:
+    may_write:
+    - "@halted"
+- class: Example13::Guarded
+  method: run_safe_navigation
+  effects:
+    may_write:
+    - "@halted"
+- class: Example13::Guarded
+  method: run_supported
+  effects:
+    may_write:
+    - "@halted"
+- class: Example13Registry
+  method: registry_instance
+  effects:
+    may_write:
+    - "@registry_instance"
+- class: Example13Tenant
+  method: initialize
+  effects:
+    may_write:
+    - "@label"
+- class: Example13Viewer
+  method: initialize
+  effects:
+    may_write:
+    - "@name"
 - class: Example2::Foo
   method: user=
   unconditional:
@@ -1123,6 +1241,12 @@ method_entry_facts:
   method: dispatch_name
   ivars:
     "@name": "::String"
+- class: Example13::Guarded
+  method: act_supported
+  self_methods:
+    current_user: "::Example13Viewer"
+  consts:
+    Example13Registry.user: "::Example13Viewer"
 - class: Example4
   method: run_foo_name
   consts:

--- a/spec/dummy/sig/rbs_infer/app/models/example13.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example13.rbs
@@ -1,0 +1,69 @@
+class Example13
+  def self.run: () -> untyped
+end
+
+class Example13
+  class Guarded
+    @name: String
+    @halted: false | true
+
+    def initialize: (name: String) -> bool
+    def current_user: () -> Example13Viewer?
+    def halt: () -> bool
+    def with_format: () ?{ (untyped) -> untyped } -> untyped
+    def guard_supported: () -> Example13Viewer?
+    def run_supported: () -> String?
+    def act_supported: () -> String
+    def guard_const_tested: () -> untyped
+    def run_const_tested: () -> untyped
+    def act_const_tested: () -> untyped
+    def guard_safe_navigation: () -> untyped
+    def run_safe_navigation: () -> untyped
+    def act_safe_navigation: () -> untyped
+    def guard_conjunction: () -> untyped
+    def run_conjunction: () -> untyped
+    def act_conjunction: () -> untyped
+    def guard_implicit_return: () -> bool?
+    def run_implicit_return: () -> String?
+    def act_implicit_return: () -> String
+    def guard_block_halt: () -> untyped
+    def run_block_halt: () -> String?
+    def act_block_halt: () -> String
+    def guard_composite: () -> untyped
+    def run_composite: () -> untyped
+    def act_composite: () -> untyped
+  end
+end
+
+class Example13Registry
+  self.@registry_instance: Example13Registry?
+
+  module GeneratedAttributes
+    attr_accessor user: (Example13Viewer? | nil)?
+    attr_accessor tenant: (Example13Tenant | nil)?
+    attr_writer registry_instance: untyped
+  end
+
+  include GeneratedAttributes
+
+  def self.registry_instance: () -> Example13Registry
+  def self.user: () -> (Example13Viewer? | nil)?
+  def self.user=: ((Example13Viewer? | nil) value) -> (Example13Viewer? | nil)
+  def self.tenant: () -> (Example13Tenant | nil)?
+  def self.tenant=: ((Example13Tenant | nil) value) -> (Example13Tenant | nil)
+end
+
+class Example13Viewer
+  def self.find: (String name) -> Example13Viewer?
+
+  attr_reader name: String
+
+  def initialize: (name: String) -> void
+  def active?: () -> bool
+end
+
+class Example13Tenant
+  attr_reader label: String
+
+  def initialize: (label: String) -> void
+end

--- a/spec/expectations/models/example13.rbs
+++ b/spec/expectations/models/example13.rbs
@@ -1,0 +1,69 @@
+class Example13
+  def self.run: () -> untyped
+end
+
+class Example13
+  class Guarded
+    @name: String
+    @halted: false | true
+
+    def initialize: (name: String) -> bool
+    def current_user: () -> Example13Viewer?
+    def halt: () -> bool
+    def with_format: () ?{ (untyped) -> untyped } -> untyped
+    def guard_supported: () -> Example13Viewer?
+    def run_supported: () -> String?
+    def act_supported: () -> String
+    def guard_const_tested: () -> untyped
+    def run_const_tested: () -> untyped
+    def act_const_tested: () -> untyped
+    def guard_safe_navigation: () -> untyped
+    def run_safe_navigation: () -> untyped
+    def act_safe_navigation: () -> untyped
+    def guard_conjunction: () -> untyped
+    def run_conjunction: () -> untyped
+    def act_conjunction: () -> untyped
+    def guard_implicit_return: () -> bool?
+    def run_implicit_return: () -> String?
+    def act_implicit_return: () -> String
+    def guard_block_halt: () -> untyped
+    def run_block_halt: () -> String?
+    def act_block_halt: () -> String
+    def guard_composite: () -> untyped
+    def run_composite: () -> untyped
+    def act_composite: () -> untyped
+  end
+end
+
+class Example13Registry
+  self.@registry_instance: Example13Registry?
+
+  module GeneratedAttributes
+    attr_accessor user: (Example13Viewer? | nil)?
+    attr_accessor tenant: (Example13Tenant | nil)?
+    attr_writer registry_instance: untyped
+  end
+
+  include GeneratedAttributes
+
+  def self.registry_instance: () -> Example13Registry
+  def self.user: () -> (Example13Viewer? | nil)?
+  def self.user=: ((Example13Viewer? | nil) value) -> (Example13Viewer? | nil)
+  def self.tenant: () -> (Example13Tenant | nil)?
+  def self.tenant=: ((Example13Tenant | nil) value) -> (Example13Tenant | nil)
+end
+
+class Example13Viewer
+  def self.find: (String name) -> Example13Viewer?
+
+  attr_reader name: String
+
+  def initialize: (name: String) -> void
+  def active?: () -> bool
+end
+
+class Example13Tenant
+  attr_reader label: String
+
+  def initialize: (label: String) -> void
+end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -7,6 +7,16 @@ app/models/concerns/test/filtrable.rb:7:4: [error] Type `(singleton(::Test) & si
 app/models/concerns/test/filtrable.rb:8:26: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `where`
 app/models/concerns/test/filtrable.rb:8:4: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `scope`
 app/models/example10.rb:27:26: [error] Type `(::String | nil)` does not have method `upcase`
+app/models/example13.rb:117:29: [error] Type `(::Example13Viewer | nil)` does not have method `name`
+app/models/example13.rb:140:29: [error] Type `(::Example13Viewer | nil)` does not have method `name`
+app/models/example13.rb:168:6: [error] `act_implicit_return` requires `self.current_user.name` to be non-nil here
+app/models/example13.rb:168:6: [error] `act_implicit_return` requires `self.current_user` to be non-nil here
+app/models/example13.rb:172:19: [error] Type `(::Example13Viewer | nil)` does not have method `name`
+app/models/example13.rb:204:6: [error] `act_block_halt` requires `self.current_user.name` to be non-nil here
+app/models/example13.rb:204:6: [error] `act_block_halt` requires `self.current_user` to be non-nil here
+app/models/example13.rb:208:19: [error] Type `(::Example13Viewer | nil)` does not have method `name`
+app/models/example13.rb:234:29: [error] Type `(::Example13Viewer | nil)` does not have method `name`
+app/models/example13.rb:93:29: [error] Type `(::Example13Viewer | nil)` does not have method `name`
 app/models/example3.rb:122:11: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:63:13: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:64:26: [error] Type `(::Example3::User | nil)` does not have method `name`

--- a/spec/expectations/steep_contracts.yml
+++ b/spec/expectations/steep_contracts.yml
@@ -124,6 +124,74 @@ methods:
         receiver:
           kind: self
         method: body
+  Example13::Guarded#act_block_halt:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: current_user
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: current_user
+        chain:
+        - name
+    enforced: false
+  Example13::Guarded#act_implicit_return:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: current_user
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: current_user
+        chain:
+        - name
+    enforced: false
+  Example13::Guarded#run_block_halt:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: current_user
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: current_user
+        chain:
+        - name
+    enforced: false
+  Example13::Guarded#run_implicit_return:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: current_user
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: current_user
+        chain:
+        - name
+    enforced: false
   Post#author_name:
     requires:
     - kind: not_nil

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -400,6 +400,28 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     expect(rbs.chomp).to eq(expected_rbs(name).chomp)
   end
 
+  # Halting-guard grammar (felixefelip/steep#105). What the fixture DEMONSTRATES is
+  # a steep behavior, pinned by spec/expectations/steep_baseline.txt; this snapshot
+  # pins the premise instead. Every gap there shows up as a nil-deref error, which
+  # only happens while `Example13Registry.user` is nilable — if inference ever made
+  # that reader non-nil the ten baseline entries would vanish and read as ten gaps
+  # closed. Here the nilability is explicit, so the two failures can't be confused.
+  it "example13" do
+    name = "models/example13"
+    rbs = RbsInfer::Analyzer.new(
+      target_file: "app/models/example13.rb",
+      source_files: source_files
+    ).generate_rbs
+
+    if ENV["UPDATE_EXPECTATIONS"]
+      path = expectations_dir.join("#{name}.rbs")
+      path.dirname.mkpath
+      path.write(rbs)
+    end
+
+    expect(rbs.chomp).to eq(expected_rbs(name).chomp)
+  end
+
   # The RBS the analyzer derives FROM the runtime pseudo-code, snapshotted next to
   # the pseudo-code itself. The two together localize a regression: the `.rb`
   # changed => generator bug; identical `.rb` with a different `.rbs` => inference


### PR DESCRIPTION
Reproduces every gap in felixefelip/steep#105 as a dummy fixture, in the `example*.rb` style.

`example13` bisects what the guard-clause proof accepts: the CONTROL is `ApplicationController#authenticate_user`'s shape and passes; each gap below it changes exactly one thing and errors.

| pair | deviation from the control | result |
|---|---|---|
| `*_supported` | — (control) | no error |
| `*_const_tested` | the guard TESTS the constant instead of writing it | error |
| `*_safe_navigation` | the test goes through `&.` | error |
| `*_conjunction` | the condition is a conjunction | error |
| `*_implicit_return` | guard is the last statement, so no literal `return` | error + contract error |
| `*_block_halt` | the halt sits inside a block | error + contract error |
| `*_composite` | all four at once | error |

The composite is `Authorization#ensure_can_access_account` from a real app with the framework names removed. Reaching an action past that callback is the only thing proving `Current.user` non-nil there — `require_authentication` establishes `Current.identity`, and `Current.user` is derived from it by a `find_by` that can miss.

## Two things the fixture had to be shaped around

Both measured while building it, not assumed:

**Entry facts land on the methods a flow calls, not on the rest of its own body.** Hence each pair is `run_*` (call the guard, check the halt, call the action) + `act_*`. With the deref written inline after the halt check, even the control fails.

**`Example13Registry` is top-level, unlike its `example3` counterpart.** Nested inside `Example13`, the control fails too: the guard's fact is written to the sidecar under the SOURCE SPELLING (`Registry.user` — read off the regenerated sidecar) while the read resolves to `Example13::Registry.user`, so the two never meet. That is a separate gap from #105's, documented in the file and kept out of the way so every failure here is attributable to the guard grammar. A real app rarely hits it because `Current` is top-level; an engine's `MyEngine::Current` would.

Worth its own issue — say the word and I'll open it.

## Also worth noting

Gaps 2 and 3 surface a **precondition contract error one frame up**:

```
`act_implicit_return` requires `self.current_user` to be non-nil here
```

The checker naming the exact fact the guard was supposed to supply. Only the self-method-conditioned gaps do this; the const-rooted ones just fail at the deref.

## Pinning

- `steep_baseline.txt`: 10 new entries, all `example13`. The diff is purely additive — nothing else moved.
- `spec/expectations/models/example13.rbs`: pins the premise. Every gap shows up as a nil-deref, which only holds while `Example13Registry.user` is nilable; if inference ever made that reader non-nil, the ten baseline entries would vanish and read as ten gaps closed rather than one regression.

794 examples, 0 failures.

Refs: felixefelip/steep#105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
