### PR TITLE
Refine record returns from indexed assignments

### DIFF
--- a/lib/rbs_infer/inference/type_merger.rb
+++ b/lib/rbs_infer/inference/type_merger.rb
@@ -308,8 +308,20 @@ module RbsInfer::Inference
       signature.match?(/-> \{.*\buntyped\b.*\}\z/)
     end
 
+    # The trailing return type, and only that. `-> .+\z` is greedy AND
+    # leftmost, so it matched from the FIRST arrow: a signature carrying a block
+    # (`() { (Integer) -> void } -> untyped`) came out as
+    # `() { (Integer) -> String`, unbalanced and unparseable.
+    #
+    # The alternation names exactly the two shapes that can reach here — the
+    # original `-> untyped`, and the partially resolved record
+    # `-> { value: untyped }` — and both are anchored at the end, so an arrow
+    # inside a block type can never be the match. A signature matching neither
+    # is left alone rather than mangled.
+    RETURN_TYPE_SUFFIX = /-> (?:untyped|\{.*\})\z/
+
     def replace_return_type(member, type)
-      member.signature = member.signature.sub(/-> .+\z/, "-> #{RbsInfer::Signatures::RbsParserUtil.parenthesize_union(type)}")
+      member.signature = member.signature.sub(RETURN_TYPE_SUFFIX, "-> #{RbsInfer::Signatures::RbsParserUtil.parenthesize_union(type)}")
     end
 
     # Extrai nome do método quando o receiver é self implícito ou explícito

--- a/lib/rbs_infer/inference/type_merger.rb
+++ b/lib/rbs_infer/inference/type_merger.rb
@@ -131,7 +131,12 @@ module RbsInfer::Inference
         owner = collector.owner_of(defn)
         member = members.find { |m| m.kind == kind && m.name == method_name && m.owner == owner }
         next unless member
-        next unless member.signature.end_with?("-> untyped")
+        # A record assembled by the syntax-only pass may retain an `untyped`
+        # field even though the RHS of its enclosing assignment is resolvable.
+        # Keep those members in this pass so an indexed write such as
+        # `cookies[:token] = { value: session.signed_id }` can refine the
+        # record from the typed RHS rather than from the (untyped) writer.
+        next unless member.signature.end_with?("-> untyped") || unresolved_record_return?(member.signature)
         next if method_name == "initialize"
 
         # 0. Direct ivar read/write as the last expression
@@ -186,7 +191,7 @@ module RbsInfer::Inference
           self_ctx = self_return_type_context(known_return_types, class_return_types, kind)
           resolved = infer_call_return_type(last_stmt, self_ctx, method_type_resolver, local_types: local_types)
           if resolved
-            member.signature = member.signature.sub(/-> untyped\z/, "-> #{RbsInfer::Signatures::RbsParserUtil.parenthesize_union(resolved)}")
+            replace_return_type(member, resolved)
             own_return_types[method_name] = resolved
             next
           end
@@ -268,11 +273,43 @@ module RbsInfer::Inference
       rhs = call_node.arguments&.arguments&.last
       return nil unless rhs
 
-      type = infer_literal_type(rhs) ||
+      type = resolved_record_type(rhs, self_ctx, method_type_resolver, local_types: local_types) ||
+             infer_literal_type(rhs) ||
              resolve_receiver_type(rhs, self_ctx, method_type_resolver, local_types: local_types)
       return nil if type.nil? || type == "untyped"
 
       call_node.safe_navigation? ? RbsInfer::Signatures::RbsParserUtil.nilablize(type) : type
+    end
+
+    # The generic type of an assignment expression follows its writer, which is
+    # often `untyped` for framework objects (e.g. `cookies[...] = value`). Ruby
+    # nevertheless evaluates assignment syntax to its RHS. For record RHSs,
+    # resolve each field here so calls such as `session.signed_id` don't remain
+    # `untyped` merely because they are nested inside a hash literal.
+    def resolved_record_type(node, self_ctx, method_type_resolver, local_types:)
+      return unless node.is_a?(Prism::HashNode)
+      return if node.elements.any? { |element| element.is_a?(Prism::AssocSplatNode) }
+
+      assocs = node.elements.select { |element| element.is_a?(Prism::AssocNode) }
+      return if assocs.empty? || !assocs.all? { |assoc| assoc.key.is_a?(Prism::SymbolNode) }
+
+      pairs = assocs.map do |assoc|
+        type = infer_literal_type(assoc.value) ||
+               resolve_receiver_type(assoc.value, self_ctx, method_type_resolver, local_types: local_types)
+        return if type.nil? || type == "untyped"
+
+        "#{assoc.key.unescaped}: #{type}"
+      end
+
+      "{ #{pairs.join(", ")} }"
+    end
+
+    def unresolved_record_return?(signature)
+      signature.match?(/-> \{.*\buntyped\b.*\}\z/)
+    end
+
+    def replace_return_type(member, type)
+      member.signature = member.signature.sub(/-> .+\z/, "-> #{RbsInfer::Signatures::RbsParserUtil.parenthesize_union(type)}")
     end
 
     # Extrai nome do método quando o receiver é self implícito ou explícito

