### PR TITLE
test(dummy): nest example13's registry, now that a const fact keys by identity

### DIFF
--- a/spec/dummy/app/models/example13.rb
+++ b/spec/dummy/app/models/example13.rb
@@ -15,6 +15,45 @@ class Example13
   # `# should:` vs `# actual:` records today's behavior and flips when the fork
   # closes the gap. Errors are pinned by spec/expectations/steep_baseline.txt.
   # ---------------------------------------------------------------------------
+  # Byte-for-byte example3's memoized-singleton holder, which is what
+  # `ActiveSupport::CurrentAttributes` amounts to: `Registry.user` is a constant
+  # attribute with a nilable reader, reachable by the const-path machinery.
+  #
+  # Nested, like its example3 counterpart. It could not be until
+  # felixefelip/steep#106: the guard's fact was written to the sidecar under the
+  # SOURCE SPELLING (`Registry.user`) while the read resolved
+  # `Example13::Registry.user`, so the two never met and the CONTROL failed for a
+  # keying reason rather than a guard-grammar one. Now that both sides resolve,
+  # this also stands as the regression guard for that fix.
+  class Registry
+    module GeneratedAttributes
+      attr_accessor :user, :tenant
+      attr_writer :registry_instance
+    end
+
+    include GeneratedAttributes
+
+    def self.registry_instance
+      @registry_instance ||= Registry.new
+    end
+
+    def self.user
+      registry_instance.user
+    end
+
+    def self.user=(value)
+      registry_instance.user = value
+    end
+
+    def self.tenant
+      registry_instance.tenant
+    end
+
+    def self.tenant=(value)
+      registry_instance.tenant = value
+    end
+  end
+
   class Guarded
     def initialize(name:)
       @name = name
@@ -48,7 +87,7 @@ class Example13
         return
       end
 
-      Example13Registry.user = current_user
+      Registry.user = current_user
     end
 
     def run_supported
@@ -59,7 +98,7 @@ class Example13
     end
 
     def act_supported
-      Example13Registry.user.name.upcase # should: no error; actual: no error
+      Registry.user.name.upcase # should: no error; actual: no error
     end
 
     # -------------------------------------------------------------------------
@@ -76,7 +115,7 @@ class Example13
     # non-nil in a real app's authorization layer.
     # -------------------------------------------------------------------------
     def guard_const_tested
-      unless Example13Registry.user
+      unless Registry.user
         halt
         return
       end
@@ -90,17 +129,17 @@ class Example13
     end
 
     def act_const_tested
-      Example13Registry.user.name.upcase # should: no error; actual: error (gap 1)
+      Registry.user.name.upcase # should: no error; actual: error (gap 1)
     end
 
     # -------------------------------------------------------------------------
     # GAP 1b — safe-navigation truthiness. `&.` on nil yields nil, so a truthy
-    # `Example13Registry.user&.active?` proves the receiver non-nil EXACTLY,
+    # `Registry.user&.active?` proves the receiver non-nil EXACTLY,
     # with no knowledge of what `active?` returns. Blocked by the same
     # `presence_condition_method` shape check as gap 1.
     # -------------------------------------------------------------------------
     def guard_safe_navigation
-      unless Example13Registry.user&.active?
+      unless Registry.user&.active?
         halt
         return
       end
@@ -114,7 +153,7 @@ class Example13
     end
 
     def act_safe_navigation
-      Example13Registry.user.name.upcase # should: no error; actual: error (gap 1b)
+      Registry.user.name.upcase # should: no error; actual: error (gap 1b)
     end
 
     # -------------------------------------------------------------------------
@@ -123,7 +162,7 @@ class Example13
     # the whole condition. Today the `and` node isn't a send, so nothing is read.
     # -------------------------------------------------------------------------
     def guard_conjunction
-      unless Example13Registry.tenant && Example13Registry.user
+      unless Registry.tenant && Registry.user
         halt
         return
       end
@@ -137,7 +176,7 @@ class Example13
     end
 
     def act_conjunction
-      Example13Registry.user.name.upcase # should: no error; actual: error (gap 1c)
+      Registry.user.name.upcase # should: no error; actual: error (gap 1c)
     end
 
     # -------------------------------------------------------------------------
