### PR TITLE
fix(ar_runtime): resolve a has_many :through element through the chain

### DIFF
--- a/lib/rbs_infer/extensions/rails/active_record/runtime/concern_resolver.rb
+++ b/lib/rbs_infer/extensions/rails/active_record/runtime/concern_resolver.rb
@@ -46,20 +46,43 @@ module RbsInfer
             module_function
 
             # units: every `ModelReflections` scanned, classes and modules.
-            # Returns the CLASS units only, each with its includes expanded and
-            # the ones left with nothing to model dropped.
+            # Returns the CLASS units only, each with its includes expanded.
+            #
+            # A class left with nothing to model is KEPT: this list is also the
+            # table the element resolver looks classes up in, and a model that
+            # declares no association of its own is still a valid element for
+            # someone else's `has_many` (felixefelip/rbs_infer#141). Emitting
+            # nothing for it is the builder's call, not this one's.
             def resolve(units)
-              by_name = units.to_h { |unit| [unit.class_name, unit] }
+              concerns = index_concerns(units)
 
-              units.select { |unit| unit.kind == :class }.filter_map do |unit|
-                resolved = ModelReflections.new(
-                  path: unit.path,
-                  class_name: unit.class_name,
-                  kind: :class,
-                  body: expand(unit, by_name, Set.new)
-                )
-                resolved unless resolved.empty?
-              end
+              units.select { |unit| unit.kind == :class }
+                .group_by(&:class_name)
+                .map { |class_name, reopens| merge(class_name, reopens, concerns) }
+            end
+
+            # Every reopen of the same class is ONE model: Ruby reopens a class
+            # rather than replacing it, so `class Post` written in two files
+            # registers the associations of both.
+            #
+            # Indexing by name and letting one win dropped the other's
+            # reflections: `class Post` reopened only to nest `Post::Archiver`
+            # erased Post's own `belongs_to :user`, and with it the construction
+            # flow of every proxy whose `build` needed that inverse.
+            def merge(class_name, reopens, concerns)
+              ModelReflections.new(
+                path: reopens.first.path,
+                class_name: class_name,
+                kind: :class,
+                body: reopens.flat_map { |unit| expand(unit, concerns, Set.new) }
+              )
+            end
+
+            # Only MODULES are ever spliced, so only modules are in the lookup
+            # table — which also settles what a class and a concern sharing a
+            # name resolve to, without the answer depending on scan order.
+            def index_concerns(units)
+              units.select { |unit| unit.kind == :module }.to_h { |unit| [unit.class_name, unit] }
             end
 
             # The unit's body with every `Include` replaced by the included
@@ -70,7 +93,7 @@ module RbsInfer
             # `visited` makes a re-include a no-op, matching Ruby (a module
             # already in the ancestor chain is not inserted twice) and cutting
             # any cycle a mutually-including pair would create.
-            def expand(unit, by_name, visited)
+            def expand(unit, concerns, visited)
               return [] if visited.include?(unit.class_name)
 
               visited << unit.class_name
@@ -78,20 +101,20 @@ module RbsInfer
               unit.body.flat_map do |entry|
                 next [entry] unless entry.is_a?(Include)
 
-                concern = lookup(entry.name, unit.class_name, by_name)
-                concern && concern.kind == :module ? expand(concern, by_name, visited) : []
+                concern = lookup(entry.name, unit.class_name, concerns)
+                concern ? expand(concern, concerns, visited) : []
               end
             end
 
             # `include Taggable` inside `class Post` is `Post::Taggable` when that
             # exists — Ruby resolves a bare constant from the enclosing namespace
             # outward, and a concern is conventionally nested under its host.
-            def lookup(name, enclosing, by_name)
+            def lookup(name, enclosing, concerns)
               found = RbsInfer::AST::LexicalConstantResolver.resolve(
                 name: name, enclosing: enclosing
-              ) { |candidate| by_name.key?(candidate) }
+              ) { |candidate| concerns.key?(candidate) }
 
-              found && by_name[found]
+              found && concerns[found]
             end
           end
         end