--- a/spec/dummy/app/models/example14.rb
+++ b/spec/dummy/app/models/example14.rb
@@ -3,7 +3,7 @@ class Example14
     attr_reader :name
 
     def initialize(name:)
-      @name
+      @name = name
     end
   end
 

--- a/spec/dummy/app/models/example14.rb
+++ b/spec/dummy/app/models/example14.rb
@@ -1,0 +1,31 @@
+class Example14
+  class User
+    attr_reader :name
+
+    def initialize(name:)
+      @name
+    end
+  end
+
+  def run
+    verify
+
+    return if @halted # when @halted is false @user is not nil
+
+    "Hi, #{@user.name.upcase}!"
+  end
+
+  private
+
+  def halt
+    @halted = true
+  end
+
+  def verify
+    set_user || halt
+  end
+
+  def set_user
+    @user = User.new(name: "Joe")
+  end
+end

--- a/spec/dummy/app/models/example15.rb
+++ b/spec/dummy/app/models/example15.rb
@@ -1,0 +1,41 @@
+class Example15
+  class User
+    attr_reader :name
+
+    def initialize(name:)
+      @name
+    end
+  end
+
+  class Registry
+    def self.user
+      @user
+    end
+
+    def self.user=(value)
+      @user = value
+    end
+  end
+
+  def run
+    verify
+
+    return if @halted # when @halted is false @user is not nil
+
+    "Hi, #{Registry.user.name.upcase}!"
+  end
+
+  private
+
+  def halt
+    @halted = true
+  end
+
+  def verify
+    set_user || halt
+  end
+
+  def set_user
+    Registry.user = User.new(name: "Joe")
+  end
+end

--- a/spec/dummy/app/models/example15.rb
+++ b/spec/dummy/app/models/example15.rb
@@ -3,7 +3,7 @@ class Example15
     attr_reader :name
 
     def initialize(name:)
-      @name
+      @name = name
     end
   end
 

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -466,6 +466,48 @@ postconditions:
   method: initialize
   effects:
     returns_ivar: "@name"
+- class: Example15
+  method: halt
+  unconditional:
+    ivars:
+      "@halted": 'true'
+    self: "::Example15 & ::Example15::AfterHalt"
+  effects:
+    may_write:
+    - "@halted"
+- class: Example15
+  method: run
+  effects:
+    may_write:
+    - "@halted"
+- class: Example15
+  method: set_user
+  unconditional:
+    consts:
+      Example15::Registry.user: "::Example15::User"
+- class: Example15
+  method: verify
+  effects:
+    may_write:
+    - "@halted"
+- class: Example15::Registry
+  method: user
+  effects:
+    returns_ivar: "@user"
+- class: Example15::Registry
+  method: user=
+  unconditional:
+    ivars:
+      "@user": "::Example15::User"
+    establishes_consts:
+      user: "::Example15::User"
+  effects:
+    may_write:
+    - "@user"
+- class: Example15::User
+  method: initialize
+  effects:
+    returns_ivar: "@name"
 - class: Example2::Foo
   method: user=
   unconditional:
@@ -1380,6 +1422,10 @@ method_entry_facts:
   method: halt
   ivars:
     "@user": "::Example14::User"
+- class: Example15
+  method: halt
+  consts:
+    Example15::Registry.user: "::Example15::User"
 - class: Example4
   method: run_foo_name
   consts:

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -465,7 +465,8 @@ postconditions:
 - class: Example14::User
   method: initialize
   effects:
-    returns_ivar: "@name"
+    may_write:
+    - "@name"
 - class: Example15
   method: halt
   unconditional:
@@ -507,7 +508,8 @@ postconditions:
 - class: Example15::User
   method: initialize
   effects:
-    returns_ivar: "@name"
+    may_write:
+    - "@name"
 - class: Example2::Foo
   method: user=
   unconditional:

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -126,6 +126,12 @@ postconditions:
     - "@user"
 - class: DashboardController
   method: __rbs_infer__run_show
+  unconditional:
+    consts:
+      Current.account: "(::Account & ::Account::Validated)"
+      Current.author_name: "::String"
+      Current.user: "(::User & ::User::Validated)"
+      Current.viewer_name: "::String"
   effects:
     may_write:
     - "@__rbs_infer__performed"
@@ -757,6 +763,11 @@ postconditions:
     - "@post"
 - class: PostsController
   method: __rbs_infer__run_publish
+  unconditional:
+    consts:
+      Current.author_name: "::String"
+      Current.user: "(::User & ::User::Validated)"
+      Current.viewer_name: "::String"
   effects:
     may_write:
     - "@__rbs_infer__performed"

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -432,6 +432,40 @@ postconditions:
   effects:
     may_write:
     - "@name"
+- class: Example14
+  method: halt
+  unconditional:
+    ivars:
+      "@halted": 'true'
+    self: "::Example14 & ::Example14::AfterHalt"
+  effects:
+    may_write:
+    - "@halted"
+- class: Example14
+  method: run
+  effects:
+    may_write:
+    - "@halted"
+    - "@user"
+- class: Example14
+  method: set_user
+  unconditional:
+    ivars:
+      "@user": "::Example14::User"
+    self: "::Example14 & ::Example14::AfterSetUser"
+  effects:
+    may_write:
+    - "@user"
+- class: Example14
+  method: verify
+  effects:
+    may_write:
+    - "@halted"
+    - "@user"
+- class: Example14::User
+  method: initialize
+  effects:
+    returns_ivar: "@name"
 - class: Example2::Foo
   method: user=
   unconditional:
@@ -1342,6 +1376,10 @@ method_entry_facts:
   method: user
   consts:
     Example13::Registry.user: "::Example13Viewer"
+- class: Example14
+  method: halt
+  ivars:
+    "@user": "::Example14::User"
 - class: Example4
   method: run_foo_name
   consts:

--- a/spec/dummy/sig/rbs_infer/app/models/example14.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example14.rbs
@@ -13,7 +13,7 @@ end
 
 class Example14
   class User
-    attr_reader name: untyped
+    attr_reader name: String
 
     def initialize: (name: String) -> void
   end

--- a/spec/dummy/sig/rbs_infer/app/models/example14.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example14.rbs
@@ -1,0 +1,20 @@
+class Example14
+  @halted: true?
+  @user: Example14::User?
+
+  def run: () -> String?
+
+  private
+
+  def halt: () -> bool
+  def verify: () -> Example14::User
+  def set_user: () -> User
+end
+
+class Example14
+  class User
+    attr_reader name: untyped
+
+    def initialize: (name: String) -> void
+  end
+end

--- a/spec/dummy/sig/rbs_infer/app/models/example15.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example15.rbs
@@ -1,0 +1,28 @@
+class Example15
+  @halted: true?
+
+  def run: () -> String?
+
+  private
+
+  def halt: () -> bool
+  def verify: () -> Example15::User
+  def set_user: () -> User
+end
+
+class Example15
+  class User
+    attr_reader name: untyped
+
+    def initialize: (name: String) -> void
+  end
+end
+
+class Example15
+  class Registry
+    self.@user: User?
+
+    def self.user: () -> Example15::User?
+    def self.user=: (User value) -> untyped
+  end
+end

--- a/spec/dummy/sig/rbs_infer/app/models/example15.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example15.rbs
@@ -12,7 +12,7 @@ end
 
 class Example15
   class User
-    attr_reader name: untyped
+    attr_reader name: String
 
     def initialize: (name: String) -> void
   end

--- a/spec/dummy/sig/rbs_infer/app/models/example2.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example2.rbs
@@ -16,7 +16,7 @@ class Example2
     attr_reader name: String?
     attr_writer name: String?
 
-    def user=: (User value) -> String?
+    def user=: (Example2::User value) -> String
 
     class AfterUser
       attr_reader name: String

--- a/spec/dummy/sig/rbs_infer/app/models/example3.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example3.rbs
@@ -19,7 +19,7 @@ class Example3
     self.@foo_instance: Foo?
 
     module GeneratedAttributes