@@ -216,7 +255,7 @@ class Example13
     # method's last statement.
     # -------------------------------------------------------------------------
     def guard_composite
-      unless Example13Registry.tenant && Example13Registry.user&.active?
+      unless Registry.tenant && Registry.user&.active?
         with_format do |_format|
           halt
         end
@@ -231,62 +270,20 @@ class Example13
     end
 
     def act_composite
-      Example13Registry.user.name.upcase # should: no error; actual: error (composite)
+      Registry.user.name.upcase # should: no error; actual: error (composite)
     end
   end
 
   # The call site. Pins `name` to `String` and — exactly as example3 does — makes
-  # both `Example13Registry` slots nilable by writing nil to them, so the
+  # both `Registry` slots nilable by writing nil to them, so the
   # nilability comes from the code rather than from an annotation.
   def self.run
-    Example13Registry.tenant = Example13Tenant.new(label: 'acme')
+    Registry.tenant = Example13Tenant.new(label: 'acme')
 
-    Example13Registry.user = nil
-    Example13Registry.tenant = nil
+    Registry.user = nil
+    Registry.tenant = nil
 
     Guarded.new(name: 'John Doe').run_composite
-  end
-end
-
-# Byte-for-byte example3's memoized-singleton holder, which is what
-# `ActiveSupport::CurrentAttributes` amounts to: `Example13Registry.user` is a
-# constant attribute with a nilable reader, reachable by the const-path
-# machinery.
-#
-# TOP-LEVEL ON PURPOSE, unlike its example3 counterpart. Nested inside
-# `Example13`, the CONTROL below fails too — the guard's fact is written to the
-# sidecar under the SOURCE SPELLING (`Registry.user`, measured) while the read is
-# resolved to `Example13::Registry.user`, so the two never meet. That is a
-# separate gap from the ones this file is about, and a real app rarely hits it
-# because `Current` is top-level; an engine's `MyEngine::Current` would. Kept
-# out of the way here so every failure below is attributable to the guard
-# grammar and nothing else.
-class Example13Registry
-  module GeneratedAttributes
-    attr_accessor :user, :tenant
-    attr_writer :registry_instance
-  end
-
-  include GeneratedAttributes
-
-  def self.registry_instance
-    @registry_instance ||= Example13Registry.new
-  end
-
-  def self.user
-    registry_instance.user
-  end
-
-  def self.user=(value)
-    registry_instance.user = value
-  end
-
-  def self.tenant
-    registry_instance.tenant
-  end
-
-  def self.tenant=(value)
-    registry_instance.tenant = value
   end
 end
 

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -282,8 +282,8 @@ postconditions:
   method: run
   unconditional:
     consts:
-      Example13Registry.tenant: "::Example13Tenant"
-      Example13Registry.user: nil
+      Example13::Registry.tenant: "::Example13Tenant"
+      Example13::Registry.user: nil
 - class: Example13::Guarded
   method: guard_block_halt
   effects:
@@ -324,7 +324,7 @@ postconditions:
       gate_ivar: "@halted"
       type: "::Example13Viewer"
   conditional_const_returns:
-    Example13Registry.user:
+    Example13::Registry.user:
       gate_ivar: "@halted"
       type: "::Example13Viewer"
 - class: Example13::Guarded
@@ -381,7 +381,7 @@ postconditions:
   effects:
     may_write:
     - "@halted"
-- class: Example13Registry
+- class: Example13::Registry
   method: registry_instance
   effects:
     may_write:
@@ -414,27 +414,32 @@ postconditions:
   method: gap_alias_read
   unconditional:
     consts:
-      Foo.user: "::Example3::User"
+      Example3::Foo.name: "::String"
+      Example3::Foo.user: "::Example3::User"
 - class: Example3
   method: gap_alias_write
   unconditional:
     consts:
-      Foo.user: "::Example3::User"
+      Example3::Foo.name: "::String"
+      Example3::Foo.user: "::Example3::User"
 - class: Example3
   method: gap_callee_mutation
   unconditional:
     consts:
-      Foo.user: "::Example3::User"
+      Example3::Foo.name: "::String"
+      Example3::Foo.user: "::Example3::User"
 - class: Example3
   method: gap_conditional
   unconditional:
     consts:
-      Foo.user: "::Example3::User"
+      Example3::Foo.name: "::String"
+      Example3::Foo.user: "::Example3::User"
 - class: Example3
   method: run
   unconditional:
     consts:
-      Foo.user: "::Example3::User"
+      Example3::Foo.name: "::String"
+      Example3::Foo.user: "::Example3::User"
 - class: Example3::Foo
   method: user=
   unconditional:
@@ -1246,7 +1251,7 @@ method_entry_facts:
   self_methods:
     current_user: "::Example13Viewer"
   consts:
-    Example13Registry.user: "::Example13Viewer"
+    Example13::Registry.user: "::Example13Viewer"
 - class: Example4
   method: run_foo_name
   consts:

--- a/spec/dummy/sig/rbs_infer/app/models/example13.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example13.rbs
@@ -3,6 +3,26 @@ class Example13
 end
 
 class Example13
+  class Registry
+    self.@registry_instance: Registry?
+
+    module GeneratedAttributes
+      attr_accessor user: (Example13Viewer? | nil)?
+      attr_accessor tenant: (Example13Tenant | nil)?
+      attr_writer registry_instance: untyped
+    end
+
+    include GeneratedAttributes
+
+    def self.registry_instance: () -> Example13::Registry
+    def self.user: () -> (Example13Viewer? | nil)?
+    def self.user=: ((Example13Viewer? | nil) value) -> (Example13Viewer? | nil)
+    def self.tenant: () -> (Example13Tenant | nil)?
+    def self.tenant=: ((Example13Tenant | nil) value) -> (Example13Tenant | nil)
+  end
+end
+
+class Example13
   class Guarded
     @name: String
     @halted: false | true
@@ -33,24 +53,6 @@ class Example13
     def run_composite: () -> untyped
     def act_composite: () -> untyped
   end
-end
-
-class Example13Registry
-  self.@registry_instance: Example13Registry?
-
-  module GeneratedAttributes
-    attr_accessor user: (Example13Viewer? | nil)?
-    attr_accessor tenant: (Example13Tenant | nil)?
-    attr_writer registry_instance: untyped
-  end
-
-  include GeneratedAttributes
-
-  def self.registry_instance: () -> Example13Registry
-  def self.user: () -> (Example13Viewer? | nil)?
-  def self.user=: ((Example13Viewer? | nil) value) -> (Example13Viewer? | nil)
-  def self.tenant: () -> (Example13Tenant | nil)?
-  def self.tenant=: ((Example13Tenant | nil) value) -> (Example13Tenant | nil)
 end
 
 class Example13Viewer

--- a/spec/expectations/models/example13.rbs
+++ b/spec/expectations/models/example13.rbs
@@ -3,6 +3,26 @@ class Example13
 end
 
 class Example13
+  class Registry
+    self.@registry_instance: Registry?
+
+    module GeneratedAttributes
+      attr_accessor user: (Example13Viewer? | nil)?
+      attr_accessor tenant: (Example13Tenant | nil)?
+      attr_writer registry_instance: untyped
+    end
+
+    include GeneratedAttributes
+
+    def self.registry_instance: () -> Example13::Registry
+    def self.user: () -> (Example13Viewer? | nil)?
+    def self.user=: ((Example13Viewer? | nil) value) -> (Example13Viewer? | nil)
+    def self.tenant: () -> (Example13Tenant | nil)?
+    def self.tenant=: ((Example13Tenant | nil) value) -> (Example13Tenant | nil)
+  end
+end
+
+class Example13
   class Guarded
     @name: String
     @halted: false | true
@@ -33,24 +53,6 @@ class Example13
     def run_composite: () -> untyped
     def act_composite: () -> untyped
   end