--- a/lib/rbs_infer/extensions/rails/active_record/runtime/pseudo_code_builder.rb
+++ b/lib/rbs_infer/extensions/rails/active_record/runtime/pseudo_code_builder.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
+require "set"
 require "active_support/core_ext/string/inflections"
 require_relative "../../../../ast/lexical_constant_resolver"
+require_relative "reflection_scanner"
 
 module RbsInfer
   module Extensions
@@ -42,6 +44,7 @@ module RbsInfer
             def initialize(models:)
               @models = models
               @by_class = models.to_h { |m| [m.class_name, m] }
+              @elements = {}
             end
 
             # Returns [FileEntry], or [] when nothing qualifies (no model has a
@@ -86,7 +89,7 @@ module RbsInfer
                   # emitting it), so `owner.<assoc>` types via this pseudo-code.
                   # An element outside the scanned models can't be modeled
                   # (its class/proxy may not exist), so it's skipped.
-                  element = resolve_element(model.class_name, assoc.class_name)
+                  element = element_for(model, assoc)
                   next unless element
 
                   plan[model.class_name][:getters] << {
@@ -149,23 +152,48 @@ module RbsInfer
             # `owner`) so rbs_infer types `owner` from the getter call-site.
             # When the element has an inverse belongs_to back at the owner, the
             # proxy also gets the construction flow (`build`/`create`/`create!`);
-            # without one (e.g. a `has_many :through`), only owner capture is
-            # emitted and construction is inherited from the real proxy.
+            # without one, only owner capture is emitted and construction is
+            # inherited from the real proxy.
             def proxy_reopens
-              seen = {}
-              @models.flat_map do |owner|
-                owner.has_many.filter_map do |assoc|
-                  element = resolve_element(owner.class_name, assoc.class_name)
+              proxy_plan.map do |ns, info|
+                FileEntry.new(filename: "#{file_name(ns)}.rb", source: proxy_source(ns, info[:element], info[:inverse]))
+              end
+            end
+
+            # ns => { element:, inverse: }.
+            #
+            # The namespace is per (owner, ELEMENT) pair, so several associations
+            # can land on the same one — `comments` and `accessible_comments` are
+            # both User -> Comment. The candidate that models construction wins
+            # whatever the declaration order is: a concern's `include` sits above
+            # the class's own macros, so `accessible_comments` is reached first,
+            # and taking the first would strip `user.comments.create` of its
+            # construction flow.
+            def proxy_plan
+              plan = {}
+
+              @models.each do |owner|
+                owner.has_many.each do |assoc|
+                  element = element_for(owner, assoc)
                   next unless element
 
                   ns = proxy_namespace(owner.class_name, element.class_name)
-                  next if seen[ns]
-
-                  seen[ns] = true
-                  inverse = element.inverse_belongs_to_for(owner.class_name)
-                  FileEntry.new(filename: "#{file_name(ns)}.rb", source: proxy_source(ns, element.class_name, inverse))
+                  inverse = inverse_for(owner, assoc, element)
+                  plan[ns] = { element: element.class_name, inverse: inverse } if inverse || !plan.key?(ns)
                 end
               end
+
+              plan
+            end
+
+            # The belongs_to that `build` establishes from the owner — none for a
+            # `through:` association: Active Record builds the element WITHOUT
+            # pointing it back at the owner there (`user.accessible_cards.build`
+            # leaves `creator` unset, since the row that links them lives on the
+            # join). Emitting `record.creator = owner` would hand the contract
+            # machinery a fact the runtime never establishes.
+            def inverse_for(owner, assoc, element)
+              element.inverse_belongs_to_for(owner.class_name) unless assoc.through
             end
 
             def proxy_source(ns, element_class, inverse)
@@ -231,8 +259,80 @@ module RbsInfer
               "#{(header + lines).join("\n")}\n"
             end
 
-            # The model an association names, resolved the way Ruby (and therefore
-            # `ActiveRecord::Base.compute_type`) resolves the constant: from the owner's
+            # --- element resolution ------------------------------------------
+
+            # The model a `has_many`'s elements are, resolved the way Active
+            # Record resolves it: by walking the `through:` chain when there is
+            # one, and otherwise from the written (or conventional) class name.
+            # nil when the element is outside the scanned models — neither its
+            # class nor its proxy would exist, so it cannot be modeled.
+            #
+            # Deriving it from the ASSOCIATION NAME alone dropped every through
+            # association whose name is not the element's: `has_many
+            # :accessible_cards, through: :boards, source: :cards` guessed
+            # `AccessibleCard`, found no such model, and emitted neither the
+            # getter nor the proxy — `user.accessible_cards` had no type at all
+            # (felixefelip/rbs_infer#141).
+            def element_for(owner, assoc, seen = Set.new)
+              key = [owner.class_name, assoc.name]
+              return @elements[key] if @elements.key?(key)
+              return nil unless seen.add?(key)
+
+              @elements[key] =
+                if assoc.through
+                  # `class_name:` is not what names a through association's
+                  # element (Active Record takes it from the source reflection),
+                  # so the chain decides. The conventional name is the fallback
+                  # for a `through:` this scan cannot follow — a `has_one`, or an
+                  # association declared in a gem.
+                  through_element(owner, assoc, seen) || resolve_constant(assoc.class_name, owner.class_name)
+                else
+                  resolve_constant(assoc.class_name, owner.class_name)
+                end
+            end
+
+            # `has_many :accessible_cards, through: :boards, source: :cards` is
+            # `Card`: hop to the owner's `boards` — itself possibly a through,
+            # hence the recursion, since `accessible_comments` goes through
+            # `accessible_cards` — then read `cards` off THAT model, which is
+            # where the element's name (and any `class_name:` on it) lives.
+            def through_element(owner, assoc, seen)
+              hop = association_named(owner, assoc.through)
+              return nil unless hop
+
+              hop_model = association_element(owner, hop, seen)
+              return nil unless hop_model
+
+              source = source_association(hop_model, assoc)
+              source && association_element(hop_model, source, seen)
+            end
+
+            # The source reflection Active Record looks for: the `source:` name
+            # when given, and otherwise the association's own name in singular
+            # then plural. `has_many :assignees, through: :assignments` reads
+            # `assignee` off `Assignment` — which is where `class_name: "User"`
+            # is written, and why guessing from `assignees` cannot work.
+            def source_association(hop_model, assoc)
+              names = assoc.source ? [assoc.source] : [assoc.name.singularize, assoc.name].uniq
+              names.filter_map { |name| association_named(hop_model, name) }.first
+            end
+
+            def association_named(model, name)
+              model.has_many.find { |a| a.name == name } || model.belongs_to.find { |b| b.name == name }
+            end
+
+            # A hop lands on a model either through a collection — recursing,
+            # since a `through:` can chain — or through a `belongs_to`, which
+            # names its element directly.
+            def association_element(owner, assoc, seen)
+              case assoc
+              when HasMany then element_for(owner, assoc, seen)
+              when BelongsTo then resolve_constant(assoc.class_name, owner.class_name)
+              end
+            end
+
+            # The model a written constant names, resolved the way Ruby (and therefore
+            # `ActiveRecord::Base.compute_type`) resolves it: from the owner's
             # namespace outward. `has_many :recomendacao_vacinas` inside `Caderneta` is
             # `Caderneta::RecomendacaoVacina` when that exists, and only then the top-level
             # `RecomendacaoVacina` (felixefelip/rbs_infer#128).
@@ -243,7 +343,7 @@ module RbsInfer
             # had no type at all. The walk itself lives in `LexicalConstantResolver` —
             # shared with every other site that turns a written constant into a class
             # (felixefelip/rbs_infer#129); the scanned-model table is the oracle.
-            def resolve_element(owner_class, element_class)
+            def resolve_constant(element_class, owner_class)
               found = RbsInfer::AST::LexicalConstantResolver.resolve(
                 name: element_class, enclosing: owner_class
               ) { |candidate| @by_class.key?(candidate) }

--- a/lib/rbs_infer/extensions/rails/active_record/runtime/reflection_scanner.rb
+++ b/lib/rbs_infer/extensions/rails/active_record/runtime/reflection_scanner.rb
@@ -9,7 +9,14 @@ module RbsInfer
       module ActiveRecord
         module Runtime
           BelongsTo = Struct.new(:name, :class_name, :default_body, keyword_init: true)
-          HasMany   = Struct.new(:name, :class_name, keyword_init: true)
+
+          # `through`/`source` are the `has_many :through` options, kept raw
+          # because the element's class is NOT knowable from this file: it lives
+          # on the model the chain hops to (`has_many :assignees, through:
+          # :assignments` is `User`, because `Assignment belongs_to :assignee,
+          # class_name: "User"`). `class_name` here is the conventional guess
+          # from the association name, which the resolver only falls back to.
+          HasMany   = Struct.new(:name, :class_name, :through, :source, keyword_init: true)
 
           # `before_validation :a, :b` — one entry per macro call, so the
           # declaration ORDER survives the concern splice (Rails runs the
@@ -58,11 +65,6 @@ module RbsInfer
               body.grep(Include).map(&:name)
             end
 
-            # Nothing for the generator to model.
-            def empty?
-              belongs_to.empty? && has_many.empty? && before_validation_callbacks.empty?
-            end
-
             # The `belongs_to` on this model whose target is `owner_class` — the
             # inverse the association-construction path sets (`record.post =
             # owner`). nil when no belongs_to points back at the owner.
@@ -105,7 +107,17 @@ module RbsInfer
 
               is_class = node.is_a?(Prism::ClassNode)
               body = is_class ? class_body(node) : concern_body(node)
-              return nil if body.empty?
+
+              # A CLASS is kept even when it declares nothing, because the set of
+              # scanned classes is also the ORACLE the element resolver consults:
+              # `has_many :data_exports, class_name: "User::DataExport"` is only
+              # modelable if `User::DataExport` is in it, and that model declares
+              # no association of its own (felixefelip/rbs_infer#141). It still
+              # produces no reopen — the builder emits for what needs one.
+              #
+              # A concern that declares nothing has nothing to splice, and is not
+              # a model, so it is dropped here.
+              return nil if !is_class && body.empty?
 
               ModelReflections.new(
                 path: path,
@@ -147,7 +159,12 @@ module RbsInfer
                 )]
               when :has_many
                 name = first_symbol(stmt) or return []