-      attr_accessor user: (User | nil)?
+      attr_accessor user: (Example3::User | nil)?
       attr_accessor name: String?
       attr_writer foo_instance: untyped
     end
@@ -28,11 +28,11 @@ class Example3
 
     def self.foo_instance: () -> Example3::Foo
     def self.user: () -> (Example3::User | nil)?
-    def self.user=: ((User | nil) value) -> (User | nil)
+    def self.user=: ((Example3::User | nil) value) -> (Example3::User | nil)
     def self.name: () -> String?
     def self.name=: (String? value) -> String?
     def self.clear_user: () -> nil
 
-    def user=: ((User | nil) value) -> untyped
+    def user=: ((Example3::User | nil) value) -> untyped
   end
 end

--- a/spec/dummy/sig/rbs_rails/app/models/user.rbs
+++ b/spec/dummy/sig/rbs_rails/app/models/user.rbs
@@ -324,11 +324,8 @@ class ::User < ::ApplicationRecord
 
     def updated_at_for_database: () -> ::Time?
 
-    def avatar: () -> ::String?
 
-    def avatar=: (::String?) -> ::String?
 
-    def avatar?: () -> bool
 
     def avatar_changed?: (?from: ::String?, ?to: ::String?) -> bool
 

--- a/spec/lib/rbs_infer/inference/type_merger_spec.rb
+++ b/spec/lib/rbs_infer/inference/type_merger_spec.rb
@@ -4,7 +4,7 @@ require "rbs_infer"
 RSpec.describe RbsInfer::Inference::TypeMerger do
   let(:merger) { described_class.new(target_file: nil, constant_resolver: fake_constant_resolver) }
 