-end
-
-class Example13Registry
-  self.@registry_instance: Example13Registry?
-
-  module GeneratedAttributes
-    attr_accessor user: (Example13Viewer? | nil)?
-    attr_accessor tenant: (Example13Tenant | nil)?
-    attr_writer registry_instance: untyped
-  end
-
-  include GeneratedAttributes
-
-  def self.registry_instance: () -> Example13Registry
-  def self.user: () -> (Example13Viewer? | nil)?
-  def self.user=: ((Example13Viewer? | nil) value) -> (Example13Viewer? | nil)
-  def self.tenant: () -> (Example13Tenant | nil)?
-  def self.tenant=: ((Example13Tenant | nil) value) -> (Example13Tenant | nil)
 end
 
 class Example13Viewer

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -7,16 +7,16 @@ app/models/concerns/test/filtrable.rb:7:4: [error] Type `(singleton(::Test) & si
 app/models/concerns/test/filtrable.rb:8:26: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `where`
 app/models/concerns/test/filtrable.rb:8:4: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `scope`
 app/models/example10.rb:27:26: [error] Type `(::String | nil)` does not have method `upcase`
-app/models/example13.rb:117:29: [error] Type `(::Example13Viewer | nil)` does not have method `name`
-app/models/example13.rb:140:29: [error] Type `(::Example13Viewer | nil)` does not have method `name`
-app/models/example13.rb:168:6: [error] `act_implicit_return` requires `self.current_user.name` to be non-nil here
-app/models/example13.rb:168:6: [error] `act_implicit_return` requires `self.current_user` to be non-nil here
-app/models/example13.rb:172:19: [error] Type `(::Example13Viewer | nil)` does not have method `name`
-app/models/example13.rb:204:6: [error] `act_block_halt` requires `self.current_user.name` to be non-nil here
-app/models/example13.rb:204:6: [error] `act_block_halt` requires `self.current_user` to be non-nil here
-app/models/example13.rb:208:19: [error] Type `(::Example13Viewer | nil)` does not have method `name`
-app/models/example13.rb:234:29: [error] Type `(::Example13Viewer | nil)` does not have method `name`
-app/models/example13.rb:93:29: [error] Type `(::Example13Viewer | nil)` does not have method `name`
+app/models/example13.rb:132:20: [error] Type `(::Example13Viewer | nil)` does not have method `name`
+app/models/example13.rb:156:20: [error] Type `(::Example13Viewer | nil)` does not have method `name`
+app/models/example13.rb:179:20: [error] Type `(::Example13Viewer | nil)` does not have method `name`
+app/models/example13.rb:207:6: [error] `act_implicit_return` requires `self.current_user.name` to be non-nil here
+app/models/example13.rb:207:6: [error] `act_implicit_return` requires `self.current_user` to be non-nil here
+app/models/example13.rb:211:19: [error] Type `(::Example13Viewer | nil)` does not have method `name`
+app/models/example13.rb:243:6: [error] `act_block_halt` requires `self.current_user.name` to be non-nil here
+app/models/example13.rb:243:6: [error] `act_block_halt` requires `self.current_user` to be non-nil here
+app/models/example13.rb:247:19: [error] Type `(::Example13Viewer | nil)` does not have method `name`
+app/models/example13.rb:273:20: [error] Type `(::Example13Viewer | nil)` does not have method `name`
 app/models/example3.rb:122:11: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:63:13: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:64:26: [error] Type `(::Example3::User | nil)` does not have method `name`


### PR DESCRIPTION
Follow-up to #133, unblocked by felixefelip/steep#106.

`example13`'s memoized-singleton holder moves back inside `Example13`, where every other example fixture's lives. #133 had to hoist it to the top level: the guard's fact was written to the sidecar under the source spelling (`Registry.user`) while the read resolved `Example13::Registry.user`, so the CONTROL failed for a keying reason rather than a guard-grammar one. The comment explaining that is replaced by one noting the fixture now stands as the regression guard for the fix.

## What the steep fix did to the checked-in sidecar

```diff
-      Foo.user: "::Example3::User"
+      Example3::Foo.name: "::String"
+      Example3::Foo.user: "::Example3::User"
```

`Example3::Foo.name` appears for the first time — an establishment that had never been reachable, from a fixture that has been nested since the day it was written.

## The baseline

10 lines for 10 lines: the same errors, shifted by the nesting. No gap opened or closed — which is the point. The fixture still reproduces exactly what felixefelip/steep#105 describes, now without the caveat.

794 examples, 0 failures.

Refs: felixefelip/steep#105, felixefelip/steep#106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
