### PR TITLE
test(dummy): mark gap 1 closed in example13, and refresh for the conjunction

### DIFF
--- a/spec/dummy/app/models/example13.rb
+++ b/spec/dummy/app/models/example13.rb
@@ -1,20 +1,4 @@
 class Example13
-  # ---------------------------------------------------------------------------
-  # Halting-guard gaps (felixefelip/steep#105). Every `guard_*` below is a guard
-  # a human reads as "past this line the slot is populated" — the same sentence
-  # `ApplicationController#authenticate_user` gets right today. Each varies ONE
-  # thing from that working shape, so the file reads as a bisection of what the
-  # guard grammar accepts.
-  #
-  # Each pair is the runner shape the controller pseudo-code emits: `run_*` is
-  # the flow (call the guard, check the halt, call the action) and `act_*` is the
-  # action whose ENTRY the fact has to reach. The split is not cosmetic — entry
-  # facts are attributed to the methods a flow calls after the halt check, not to
-  # the remainder of the flow's own body.
-  #
-  # `# should:` vs `# actual:` records today's behavior and flips when the fork
-  # closes the gap. Errors are pinned by spec/expectations/steep_baseline.txt.
-  # ---------------------------------------------------------------------------
   # Byte-for-byte example3's memoized-singleton holder, which is what
   # `ActiveSupport::CurrentAttributes` amounts to: `Registry.user` is a constant
   # attribute with a nilable reader, reachable by the const-path machinery.
@@ -54,6 +38,23 @@ class Example13
     end
   end
 
+  # ---------------------------------------------------------------------------
+  # Halting-guard grammar (felixefelip/steep#105). Every `guard_*` below is a
+  # guard a human reads as "past this line the slot is populated" — the same
+  # sentence `ApplicationController#authenticate_user` gets right. Each varies
+  # ONE thing from that working shape, so the file reads as a bisection of what
+  # the grammar accepts.
+  #
+  # Each pair is the runner shape the controller pseudo-code emits: `run_*` is
+  # the flow (call the guard, check the halt, call the action) and `act_*` is the
+  # action whose ENTRY the fact has to reach. The split is not cosmetic — entry
+  # facts are attributed to the methods a flow calls after the halt check, not to
+  # the remainder of the flow's own body.
+  #
+  # `# should:` vs `# actual:` records today's behavior and flips when the fork
+  # closes a gap; a closed one stays here as its regression guard. Errors are
+  # pinned by spec/expectations/steep_baseline.txt.
+  # ---------------------------------------------------------------------------
   class Guarded
     def initialize(name:)
       @name = name
@@ -102,13 +103,16 @@ class Example13
     end
 
     # -------------------------------------------------------------------------
-    # GAP 1 — the guard TESTS the constant instead of writing it.
+    # GAP 1 — CLOSED by felixefelip/steep#107. The guard TESTS the constant
+    # instead of writing it.
     #
     # The only difference from the control is that the fact is read off the
     # condition rather than off a subsequent assignment. `presence_condition_
-    # method` accepts only a bare self-send, so a const-rooted receiver proves
-    # nothing — and `conditional_const_returns` is populated exclusively from
-    # writes, which means there is NO path at all from a guard that tests.
+    # method` accepted only a bare self-send and returned a method NAME, so a
+    # const-rooted receiver had nowhere to go — and `conditional_const_returns`
+    # was populated exclusively from writes, so there was no path from a guard
+    # that tests even in principle. The condition decoder now returns a list of
+    # tagged facts.
     #
     # Testing is the far commoner shape: a guard normally asserts what someone
     # else already populated. It is the entire proof that `Current.user` is
@@ -129,14 +133,17 @@ class Example13
     end
 
     def act_const_tested
-      Registry.user.name.upcase # should: no error; actual: error (gap 1)
+      Registry.user.name.upcase # should: no error; actual: no error
     end
 
     # -------------------------------------------------------------------------
-    # GAP 1b — safe-navigation truthiness. `&.` on nil yields nil, so a truthy
-    # `Registry.user&.active?` proves the receiver non-nil EXACTLY,
-    # with no knowledge of what `active?` returns. Blocked by the same
-    # `presence_condition_method` shape check as gap 1.
+    # GAP 1b — CLOSED by felixefelip/steep#108. Safe-navigation truthiness:
+    # `&.` on nil yields nil, so a truthy `Registry.user&.active?` proves the
+    # receiver non-nil EXACTLY, with no knowledge of what `active?` returns.
+    #
+    # Stating the fact as being about the RECEIVER is what made the arguments of
+    # the safe-navigated call irrelevant, and what makes a chain (`a&.b&.c`)
+    # prove its innermost nameable slot.
     # -------------------------------------------------------------------------
     def guard_safe_navigation
       unless Registry.user&.active?
@@ -153,13 +160,19 @@ class Example13
     end
 
     def act_safe_navigation
-      Registry.user.name.upcase # should: no error; actual: error (gap 1b)
+      Registry.user.name.upcase # should: no error; actual: no error
     end
 
     # -------------------------------------------------------------------------
-    # GAP 1c — conjunction. `A && B` truthy proves each conjunct truthy, so both
-    # facts are available; an un-decodable conjunct should be skipped, not sink
-    # the whole condition. Today the `and` node isn't a send, so nothing is read.
+    # GAP 1c — CLOSED by felixefelip/steep#109. Conjunction: `A && B` is truthy
+    # only if both are, so it proves everything either conjunct does. An
+    # un-decodable conjunct is skipped rather than sinking the whole condition,
+    # and `||` deliberately distributes to nothing — a truthy disjunction says
+    # only that at least ONE operand was, with no way to tell which.
+    #
+    # The sharp edge is the `!` that turns `if !x` into "x is truthy here": it
+    # belongs to the whole condition, and re-applying it per conjunct would make
+    # `A && !B` claim `B` present when it is provably falsy.
     # -------------------------------------------------------------------------
     def guard_conjunction
       unless Registry.tenant && Registry.user