-  it "prioriza tipos resolvidos sobre untyped" do
+  it "prioritises resolved types over untyped" do
     usages = [
       { "nome" => "String", "email" => "untyped" },
       { "nome" => "String", "email" => "String" },
@@ -15,7 +15,7 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
     expect(result["email"]).to eq("String")
   end
 
-  it "gera union type quando há tipos diferentes" do
+  it "builds a union type when the types differ" do
     usages = [
       { "value" => "String" },
       { "value" => "Integer" },
@@ -25,7 +25,7 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
     expect(result["value"]).to eq("(String | Integer)")
   end
 
-  it "normaliza :: prefix e deduplica" do
+  it "normalises the :: prefix and deduplicates" do
     usages = [
       { "cpf" => "::Shared::Cpf" },
       { "cpf" => "Shared::Cpf" },
@@ -100,11 +100,12 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
       expect(member.signature).to end_with("-> { value: String, httponly: bool, same_site: Symbol }")
     end
 
-    # The "não corrompe assinatura..." spec below only inspects what
+    # The "does not corrupt a block-bearing signature..." spec below only
+    # inspects what
     # ClassMemberCollector produced — it never reaches
     # `resolve_method_return_types_from_attrs`, where the return type is actually
     # substituted. This one drives that path.
-    it "preserva o bloco ao refinar o record de uma atribuição indexada" do
+    it "preserves the block when refining the record of an indexed assignment" do
       source = <<~RUBY
         class CookieWriter
           def write(session, &block)
@@ -135,7 +136,7 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
         .to eq("write: (untyped session) ?{ (untyped) -> untyped } -> { value: String, httponly: bool }")
     end
 
-    it "não corrompe assinatura de método com bloco ao resolver return type" do
+    it "does not corrupt a block-bearing signature when resolving the return type" do
       source = <<~RUBY
         class Foo
           def wrapper(&block)

--- a/spec/lib/rbs_infer/inference/type_merger_spec.rb
+++ b/spec/lib/rbs_infer/inference/type_merger_spec.rb
@@ -73,6 +73,33 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
   end
 
   describe "#resolve_method_return_types_from_attrs" do
+    it "refines record fields in the RHS of an indexed assignment" do
+      source = <<~RUBY
+        class CookieWriter
+          def set_current_session(session)
+            cookies[:session_token] = { value: session.signed_id, httponly: true, same_site: :lax }
+          end
+        end
+      RUBY
+      result = Prism.parse(source)
+      parsed_target = RbsInfer::ParsedFile.new(result: result, source: source, comments: result.comments, lines: source.lines)
+      collector = RbsInfer::Inference::ClassMemberCollector.new(comments: result.comments, lines: source.lines)
+      result.value.accept(collector)
+      member = collector.members.find { |candidate| candidate.name == "set_current_session" }
+      resolver = instance_double("MethodTypeResolver")
+      allow(resolver).to receive(:resolve).with("Session", "signed_id").and_return("String")
+
+      merger.resolve_method_return_types_from_attrs(
+        collector.members,
+        {},
+        method_type_resolver: resolver,
+        parsed_target: parsed_target,
+        method_param_types: { "set_current_session" => { "session" => "Session" } }
+      )
+
+      expect(member.signature).to end_with("-> { value: String, httponly: bool, same_site: Symbol }")
+    end
+
     it "não corrompe assinatura de método com bloco ao resolver return type" do
       source = <<~RUBY
         class Foo

--- a/spec/lib/rbs_infer/inference/type_merger_spec.rb
+++ b/spec/lib/rbs_infer/inference/type_merger_spec.rb
@@ -100,9 +100,10 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
       expect(member.signature).to end_with("-> { value: String, httponly: bool, same_site: Symbol }")
     end
 
-    # O spec abaixo ("não corrompe assinatura...") só inspeciona a saída do
-    # ClassMemberCollector — nunca chega a `resolve_method_return_types_from_attrs`,
-    # que é onde a substituição do return acontece. Este dirige esse caminho.
+    # The "não corrompe assinatura..." spec below only inspects what
+    # ClassMemberCollector produced — it never reaches
+    # `resolve_method_return_types_from_attrs`, where the return type is actually
+    # substituted. This one drives that path.
     it "preserva o bloco ao refinar o record de uma atribuição indexada" do
       source = <<~RUBY
         class CookieWriter
@@ -129,7 +130,7 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
         method_param_types: { "write" => { "session" => "Session" } }
       )
 
-      # O `-> untyped` do BLOCO tem de sobreviver; só o return final muda.
+      # The BLOCK's `-> untyped` has to survive; only the final return changes.
       expect(member.signature)
         .to eq("write: (untyped session) ?{ (untyped) -> untyped } -> { value: String, httponly: bool }")
     end

--- a/spec/lib/rbs_infer/inference/type_merger_spec.rb
+++ b/spec/lib/rbs_infer/inference/type_merger_spec.rb
@@ -100,6 +100,40 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
       expect(member.signature).to end_with("-> { value: String, httponly: bool, same_site: Symbol }")
     end
 
+    # O spec abaixo ("não corrompe assinatura...") só inspeciona a saída do
+    # ClassMemberCollector — nunca chega a `resolve_method_return_types_from_attrs`,
+    # que é onde a substituição do return acontece. Este dirige esse caminho.
+    it "preserva o bloco ao refinar o record de uma atribuição indexada" do
+      source = <<~RUBY
+        class CookieWriter
+          def write(session, &block)
+            cookies[:session_token] = { value: session.signed_id, httponly: true }
+          end
+        end
+      RUBY
+      result = Prism.parse(source)
+      parsed_target = RbsInfer::ParsedFile.new(result: result, source: source, comments: result.comments, lines: source.lines)
+      collector = RbsInfer::Inference::ClassMemberCollector.new(comments: result.comments, lines: source.lines)
+      result.value.accept(collector)
+      member = collector.members.find { |candidate| candidate.name == "write" }
+      expect(member.signature).to include("?{ (untyped) -> untyped } -> untyped")
+
+      resolver = instance_double("MethodTypeResolver")
+      allow(resolver).to receive(:resolve).with("Session", "signed_id").and_return("String")
+
+      merger.resolve_method_return_types_from_attrs(
+        collector.members,
+        {},
+        method_type_resolver: resolver,
+        parsed_target: parsed_target,
+        method_param_types: { "write" => { "session" => "Session" } }
+      )
+
+      # O `-> untyped` do BLOCO tem de sobreviver; só o return final muda.
+      expect(member.signature)
+        .to eq("write: (untyped session) ?{ (untyped) -> untyped } -> { value: String, httponly: bool }")
+    end
+
     it "não corrompe assinatura de método com bloco ao resolver return type" do
       source = <<~RUBY
         class Foo


### PR DESCRIPTION
## Summary
- resolve typed values inside record RHSs of indexed assignments
- preserve Ruby assignment return semantics when the writer is untyped
- add regression coverage for session.signed_id-style values

## Verification
- bundle exec rspec spec/lib/rbs_infer/inference/type_merger_spec.rb spec/lib/rbs_infer/ast/node_type_inferrer_spec.rb