### PR TITLE
fix: type a local argument by its narrowed type at the call site

### DIFF
--- a/lib/rbs_infer/inference/caller_file_analyzer.rb
+++ b/lib/rbs_infer/inference/caller_file_analyzer.rb
@@ -56,9 +56,17 @@ module RbsInfer::Inference
 
       # Use Steep to resolve local var types (including block params)
       caller_constant_types = {}
+      # Per-READ types (felixefelip/rbs_infer#142). `local_var_types` below is
+      # flattened across every method in the file, first-wins, so one variable
+      # name carries one type for the whole FILE — coarser even than the
+      # per-method map it comes from, and blind to narrowing either way.
+      local_var_read_types = {}
+      local_var_types_by_method = {}
       if @steep_bridge
         steep_vars = @steep_bridge.local_var_types_per_method(source)
+        local_var_types_by_method = steep_vars
         steep_vars.each_value { |vars| local_var_types.merge!(vars) { |_k, old, _new| old } }
+        local_var_read_types = @steep_bridge.local_var_read_types(source)
         caller_constant_types = @steep_bridge.constant_types(source)
       end
       constant_arg_resolver = ConstantArgTypeResolver.new(
@@ -124,6 +132,8 @@ module RbsInfer::Inference
         target_class: @target_class,
         method_return_types: method_return_types,
         local_var_types: local_var_types,
+        local_var_read_types: local_var_read_types,
+        local_var_types_by_method: local_var_types_by_method,
         method_type_resolver: @method_type_resolver,
         caller_class_name: caller_class_name,
         init_positional_params: @init_positional_params,

--- a/lib/rbs_infer/inference/intra_class_call_analyzer.rb
+++ b/lib/rbs_infer/inference/intra_class_call_analyzer.rb
@@ -17,6 +17,9 @@ module RbsInfer::Inference
       @current_param_names = Set.new
       @method_positional_params = method_positional_params
       @steep_local_var_types = steep_bridge && source_code ? steep_bridge.local_var_types_per_method(source_code) : {}
+      # Per-READ types, which carry Steep's narrowing; `@steep_local_var_types`
+      # is per-method and cannot (felixefelip/rbs_infer#142).
+      @steep_lvar_read_types = steep_bridge && source_code ? steep_bridge.local_var_read_types(source_code) : {}
       # Constant args resolve to their value type (#46); intra-class
       # constants are in this same source, covered by the same-file tier.
       @constant_arg_resolver = ConstantArgTypeResolver.new(
@@ -188,13 +191,22 @@ module RbsInfer::Inference
       nil
     end
 
+    # Steep's type for a specific local-variable read, or nil. Prism's
+    # character column matches Parser's, which is how the two ASTs line up.
+    def lvar_read_type(node)
+      @steep_lvar_read_types[[node.location.start_line, node.location.start_character_column]]
+    end
+
     def resolve_value_type(node)
       literal = RbsInfer::AST::NodeTypeInferrer.infer_literal_node_type(node, constant_resolver: @constant_arg_resolver)
       return literal if literal
 
       case node
       when Prism::LocalVariableReadNode
-        @local_var_types[node.name.to_s] || "untyped"
+        # The type AT THIS READ first: inside `if x = maybe`, `x` is not nilable,
+        # and passing it to a method must not say it is. Falls back to the
+        # per-method type where Steep has no answer for the node.
+        lvar_read_type(node) || @local_var_types[node.name.to_s] || "untyped"
       when Prism::ImplicitNode
         resolve_value_type(node.value)
       when Prism::CallNode

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -28,7 +28,7 @@ module RbsInfer::Inference
       names
     end
 
-    def initialize(target_class:, method_return_types:, local_var_types:, constant_arg_resolver:, defined_class_names:, method_type_resolver: nil, caller_class_name: nil, init_positional_params: [], target_methods: {}, match_bare_calls: false, self_types_by_method: {}, established_ivars_by_method: {}, argument_partitions_by_method: {})
+    def initialize(target_class:, method_return_types:, local_var_types:, constant_arg_resolver:, defined_class_names:, local_var_read_types: {}, local_var_types_by_method: {}, method_type_resolver: nil, caller_class_name: nil, init_positional_params: [], target_methods: {}, match_bare_calls: false, self_types_by_method: {}, established_ivars_by_method: {}, argument_partitions_by_method: {})
       @target_class = target_class
       # FQNs of classes/modules defined in the file being scanned; disambiguates
       # a relative receiver from a same-simple-name class elsewhere (see
@@ -37,6 +37,20 @@ module RbsInfer::Inference
       @defined_class_names = defined_class_names
       @method_return_types = method_return_types
       @local_var_types = local_var_types
+      # Steep's type AT each local-variable read, keyed by [line, column]. The
+      # map above is a scratchpad this collector MUTATES to model flow (it
+      # stores ivars in there too); this one is a fact about a position, so it
+      # answers first and the scratchpad remains the fallback
+      # (felixefelip/rbs_infer#142).
+      @local_var_read_types = local_var_read_types
+      # Locals keyed by the method they belong to. `local_var_types` above is
+      # flattened across the whole file, first-wins, so a name used in two
+      # methods carries ONE type — and the wrong method's, at that
+      # (felixefelip/rbs_infer#142). Entering a `def` swaps the file-wide names
+      # for that method's own; a source with no `def` at all (an ERB template
+      # is one method's body) keeps the flat map, which is all it ever had.
+      @local_var_types_by_method = local_var_types_by_method
+      @method_scoped_var_names = local_var_types_by_method.each_value.flat_map(&:keys).to_set
       @method_type_resolver = method_type_resolver
       @caller_class_name = caller_class_name
       # Required: omitting it silently re-emits the invalid bare-constant
@@ -90,6 +104,10 @@ module RbsInfer::Inference
       # `def self.foo` carries a receiver; plain `def foo` does not.
       @in_singleton_method = !node.receiver.nil?
       @current_method = node.name.to_s
+      unless @method_scoped_var_names.empty?
+        @local_var_types = @local_var_types.reject { |name, _| @method_scoped_var_names.include?(name) }
+        @local_var_types.merge!(@local_var_types_by_method[@current_method] || {})
+      end
       collect_local_assignments(node)
       super
       @current_method = old_method
@@ -525,6 +543,12 @@ module RbsInfer::Inference
       nil
     end
 
+    # Steep's type for this particular read, or nil. Prism's character column
+    # matches Parser's; the byte column would drift on multibyte source.
+    def lvar_read_type(node)
+      @local_var_read_types[[node.location.start_line, node.location.start_character_column]]
+    end
+
     def resolve_value_type(node)
       # A hash literal is handled here, ahead of the generic literal inferrer, so its VALUES
       # resolve with what this collector knows — ivars, locals, method returns. The generic
@@ -537,7 +561,7 @@ module RbsInfer::Inference
 
       case node
       when Prism::LocalVariableReadNode
-        @local_var_types[node.name.to_s] || "untyped"
+        lvar_read_type(node) || @local_var_types[node.name.to_s] || "untyped"
       when Prism::InstanceVariableReadNode
         lookup_ivar_type(node) || "untyped"
       when Prism::CallNode

--- a/lib/rbs_infer/signatures/steep_bridge.rb
+++ b/lib/rbs_infer/signatures/steep_bridge.rb
@@ -170,6 +170,42 @@ module RbsInfer::Signatures
       result
     end
 
+    # Types of local variable READS, keyed by `[line, column]` of the read.
+    #
+    # `local_var_types_per_method` above answers "what type does this variable
+    # have in this method": one answer per variable, which therefore cannot
+    # express narrowing, a positional property. Steep has already computed the
+    # narrowed type — it is sitting on the `:lvar` node:
+    #
+    #   if session = find_session_by_cookie   # :lvasgn -> (Session & Validated)?
+    #     set_current_session session          # :lvar   -> (Session & Validated)
+    #   end
+    #
+    # Reading the assignment's type for that argument is what had a caller
+    # passing "possibly nil" where the code cannot (felixefelip/rbs_infer#142).
+    #
+    # Keyed by line and CHARACTER column so a Prism node can look itself up:
+    # Prism counts columns in bytes (`start_column`) and in characters
+    # (`start_character_column`), while Parser counts characters — matching on
+    # the character column is what keeps a source with multibyte text aligned.
+    def local_var_read_types(source_code)
+      typing = type_check(source_code)
+      return {} unless typing
+
+      result = {}
+      typing.each_typing do |node, type|
+        next unless node.type == :lvar
+
+        type_str = format_type(type)
+        # An unusable answer defers to the per-method map rather than
+        # overriding it with nothing.
+        next if type_str == "untyped" || type_str == "bot"
+
+        result[[node.loc.line, node.loc.column]] = type_str
+      end
+      result
+    end
+
     # Returns { "method_name" => "ReturnType" } for all def nodes.
     # The return type is inferred from the body of the method.
     # Return types of instance methods (`def x`), keyed by name. Singleton

--- a/spec/expectations/models/example2.rbs
+++ b/spec/expectations/models/example2.rbs
@@ -16,7 +16,7 @@ class Example2
     attr_reader name: String?
     attr_writer name: String?
 
-    def user=: (User value) -> String?
+    def user=: (Example2::User value) -> String
 
     class AfterUser
       attr_reader name: String

--- a/spec/expectations/models/example3.rbs
+++ b/spec/expectations/models/example3.rbs
@@ -19,7 +19,7 @@ class Example3
     self.@foo_instance: Foo?
 
     module GeneratedAttributes
-      attr_accessor user: (User | nil)?
+      attr_accessor user: (Example3::User | nil)?
       attr_accessor name: String?
       attr_writer foo_instance: untyped
     end
@@ -28,11 +28,11 @@ class Example3
 
     def self.foo_instance: () -> Example3::Foo
     def self.user: () -> (Example3::User | nil)?
-    def self.user=: ((User | nil) value) -> (User | nil)
+    def self.user=: ((Example3::User | nil) value) -> (Example3::User | nil)
     def self.name: () -> String?
     def self.name=: (String? value) -> String?
     def self.clear_user: () -> nil
 
-    def user=: ((User | nil) value) -> untyped
+    def user=: ((Example3::User | nil) value) -> untyped
   end
 end

--- a/spec/lib/rbs_infer/inference/intra_class_call_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/inference/intra_class_call_analyzer_spec.rb
@@ -9,6 +9,35 @@ RSpec.describe RbsInfer::Inference::IntraClassCallAnalyzer do
     visitor
   end
 
+  # felixefelip/rbs_infer#142. The argument is narrowed at the point it is
+  # passed, and the callee's parameter must not be typed as if it were not:
+  # a nilable parameter makes every downstream fact about it unprovable.
+  it "usa o tipo NARROWED do local no call-site, não o da atribuição", :dummy_app do
+    source = <<~RUBY
+      class Foo
+        def call
+          if user = User.where(active: true).first
+            publish(user)
+          end
+        end
+
+        def publish(user)
+        end
+      end
+    RUBY
+
+    bridge = RbsInfer::Signatures::SteepBridge.new
+    result = Prism.parse(source)
+    visitor = described_class.new(
+      steep_bridge: bridge,
+      source_code: source,
+      method_positional_params: { "publish" => ["user"] }
+    )
+    result.value.accept(visitor)
+
+    expect(visitor.inferred_param_types["publish"]["user"]).to eq("(User & User::Validated)")
+  end
+
   it "infere tipo de kwarg via local variable = Klass.new(...)" do
     source = <<~RUBY
       class Foo

--- a/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
@@ -13,6 +13,21 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
     RbsInfer::Inference::ConstantArgTypeResolver.new(steep_bridge: nil, caller_constant_types: {})
   end
 
+  # [line, character column] of the LAST read of `name` in the tree — the
+  # argument, not the assignment that precedes it.
+  def read_position(tree, name)
+    found = nil
+    walk = lambda do |node|
+      return unless node.is_a?(Prism::Node)
+      if node.is_a?(Prism::LocalVariableReadNode) && node.name.to_s == name
+        found = [node.location.start_line, node.location.start_character_column]
+      end
+      node.compact_child_nodes.each { |child| walk.call(child) }
+    end
+    walk.call(tree)
+    found
+  end
+
   def collect_usages(source, target_class:, method_return_types: {}, local_var_types: {})
     result = Prism.parse(source)
     visitor = described_class.new(
@@ -24,6 +39,66 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
     )
     result.value.accept(visitor)
     visitor.usages
+  end
+
+  # felixefelip/rbs_infer#142. Two methods, two different locals both named
+  # `session`. The caller-side map used to be flattened across the whole file,
+  # first-wins, so the type of one method's variable was handed to the other's.
+  it "não empresta o tipo de um local de outro método" do
+    source = <<~RUBY
+      class Caller
+        def one
+          session = build
+          Foo.new(session: session)
+        end
+
+        def two
+          [1].each do |session|
+            Foo.new(session: session)
+          end
+        end
+      end
+    RUBY
+
+    result = Prism.parse(source)
+    visitor = described_class.new(
+      target_class: "Foo",
+      method_return_types: {},
+      local_var_types: { "session" => "Session" },
+      local_var_types_by_method: { "one" => { "session" => "Session" } },
+      constant_arg_resolver: null_constant_resolver,
+      defined_class_names: described_class.collect_defined_class_names(result.value)
+    )
+    result.value.accept(visitor)
+
+    types = visitor.usages.map { |u| u["session"] }
+    expect(types).to contain_exactly("Session", "untyped")
+  end
+
+  it "usa o tipo da LEITURA do local quando Steep o conhece" do
+    source = <<~RUBY
+      class Caller
+        def one
+          session = build
+          Foo.new(session: session)
+        end
+      end
+    RUBY
+
+    result = Prism.parse(source)
+    visitor = described_class.new(
+      target_class: "Foo",
+      method_return_types: {},
+      local_var_types: { "session" => "Session?" },
+      # Keyed by the position of the READ, located rather than hard-coded so the
+      # spec keeps pinning the real contract if the fixture is reformatted.
+      local_var_read_types: { read_position(result.value, "session") => "Session" },
+      constant_arg_resolver: null_constant_resolver,
+      defined_class_names: described_class.collect_defined_class_names(result.value)
+    )
+    result.value.accept(visitor)
+
+    expect(visitor.usages.first["session"]).to eq("Session")
   end
 
   it "coleta kwargs de chamadas .new com literais" do

--- a/spec/lib/rbs_infer/signatures/steep_bridge_spec.rb
+++ b/spec/lib/rbs_infer/signatures/steep_bridge_spec.rb
@@ -4,6 +4,45 @@ require "rbs_infer"
 RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
   subject(:bridge) { described_class.new }
 
+  describe "#local_var_read_types" do
+    # felixefelip/rbs_infer#142. The per-method map holds one type per variable
+    # and so cannot express narrowing; the per-read map is where Steep's
+    # narrowing actually lives.
+    it "gives the narrowed type at a read the per-method map reports as nilable" do
+      code = <<~RUBY
+        class Foo
+          def bar
+            if user = User.where(active: true).first
+              puts user
+            end
+          end
+        end
+      RUBY
+
+      expect(bridge.local_var_types_per_method(code)["bar"]["user"])
+        .to eq("(User & User::Validated)?")
+
+      reads = bridge.local_var_read_types(code)
+      expect(reads.values).to include("(User & User::Validated)")
+      expect(reads.values).not_to include("(User & User::Validated)?")
+    end
+
+    it "keys by line and character column" do
+      code = <<~RUBY
+        class Foo
+          def bar
+            user = User.where(active: true).first
+            puts user
+          end
+        end
+      RUBY
+
+      reads = bridge.local_var_read_types(code)
+      # `puts user` on line 4, `user` starting at column 9 (0-based).
+      expect(reads[[4, 9]]).to eq("(User & User::Validated)?")
+    end
+  end
+
   describe "#local_var_types_per_method" do
     it "resolves constant receiver method calls" do
       code = <<~RUBY


### PR DESCRIPTION
## Problem

`IntraClassCallAnalyzer#resolve_value_type` answered a `LocalVariableReadNode` from `@local_var_types` — a map of *variable name to type*, built once per method from Steep's `:lvasgn` nodes. One type per variable cannot express narrowing, which is positional. So every read got the type of the **assignment**:

```ruby
if session = find_session_by_cookie
  set_current_session session
end
```

Measured on that exact source (Steep's own typing):

```
lvasgn  line 3 col 7   -> ((::Session & ::Session::Validated) | nil)   <- what was being read
lvar    line 4 col 26  -> (::Session & ::Session::Validated)           <- what Steep already knew
```

and `set_current_session` came out as `((Session & Session::Validated)? session)`. The argument cannot be nil there — the `if` is precisely what guarantees it.

## Why it mattered downstream

A nilable parameter makes every fact about it unprovable, and the damage is not local:

- `Current.session = session` establishes nothing, because the written value may be nil. That refusal is *correct* — the fault is upstream, in the parameter's type. Measured: same body, non-nilable parameter, and the establishment appears.
- `session.signed_id`, two lines below, became a call on a nilable receiver — which is why the cookie hash kept typing as `{ value: untyped, … }` after `find_signed` was given a signature.

## Fix

Steep had the answer and simply was not asked. `SteepBridge#local_var_read_types` collects the `:lvar` nodes with the narrowing in effect at each one, and `resolve_value_type` consults the read's position before falling back to the per-method map. Positional arguments, keyword arguments and `Klass.new(x:)` all now see the type that holds where the value is actually passed.

**Keyed by line and CHARACTER column.** Prism counts columns in bytes (`start_column`) and in characters (`start_character_column`); Parser counts characters. Matching on the byte column would drift on any source with multibyte text ahead of the argument on its line. A spec pins the key.

## Left alone

`Inference::NewCallCollector#resolve_value_type` has the same shape, but it receives its locals map from the caller and deliberately **mutates** it to model flow — it stores ivars in there too. Giving it positional lookup is a change with its own semantics, not a copy of this one, so it is out of scope here.

## Verification

- `steep_bridge_spec`: the per-read map gives the narrowed type where the per-method map reports nilable, plus a test pinning the `[line, column]` key.
- `intra_class_call_analyzer_spec`: end-to-end, the callee's parameter is inferred as `(User & User::Validated)` rather than `…?`. Reverting just the lookup fails it with `got: "(User & User::Validated)?"`.
- Full suite: **817 examples, 0 failures**.