-                [HasMany.new(name: name, class_name: has_many_class(name, stmt))]
+                [HasMany.new(
+                  name: name,
+                  class_name: has_many_class(name, stmt),
+                  through: symbol_kwarg(stmt, "through"),
+                  source: symbol_kwarg(stmt, "source")
+                )]
               when :before_validation
                 names = symbol_args(stmt)
                 names.empty? ? [] : [BeforeValidation.new(names: names)]
@@ -219,13 +236,25 @@ module RbsInfer
             end
 
             def string_kwarg(call, key)
+              node = kwarg(call, key)
+              node.is_a?(Prism::StringNode) ? node.unescaped : nil
+            end
+
+            # `through: :boards` -> "boards". A non-literal (`source: SOURCE`)
+            # names nothing this scan can follow.
+            def symbol_kwarg(call, key)
+              node = kwarg(call, key)
+              node.is_a?(Prism::SymbolNode) ? node.value.to_s : nil
+            end
+
+            def kwarg(call, key)
               hash = call.arguments.arguments.find { |a| a.is_a?(Prism::KeywordHashNode) }
               return nil unless hash
 
               assoc = hash.elements.find do |elem|
                 elem.is_a?(Prism::AssocNode) && elem.key.is_a?(Prism::SymbolNode) && elem.key.value.to_s == key
               end