@@ -176,7 +189,7 @@ class Example13
     end
 
     def act_conjunction
-      Registry.user.name.upcase # should: no error; actual: error (gap 1c)
+      Registry.user.name.upcase # should: no error; actual: no error
     end
 
     # -------------------------------------------------------------------------

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -299,6 +299,13 @@ postconditions:
   effects:
     may_write:
     - "@halted"
+  conditional_const_returns:
+    Example13::Registry.tenant:
+      gate_ivar: "@halted"
+      type: "::Example13Tenant"
+    Example13::Registry.user:
+      gate_ivar: "@halted"
+      type: "::Example13Viewer"
 - class: Example13::Guarded
   method: guard_const_tested
   effects:
@@ -1254,6 +1261,11 @@ method_entry_facts:
   method: dispatch_name
   ivars:
     "@name": "::String"
+- class: Example13::Guarded
+  method: act_conjunction
+  consts:
+    Example13::Registry.tenant: "::Example13Tenant"
+    Example13::Registry.user: "::Example13Viewer"
 - class: Example13::Guarded
   method: act_const_tested
   consts:

--- a/spec/dummy/sig/rbs_infer/app/models/example13.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example13.rbs
@@ -41,8 +41,8 @@ class Example13
     def run_safe_navigation: () -> String?
     def act_safe_navigation: () -> String
     def guard_conjunction: () -> untyped
-    def run_conjunction: () -> untyped
-    def act_conjunction: () -> untyped
+    def run_conjunction: () -> String?
+    def act_conjunction: () -> String
     def guard_implicit_return: () -> bool?
     def run_implicit_return: () -> String?
     def act_implicit_return: () -> String

--- a/spec/expectations/models/example13.rbs
+++ b/spec/expectations/models/example13.rbs
@@ -41,8 +41,8 @@ class Example13
     def run_safe_navigation: () -> String?
     def act_safe_navigation: () -> String
     def guard_conjunction: () -> untyped
-    def run_conjunction: () -> untyped
-    def act_conjunction: () -> untyped
+    def run_conjunction: () -> String?
+    def act_conjunction: () -> String
     def guard_implicit_return: () -> bool?
     def run_implicit_return: () -> String?
     def act_implicit_return: () -> String

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -7,14 +7,13 @@ app/models/concerns/test/filtrable.rb:7:4: [error] Type `(singleton(::Test) & si
 app/models/concerns/test/filtrable.rb:8:26: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `where`
 app/models/concerns/test/filtrable.rb:8:4: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `scope`
 app/models/example10.rb:27:26: [error] Type `(::String | nil)` does not have method `upcase`
-app/models/example13.rb:179:20: [error] Type `(::Example13Viewer | nil)` does not have method `name`
-app/models/example13.rb:207:6: [error] `act_implicit_return` requires `self.current_user.name` to be non-nil here
-app/models/example13.rb:207:6: [error] `act_implicit_return` requires `self.current_user` to be non-nil here
-app/models/example13.rb:211:19: [error] Type `(::Example13Viewer | nil)` does not have method `name`
-app/models/example13.rb:243:6: [error] `act_block_halt` requires `self.current_user.name` to be non-nil here
-app/models/example13.rb:243:6: [error] `act_block_halt` requires `self.current_user` to be non-nil here
-app/models/example13.rb:247:19: [error] Type `(::Example13Viewer | nil)` does not have method `name`
-app/models/example13.rb:273:20: [error] Type `(::Example13Viewer | nil)` does not have method `name`
+app/models/example13.rb:220:6: [error] `act_implicit_return` requires `self.current_user.name` to be non-nil here
+app/models/example13.rb:220:6: [error] `act_implicit_return` requires `self.current_user` to be non-nil here
+app/models/example13.rb:224:19: [error] Type `(::Example13Viewer | nil)` does not have method `name`
+app/models/example13.rb:256:6: [error] `act_block_halt` requires `self.current_user.name` to be non-nil here
+app/models/example13.rb:256:6: [error] `act_block_halt` requires `self.current_user` to be non-nil here
+app/models/example13.rb:260:19: [error] Type `(::Example13Viewer | nil)` does not have method `name`
+app/models/example13.rb:286:20: [error] Type `(::Example13Viewer | nil)` does not have method `name`
 app/models/example3.rb:122:11: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:63:13: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:64:26: [error] Type `(::Example3::User | nil)` does not have method `name`


### PR DESCRIPTION
Companion to felixefelip/steep#109. **Depends on it** — reads red until that merges, green after.

## What changed

**Gap 1c refreshed.** Baseline 38 → 37 problems; the line that disappears is `act_conjunction`.

**Gaps 1 and 1b: markers flipped.** felixefelip/steep#107 and #108 closed them, but the refreshes so far touched only the generated artifacts, so `example13.rb` still read `# actual: error (gap 1)` and `# actual: error (gap 1b)` for two pairs that pass. The file's own convention says a marker flips when the fork closes the gap — and a stale one is worse than none, since it claims a gap is open when the fixture is in fact guarding it. Their block comments now say what closed them, so each stays as its own regression guard.

**Section header moved** down to sit above `class Guarded`, where the `guard_*` pairs it describes actually live. Nesting the registry in #134 had left it introducing the wrong class.

## Remaining in the baseline

Gap 2 (implicit return), gap 3 (block-nested halt gate), and the composite — which needs both.

794 examples, 0 failures.

Refs: felixefelip/steep#105, felixefelip/steep#109

🤖 Generated with [Claude Code](https://claude.com/claude-code)
