### PR TITLE
test(dummy): mark gap 3 closed in example13

### DIFF
--- a/spec/dummy/app/models/example13.rb
+++ b/spec/dummy/app/models/example13.rb
@@ -225,20 +225,24 @@ class Example13
     end
 
     # -------------------------------------------------------------------------
-    # GAP 3 — the halt sits inside a block. Also the CONTROL's condition, also
-    # with the literal `return`; only the halt moved one block in.
+    # GAP 3 — CLOSED by felixefelip/steep#110. The halt sits inside a block.
+    # Also the CONTROL's condition, also with the literal `return`; only the halt
+    # moved one block in.
     #
-    # `walk_sends` already handles block-nested sends, so the guard IS
-    # recognized — but `halting_gate` returns the FIRST bare self-send it walks
-    # to, which here is the block-taking `with_format`, not the `halt` inside.
-    # `Runner#resolve_gates!` then looks for the ivar `with_format` writes,
-    # finds none, and drops the spec. The gate should be a list of candidates,
-    # with the runner keeping the first that resolves.
+    # The guard WAS recognized — `walk_sends` has always handled block-nested
+    # sends. What failed was naming the gate: `halting_gate` committed to the
+    # FIRST bare self-send, here the block-taking `with_format`, which writes
+    # nothing, so `Runner#resolve_gates!` found no ivar and dropped the spec.
     #
-    # Because the condition tests a SELF-METHOD, the failure also surfaces one
+    # No position is reliably the halt: this shape puts it last, while
+    # `redirect_to root_path` puts it first (the second send is an argument). So
+    # the gate became a list of candidates in source order, resolved by the
+    # Runner — which is the side that knows which of them writes what.
+    #
+    # Because the condition tests a SELF-METHOD, the failure also surfaced one
     # frame up, as a precondition contract error on the call to the action
-    # (`requires `self.current_user` to be non-nil here`) — the checker
-    # naming the exact fact the guard was supposed to supply.
+    # (`requires `self.current_user` to be non-nil here`) — the checker naming
+    # the exact fact the guard was supposed to supply.
     # -------------------------------------------------------------------------
     def guard_block_halt
       unless current_user
@@ -257,7 +261,7 @@ class Example13
     end
 
     def act_block_halt
-      current_user.name.upcase # should: no error; actual: error (gap 3)
+      current_user.name.upcase # should: no error; actual: no error
     end
 
     # -------------------------------------------------------------------------

--- a/spec/dummy/sig/generated/.steep_contracts.yml
+++ b/spec/dummy/sig/generated/.steep_contracts.yml
@@ -124,41 +124,7 @@ methods:
         receiver:
           kind: self
         method: body
-  Example13::Guarded#act_block_halt:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: current_user
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: current_user
-        chain:
-        - name
-    enforced: false
   Example13::Guarded#act_implicit_return:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: current_user
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: current_user
-        chain:
-        - name
-    enforced: false
-  Example13::Guarded#run_block_halt:
     requires:
     - kind: not_nil
       expr:

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -289,6 +289,10 @@ postconditions:
   effects:
     may_write:
     - "@halted"
+  conditional_returns:
+    current_user:
+      gate_ivar: "@halted"
+      type: "::Example13Viewer"
 - class: Example13::Guarded
   method: guard_composite
   effects:
@@ -1261,6 +1265,10 @@ method_entry_facts:
   method: dispatch_name
   ivars:
     "@name": "::String"
+- class: Example13::Guarded
+  method: act_block_halt
+  self_methods:
+    current_user: "::Example13Viewer"
 - class: Example13::Guarded
   method: act_conjunction
   consts:

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -10,10 +10,7 @@ app/models/example10.rb:27:26: [error] Type `(::String | nil)` does not have met
 app/models/example13.rb:220:6: [error] `act_implicit_return` requires `self.current_user.name` to be non-nil here
 app/models/example13.rb:220:6: [error] `act_implicit_return` requires `self.current_user` to be non-nil here
 app/models/example13.rb:224:19: [error] Type `(::Example13Viewer | nil)` does not have method `name`
-app/models/example13.rb:256:6: [error] `act_block_halt` requires `self.current_user.name` to be non-nil here
-app/models/example13.rb:256:6: [error] `act_block_halt` requires `self.current_user` to be non-nil here
-app/models/example13.rb:260:19: [error] Type `(::Example13Viewer | nil)` does not have method `name`
-app/models/example13.rb:286:20: [error] Type `(::Example13Viewer | nil)` does not have method `name`
+app/models/example13.rb:290:20: [error] Type `(::Example13Viewer | nil)` does not have method `name`
 app/models/example3.rb:122:11: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:63:13: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:64:26: [error] Type `(::Example3::User | nil)` does not have method `name`

--- a/spec/expectations/steep_contracts.yml
+++ b/spec/expectations/steep_contracts.yml
@@ -124,41 +124,7 @@ methods:
         receiver:
           kind: self
         method: body
-  Example13::Guarded#act_block_halt:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: current_user
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: current_user
-        chain:
-        - name
-    enforced: false
   Example13::Guarded#act_implicit_return:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: current_user
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: current_user
-        chain:
-        - name
-    enforced: false
-  Example13::Guarded#run_block_halt:
     requires:
     - kind: not_nil
       expr:


### PR DESCRIPTION
Companion to felixefelip/steep#110. **Depends on it** — reads red until that merges, green after.

Baseline **37 → 34**. The three entries that go:

```
-app/models/example13.rb:256:6: [error] `act_block_halt` requires `self.current_user.name` to be non-nil here
-app/models/example13.rb:256:6: [error] `act_block_halt` requires `self.current_user` to be non-nil here
-app/models/example13.rb:260:19: [error] Type `(::Example13Viewer | nil)` does not have method `name`
```

`spec/expectations/steep_contracts.yml` also drops `Example13::Guarded#act_block_halt` entirely — the guard now supplies what that method required, so there is nothing left to demand of its callers. That is a second, independent confirmation the fact actually landed rather than the error merely moving.

The gap 3 block comment becomes what closed it, keeping the distinction the fix turned on: the guard was always *recognized* (`walk_sends` descends into blocks), and it was *naming the gate* that failed.

## Remaining

Gap 2 (implicit return) and the composite, which still needs it.

794 examples, 0 failures.

Refs: felixefelip/steep#105, felixefelip/steep#110

🤖 Generated with [Claude Code](https://claude.com/claude-code)