-              assoc&.value.is_a?(Prism::StringNode) ? assoc.value.unescaped : nil
+              assoc&.value
             end
           end
         end

--- a/spec/lib/rbs_infer/extensions/rails/active_record/runtime_generator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/active_record/runtime_generator_spec.rb
@@ -332,6 +332,161 @@ RSpec.describe RbsInfer::Extensions::Rails::ActiveRecord::RuntimeGenerator do
     end
   end
 
+  # felixefelip/rbs_infer#141. A `has_many :through`'s element class is not
+  # knowable from the association's name: `has_many :accessible_cards, through:
+  # :boards, source: :cards` is `Card`. Guessing `AccessibleCard` found no
+  # scanned model, so the association was dropped whole — no getter, no proxy,
+  # and `user.accessible_cards` with no type at all. 11 of fizzy's 64 has_many
+  # were going out this way.
+  describe "has_many :through element resolution" do
+    ACCESS = "class Access < ApplicationRecord\n  belongs_to :user\n  belongs_to :board\nend\n"
+    BOARD = "class Board < ApplicationRecord\n  has_many :cards\nend\n"
+    CARD = "class Card < ApplicationRecord\n  belongs_to :board\n  has_many :comments\nend\n"
+    CARD_COMMENT = "class Comment < ApplicationRecord\n  belongs_to :card\nend\n"
+
+    ACCESSOR = <<~RUBY
+      class User < ApplicationRecord
+        has_many :accesses
+        has_many :boards, through: :accesses
+        has_many :accessible_cards, through: :boards, source: :cards
+        has_many :accessible_comments, through: :accessible_cards, source: :comments
+      end
+    RUBY
+
+    def accessor_app(extra = {})
+      in_app({
+        "app/models/user.rb" => ACCESSOR,
+        "app/models/access.rb" => ACCESS,
+        "app/models/board.rb" => BOARD,
+        "app/models/card.rb" => CARD,
+        "app/models/comment.rb" => CARD_COMMENT
+      }.merge(extra)) { |dir| yield described_class.new(app_dir: dir).build }
+    end
+
+    it "reads the element off the `source:` association of the through model" do
+      accessor_app do |files|
+        expect(source_of(files, "user.rb")).to match(
+          /def accessible_cards\n\s*User_Card::ActiveRecord_Associations_CollectionProxy\.new\(Card, self\)/
+        )
+      end
+    end
+
+    it "follows a through whose target is itself a through" do
+      # `accessible_comments` hops to `accessible_cards` — a through association
+      # too — so the walk has to recurse before it can read `comments` off Card.
+      accessor_app do |files|
+        expect(source_of(files, "user.rb")).to match(
+          /def accessible_comments\n\s*User_Comment::ActiveRecord_Associations_CollectionProxy\.new\(Comment, self\)/
+        )
+      end
+    end
+
+    it "honours class_name: on the source reflection, with no `source:` written" do
+      # `has_many :assignees, through: :assignments` takes its element from
+      # `Assignment`'s `assignee` reflection — where `class_name: "User"` is
+      # written. Nothing in the owner's file spells `User`, which is why the
+      # name-based guess (`Assignee`) cannot work even in principle.
+      in_app(
+        "app/models/post.rb" => "class Post < ApplicationRecord\n  has_many :assignments\n  has_many :assignees, through: :assignments\nend\n",
+        "app/models/assignment.rb" => "class Assignment < ApplicationRecord\n  belongs_to :post\n  belongs_to :assignee, class_name: \"User\"\nend\n",
+        "app/models/user.rb" => "class User < ApplicationRecord\nend\n"
+      ) do |dir|
+        expect(source_of(described_class.new(app_dir: dir).build, "post.rb")).to match(
+          /def assignees\n\s*Post_User::ActiveRecord_Associations_CollectionProxy\.new\(User, self\)/
+        )
+      end
+    end
+
+    it "resolves an element that declares no association of its own" do
+      # `User::DataExport` is a model with nothing but methods. It was absent
+      # from the scanned-model table, so `has_many :data_exports` resolved to
+      # nothing — the element has to be a known CLASS, not a known association
+      # holder.
+      in_app(
+        "app/models/user.rb" => "class User < ApplicationRecord\n  has_many :data_exports, class_name: \"User::DataExport\"\nend\n",
+        "app/models/user/data_export.rb" => "class User::DataExport < Export\n  def filename\n    \"x.zip\"\n  end\nend\n"
+      ) do |dir|
+        files = described_class.new(app_dir: dir).build
+        expect(source_of(files, "user.rb")).to match(
+          /def data_exports\n\s*User_User_DataExport::ActiveRecord_Associations_CollectionProxy\.new\(User::DataExport, self\)/
+        )
+        # It needs no reopen of its own — no callbacks, no has_many.
+        expect(files.map(&:filename)).not_to include("user_data_export.rb")
+      end
+    end
+
+    it "falls back to the conventional name when the through cannot be followed" do
+      # `through:` naming a `has_one` (not scanned) or a gem's association leaves
+      # the chain unresolvable; the name-based guess is still right for the common
+      # `has_many :tags, through: :taggings` shape, so it stays as the fallback.
+      in_app(
+        "app/models/post.rb" => "class Post < ApplicationRecord\n  has_many :tags, through: :taggings\nend\n",
+        "app/models/tag.rb" => "class Tag < ApplicationRecord\n  belongs_to :post\nend\n"
+      ) do |dir|
+        expect(source_of(described_class.new(app_dir: dir).build, "post.rb")).to match(
+          /def tags\n\s*Post_Tag::ActiveRecord_Associations_CollectionProxy\.new\(Tag, self\)/
+        )
+      end
+    end
+
+    it "does not loop on associations that go through each other" do
+      # Neither resolves (Rails would raise on this too); the point is that it
+      # terminates rather than recursing forever.
+      in_app("app/models/loop.rb" => "class Loop < ApplicationRecord\n  has_many :as, through: :bs\n  has_many :bs, through: :as\nend\n") do |dir|
+        expect(described_class.new(app_dir: dir).build).to be_empty
+      end
+    end
+  end
+
+  describe "construction flow through a has_many :through" do
+    # `user.pinned_cards.build` does NOT set `card.user` — the row that links
+    # them lives on the join, so Active Record leaves the element's belongs_to
+    # alone. Emitting `record.user = owner` would hand the contract machinery a
+    # fact the runtime never establishes.
+    PIN = "class Pin < ApplicationRecord\n  belongs_to :user\n  belongs_to :card\nend\n"
+    OWNED_CARD = "class Card < ApplicationRecord\n  belongs_to :user\nend\n"
+
+    it "omits build when the only association reaching the element is a through" do
+      through_only = "class User < ApplicationRecord\n  has_many :pins\n  has_many :pinned_cards, through: :pins, source: :card\nend\n"
+      in_app("app/models/user.rb" => through_only, "app/models/pin.rb" => PIN, "app/models/card.rb" => OWNED_CARD) do |dir|
+        proxy = source_of(described_class.new(app_dir: dir).build, "user_card.rb")
+
+        expect(proxy).to match(/def owner\n\s*@owner\n\s*end/)
+        expect(proxy).not_to include("def build")
+        expect(proxy).not_to include("record.user = owner")
+      end
+    end
+
+    it "keeps build when a direct association shares the proxy namespace" do
+      # The namespace is per (owner, element) pair, so `cards` and `pinned_cards`
+      # are both `User_Card`. The through one is declared first — as a concern's
+      # would be, sitting above the class's own macros — and taking the first
+      # candidate would cost `user.cards.create` its construction flow.
+      both = "class User < ApplicationRecord\n  has_many :pins\n  has_many :pinned_cards, through: :pins, source: :card\n  has_many :cards\nend\n"
+      in_app("app/models/user.rb" => both, "app/models/pin.rb" => PIN, "app/models/card.rb" => OWNED_CARD) do |dir|
+        proxy = source_of(described_class.new(app_dir: dir).build, "user_card.rb")
+
+        expect(proxy).to match(/def build\(\*\)\n\s*record = Card\.new\n\s*record\.user = owner\n\s*record\n\s*end/)
+      end
+    end
+  end
+
+  describe "a class reopened in several files" do
+    it "keeps the reflections of every reopen" do
+      # Ruby reopens a class rather than replacing it, so both files register.
+      # Indexing by name and letting one win dropped the other's reflections: a
+      # `class Post` opened only to nest `Post::Archiver` erased Post's own
+      # `belongs_to :user`, and with it `build`'s inverse.
+      in_app(
+        "app/models/user.rb" => "class User < ApplicationRecord\n  has_many :posts\nend\n",
+        "app/models/post.rb" => "class Post < ApplicationRecord\n  belongs_to :user\nend\n",
+        "app/models/post/archiver.rb" => "class Post\n  class Archiver\n  end\nend\n"
+      ) do |dir|
+        expect(source_of(described_class.new(app_dir: dir).build, "user_post.rb")).to include("record.user = owner")
+      end
+    end
+  end
+
   describe "proxy reopen (construction flow)" do
     it "captures the owner and reopens with build/new/create/create!" do
       in_app("app/models/assignment.rb" => ASSIGNMENT, "app/models/post.rb" => POST) do |dir|


