### PR TITLE
test(dummy): example13 goes green — every halting-guard gap is closed

### DIFF
--- a/spec/dummy/app/models/example13.rb
+++ b/spec/dummy/app/models/example13.rb
@@ -51,9 +51,11 @@ class Example13
   # facts are attributed to the methods a flow calls after the halt check, not to
   # the remainder of the flow's own body.
   #
-  # `# should:` vs `# actual:` records today's behavior and flips when the fork
-  # closes a gap; a closed one stays here as its regression guard. Errors are
-  # pinned by spec/expectations/steep_baseline.txt.
+  # Every gap here is now CLOSED (felixefelip/steep#106 through #111), so the file
+  # produces no errors at all and its whole job is to be the regression guard: the
+  # baseline check fails on any NEW error, so a gap reopening surfaces as itself
+  # rather than as a number going up. Each block below records what closed it, and
+  # the `# should:` / `# actual:` markers are what flip if one comes back.
   # ---------------------------------------------------------------------------
   class Guarded
     def initialize(name:)
@@ -193,19 +195,24 @@ class Example13
     end
 
     # -------------------------------------------------------------------------
-    # GAP 2 — no explicit `return`. The condition is the CONTROL's bare
-    # self-send; the only change is that the guard is the method's last
-    # statement, so falling off the end is exactly a return. `clause_returns?`
-    # walks for a `:return` node and finds none.
+    # GAP 2 — CLOSED by felixefelip/steep#111. No explicit `return`: the
+    # condition is the CONTROL's bare self-send, and the only change is that the
+    # guard is the method's last statement, so falling off the end is exactly a
+    # return. `clause_returns?` walked for a `:return` node and found none.
     #
-    # The fix has to stay narrow — "the guard is the final statement", not
-    # "returns are optional". A halting clause that is not last does NOT halt
-    # the method; execution continues past it.
+    # The rule stayed narrow on purpose — "the guard is the FINAL statement", not
+    # "returns are optional". A halting clause with code after it does not end
+    # the method; execution continues past the `if`, and proving anything there
+    # would be a fact about a path that keeps going. That is the only place in
+    # this grammar where being too permissive yields a WRONG proof rather than a
+    # missing one, so the boundary is pinned on the fork side by a pair of tests:
+    # the same clause proves nothing with a statement after it, and proves again
+    # as soon as an explicit `return` is put back.
     #
-    # Because the condition tests a SELF-METHOD, the failure also surfaces one
+    # Because the condition tests a SELF-METHOD, the failure also surfaced one
     # frame up, as a precondition contract error on the call to the action
-    # (`requires `self.current_user` to be non-nil here`) — the checker
-    # naming the exact fact the guard was supposed to supply.
+    # (`requires `self.current_user` to be non-nil here`) — the checker naming
+    # the exact fact the guard was supposed to supply.
     # -------------------------------------------------------------------------
     def guard_implicit_return
       unless current_user
@@ -221,7 +228,7 @@ class Example13
     end
 
     def act_implicit_return
-      current_user.name.upcase # should: no error; actual: error (gap 2)
+      current_user.name.upcase # should: no error; actual: no error
     end
 
     # -------------------------------------------------------------------------
@@ -270,6 +277,10 @@ class Example13
     # framework names removed: a conjunction of const-rooted tests, one through
     # `&.`, halting inside a block, with no `return` because the guard is the
     # method's last statement.
+    #
+    # It was the last thing in this file to go green, and it needed every one of
+    # the five fixes: it kept failing while any single gap remained open, which
+    # is exactly why the file bisects them instead of leading with this.
     # -------------------------------------------------------------------------
     def guard_composite
       unless Registry.tenant && Registry.user&.active?
@@ -287,7 +298,7 @@ class Example13
     end
 
     def act_composite
-      Registry.user.name.upcase # should: no error; actual: error (composite)
+      Registry.user.name.upcase # should: no error; actual: no error
     end
   end
 

--- a/spec/dummy/sig/generated/.steep_contracts.yml
+++ b/spec/dummy/sig/generated/.steep_contracts.yml
@@ -124,40 +124,6 @@ methods:
         receiver:
           kind: self
         method: body
-  Example13::Guarded#act_implicit_return:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: current_user
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: current_user
-        chain:
-        - name
-    enforced: false
-  Example13::Guarded#run_implicit_return:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: current_user
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: current_user
-        chain:
-        - name
-    enforced: false
   Post#author_name:
     requires:
     - kind: not_nil

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -298,6 +298,13 @@ postconditions:
   effects:
     may_write:
     - "@halted"
+  conditional_const_returns:
+    Example13::Registry.tenant:
+      gate_ivar: "@halted"
+      type: "::Example13Tenant"
+    Example13::Registry.user:
+      gate_ivar: "@halted"
+      type: "::Example13Viewer"
 - class: Example13::Guarded
   method: guard_conjunction
   effects:
@@ -324,6 +331,10 @@ postconditions:
   effects:
     may_write:
     - "@halted"
+  conditional_returns:
+    current_user:
+      gate_ivar: "@halted"
+      type: "::Example13Viewer"
 - class: Example13::Guarded
   method: guard_safe_navigation
   effects:
@@ -1270,6 +1281,11 @@ method_entry_facts:
   self_methods:
     current_user: "::Example13Viewer"
 - class: Example13::Guarded
+  method: act_composite
+  consts:
+    Example13::Registry.tenant: "::Example13Tenant"
+    Example13::Registry.user: "::Example13Viewer"
+- class: Example13::Guarded
   method: act_conjunction
   consts:
     Example13::Registry.tenant: "::Example13Tenant"
@@ -1279,6 +1295,10 @@ method_entry_facts:
   consts:
     Example13::Registry.user: "::Example13Viewer"
 - class: Example13::Guarded
+  method: act_implicit_return
+  self_methods:
+    current_user: "::Example13Viewer"
+- class: Example13::Guarded
   method: act_safe_navigation
   consts:
     Example13::Registry.user: "::Example13Viewer"
@@ -1286,6 +1306,14 @@ method_entry_facts:
   method: act_supported
   self_methods:
     current_user: "::Example13Viewer"
+  consts:
+    Example13::Registry.user: "::Example13Viewer"
+- class: Example13::Guarded
+  method: current_user
+  self_methods:
+    current_user: "::Example13Viewer"
+- class: Example13::Registry
+  method: user
   consts:
     Example13::Registry.user: "::Example13Viewer"
 - class: Example4

--- a/spec/dummy/sig/rbs_infer/app/models/example13.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example13.rbs
@@ -1,5 +1,5 @@
 class Example13
-  def self.run: () -> untyped
+  def self.run: () -> String?
 end
 
 class Example13
@@ -50,8 +50,8 @@ class Example13
     def run_block_halt: () -> String?
     def act_block_halt: () -> String
     def guard_composite: () -> untyped
-    def run_composite: () -> untyped
-    def act_composite: () -> untyped
+    def run_composite: () -> String?
+    def act_composite: () -> String
   end
 end
 

--- a/spec/expectations/models/example13.rbs
+++ b/spec/expectations/models/example13.rbs
@@ -1,5 +1,5 @@
 class Example13
-  def self.run: () -> untyped
+  def self.run: () -> String?
 end
 
 class Example13
@@ -50,8 +50,8 @@ class Example13
     def run_block_halt: () -> String?
     def act_block_halt: () -> String
     def guard_composite: () -> untyped
-    def run_composite: () -> untyped
-    def act_composite: () -> untyped
+    def run_composite: () -> String?
+    def act_composite: () -> String
   end
 end
 

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -7,10 +7,6 @@ app/models/concerns/test/filtrable.rb:7:4: [error] Type `(singleton(::Test) & si
 app/models/concerns/test/filtrable.rb:8:26: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `where`
 app/models/concerns/test/filtrable.rb:8:4: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `scope`
 app/models/example10.rb:27:26: [error] Type `(::String | nil)` does not have method `upcase`
-app/models/example13.rb:220:6: [error] `act_implicit_return` requires `self.current_user.name` to be non-nil here
-app/models/example13.rb:220:6: [error] `act_implicit_return` requires `self.current_user` to be non-nil here
-app/models/example13.rb:224:19: [error] Type `(::Example13Viewer | nil)` does not have method `name`
-app/models/example13.rb:290:20: [error] Type `(::Example13Viewer | nil)` does not have method `name`
 app/models/example3.rb:122:11: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:63:13: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:64:26: [error] Type `(::Example3::User | nil)` does not have method `name`

--- a/spec/expectations/steep_contracts.yml
+++ b/spec/expectations/steep_contracts.yml
@@ -124,40 +124,6 @@ methods:
         receiver:
           kind: self
         method: body
-  Example13::Guarded#act_implicit_return:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: current_user
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: current_user
-        chain:
-        - name
-    enforced: false
-  Example13::Guarded#run_implicit_return:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: current_user
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: current_user
-        chain:
-        - name
-    enforced: false
   Post#author_name:
     requires:
     - kind: not_nil


### PR DESCRIPTION
Companion to felixefelip/steep#111. **Depends on it** — reads red until that merges, green after.

Baseline **34 → 30**, and `example13` leaves the error list entirely, taking `Example13::Guarded#act_implicit_return`'s entry in `steep_contracts.yml` with it.

## The composite is the one worth noting

It stayed red through all four earlier fixes and needed every one of the five, because it is all of them at once:

```ruby
def guard_composite
  unless Registry.tenant && Registry.user&.active?
    with_format do |_format|
      halt
    end
  end
end
```

A conjunction of const-rooted tests, one through `&.`, halting inside a block, with no `return` because the guard is the method's last statement. That is `Authorization#ensure_can_access_account` from a real app with the framework names removed — and reaching an action past it was the only thing proving `Current.user` non-nil there, which is where this whole line of work started.

## What the file is for now

Its job flips. With no errors left, the baseline pins it by failing on any **new** one, so a gap reopening surfaces as itself rather than as a count going up. Each block records what closed it, and the `# should:` / `# actual:` markers are what flip if one comes back.

794 examples, 0 failures.

Refs: felixefelip/steep#105, felixefelip/steep#111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