### PR DESCRIPTION
`user.accessible_cards` had no type at all, and nothing said so. The element
class came from the association NAME, so `has_many :accessible_cards, through:
:boards, source: :cards` guessed `AccessibleCard`, found no scanned model under
that name, and hit the `next unless element` — no getter, no proxy reopen, no
diagnostic. **11 of fizzy's 64 `has_many` were leaving this way.**

Note it is not `through:` that breaks: `has_many :boards, through: :accesses`
works, because the name happens to match the class.

## Walking the chain

`element_for` hops to the owner's `through:` association, resolves THAT model —
recursively, since `accessible_comments` goes through `accessible_cards`, itself
a through — and reads the source reflection off it, among its `has_many` **and**
its `belongs_to`. Memoized, with a cycle guard. The conventional name stays as
the fallback for a `through:` this scan cannot follow (a `has_one`, an
association declared in a gem).

Reading `source:` alone would have been the four-line fix, and it is not enough:

```ruby
# app/models/card/assignable.rb
has_many :assignees, through: :assignments   # no source:

# app/models/assignment.rb
belongs_to :assignee, class_name: "User"     # the class is HERE
```

Active Record singularizes the name (`assignees` → `assignee`) and reads that
reflection. Nothing in the owner's file spells `User`, so no amount of guessing
from `assignees` can work.

## Two more silently-dropped-association gaps

* **A class that declares nothing was not in the table.** `has_many
  :data_exports, class_name: "User::DataExport"` resolved to nothing because
  `User::DataExport` has only methods. The scanned-class list is the resolver's
  ORACLE, so a class now enters it whether or not it declares anything —
  emitting a reopen for it stays the builder's call.
* **A class reopened in several files kept one file's reflections.** Ruby
  reopens rather than replaces, so `class Post` written twice registers both.
  Indexing by name and letting one win meant a `class Post` opened only to nest
  `Post::Archiver` erased Post's own `belongs_to :user`, and with it the
  construction flow of every proxy whose `build` needed that inverse. The dummy
  snapshot caught this. Reopens are merged now, and the concern lookup table
  indexes only modules — which also settles what a class and a same-named
  concern resolve to, without it depending on scan order.

## Behavior change to review

`build`/`create`/`create!` are no longer emitted for a `through:` association.
Active Record does not establish the inverse there — `user.boards.build` leaves
`board.creator` unset, since the row that links them lives on the join — so
`record.creator = owner` was handing the contract machinery a fact the runtime
never establishes. In fizzy this shows up as `user_board.rb` losing its
construction flow.

Because a proxy namespace is per (owner, element) PAIR, the candidate that
models construction now wins the namespace whatever the declaration order is:
`comments` and `accessible_comments` are both User -> Comment, a concern's
`include` sits above the class's own macros, and taking the first would have
cost `user.comments.create` its `build`.

## Measured

Ran the resolver over fizzy's `app/models`: **0 of 64 `has_many` dropped, was
11.**

| | recovered |
|---|---|
| `User#accessible_cards` / `_columns` / `_comments` / `_events` | ✓ |
| `User#assigned_cards` / `pinned_cards` / `data_exports` | ✓ |
| `Card#assignees` / `watchers` | ✓ |
| `Board#access_only_users`, `Account#exports` | ✓ |

## Tests

`bundle exec rspec`: **814 examples, 0 failures.** 9 new examples — explicit
`source:`, a through of a through, `class_name:` on the source reflection with
no `source:` written, an element that declares nothing, the unfollowable-through
fallback, the cycle guard, the `build` gate, the namespace preference, and the
class reopened in several files.

The dummy snapshot is byte-identical, so this is inert for an app without these
shapes.
