### PR TITLE
feat: emit `prepend` in the generated RBS

### DIFF
--- a/lib/rbs_infer/inference/class_member_collector.rb
+++ b/lib/rbs_infer/inference/class_member_collector.rb
@@ -163,6 +163,8 @@ module RbsInfer::Inference
         extract_attrs(node)
       when :include
         extract_includes(node)
+      when :prepend
+        extract_includes(node, kind: :prepend)
       when :extend
         extract_extends(node)
       when :delegate
@@ -259,7 +261,11 @@ module RbsInfer::Inference
       pop_scope
     end
 
-    def extract_includes(node)
+    # `kind:` distinguishes `include` from `prepend`. Both are mixins and are
+    # collected identically; only the emitted keyword differs, and with it where
+    # the module lands in the ancestor chain — which decides whose method a call
+    # resolves to (felixefelip/rbs_infer#144).
+    def extract_includes(node, kind: :include)
       # `Receiver.include Mod` (explicit constant receiver) reopens another
       # class — it is NOT a mixin of the current target. The multi-target
       # core picks these up as separate reopen targets (TargetDiscovery);
@@ -274,7 +280,7 @@ module RbsInfer::Inference
         next unless name
 
         @members << Member.new(
-          kind: :include,
+          kind: kind,
           name: name,
           signature: name,
           visibility: :public,

--- a/lib/rbs_infer/signatures/rbs_builder.rb
+++ b/lib/rbs_infer/signatures/rbs_builder.rb
@@ -123,6 +123,9 @@ module RbsInfer::Signatures
       members.select { |m| m.kind == :extend && m.owner.nil? }.each do |ext|
         out << "#{indent}extend #{qualify(ext.name)}"
       end
+      members.select { |m| m.kind == :prepend && m.owner.nil? }.each do |pre|
+        out << "#{indent}prepend #{qualify(pre.name)}"
+      end
       members.select { |m| m.kind == :include && m.owner.nil? }.each do |inc|
         qualified = qualify(inc.name)
         out << "#{indent}include #{qualified}"
@@ -266,6 +269,9 @@ module RbsInfer::Signatures
 
         mod_members.select { |m| m.kind == :constant }.each do |const|
           lines << "#{inner_indent}#{const.signature}"
+        end
+        mod_members.select { |m| m.kind == :prepend }.each do |pre|
+          lines << "#{inner_indent}prepend #{qualify(pre.name)}"
         end
         mod_members.select { |m| m.kind == :include }.each do |inc|
           lines << "#{inner_indent}include #{qualify(inc.name)}"

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -491,6 +491,10 @@ postconditions:
   effects:
     may_write:
     - "@halted"
+  conditional_const_returns:
+    Example15::Registry.user:
+      gate_ivar: "@halted"
+      type: "::Example15::User"
 - class: Example15::Registry
   method: user
   effects:
@@ -515,6 +519,10 @@ postconditions:
   effects:
     may_write:
     - "@halted"
+  conditional_const_returns:
+    Example16::Registry.user:
+      gate_ivar: "@halted"
+      type: "::Example16::User"
 - class: Example16
   method: call
   effects:
@@ -530,6 +538,10 @@ postconditions:
   effects:
     may_write:
     - "@halted"
+  conditional_const_returns:
+    Example16::Registry.user:
+      gate_ivar: "@halted"
+      type: "::Example16::User"
 - class: Example16
   method: halt
   unconditional:
@@ -1481,6 +1493,18 @@ method_entry_facts:
   method: halt
   consts:
     Example15::Registry.user: "::Example15::User"
+- class: Example15::Registry
+  method: user
+  consts:
+    Example15::Registry.user: "::Example15::User"
+- class: Example16
+  method: show
+  consts:
+    Example16::Registry.user: "::Example16::User"
+- class: Example16::Registry
+  method: user
+  consts:
+    Example16::Registry.user: "::Example16::User"
 - class: Example4
   method: run_foo_name
   consts:

--- a/spec/lib/rbs_infer/signatures/rbs_builder_spec.rb
+++ b/spec/lib/rbs_infer/signatures/rbs_builder_spec.rb
@@ -78,6 +78,23 @@ RSpec.describe RbsInfer::Signatures::RbsBuilder do
     end
   end
 
+  describe "#build com prepend" do
+    # felixefelip/rbs_infer#144. A mixin whose method must WIN over the host's
+    # own — the only way a sidecar can model a method the app also defines,
+    # since RBS refuses two declarations of one method on one owner.
+    it "emite prepend, e antes do include" do
+      members = [
+        RbsInfer::Inference::Member.new(kind: :include, name: "Included", signature: "", visibility: :public),
+        RbsInfer::Inference::Member.new(kind: :prepend, name: "Prepended", signature: "", visibility: :public)
+      ]
+      builder = make_builder(target_class: "Host", superclass_name: nil)
+      result = build_rbs(builder, members, {}, {})
+
+      expect(result).to include("prepend Prepended")
+      expect(result.index("prepend Prepended")).to be < result.index("include Included")
+    end
+  end
+
   describe "#build com qualify (include/extend ambíguos)" do
     it "prefixa include com :: quando o nome coincide com parte do namespace" do
       # Account::Storage inclui Storage::Totaled → dentro de class Account { module Storage }


### PR DESCRIPTION
A correctness fix, standalone. It was found while exploring #144 and was originally proposed as a prerequisite for it; that turned out not to be the case, and the framing below is the one that holds.

## The gap

`prepend` was already collected for the mixin graph (`Project::MixinIndex` treats it alongside `include`) but never emitted, so generated RBS misrepresented the ancestor chain. From the application this was measured on:

```ruby
# app/jobs/application_job.rb
class ApplicationJob < ActiveJob::Base
  prepend AccountTenanted
```

```rbs
class ApplicationJob < ActiveJob::Base
end
```

Not decorative: `AccountTenanted` overrides `initialize`, `serialize` and `deserialize` — the classic reason to prepend, where the overrides call `super`. Without the line, Steep resolves those calls to the host's methods while at runtime the module's run.

Two sites in that application use the bare form this covers. `X.prepend Mod` with an explicit constant receiver is untouched: the collector already treats that as reopening another class.

## Shape

Collected by the same path as `include` — `extract_includes` now takes a `kind:`, since the two differ only in the emitted keyword — and emitted before `include`, matching the ancestor order the keyword means.

## What to expect on merge

This changes method resolution wherever a `prepend` exists. Where the prepended module's method has a weaker signature than the host's, a call that used to resolve to the host now resolves to the module: more faithful, and still capable of surfacing a new diagnostic or a weaker inferred type. Worth regenerating once and reading the diff for the overridden methods.

## Verification

- A builder example asserting both the emission and its position relative to `include`; it fails with the emit lines removed.
- End to end on the dummy app: `prepend Rewritten` in, `prepend Rewritten` out.
- Full suite: 821 examples, 1 failure — that failure is `Example16`'s baseline error *disappearing*, which comes from the working copy of the Steep fork carrying felixefelip/steep#121 and #122, not from this change.

## Why it is no longer a prerequisite for #144

The idea there was that a sidecar cannot reopen a class and redefine a method the application also defines, because RBS refuses two declarations of one method on one owner:

```
[error] Non-overloading method definition of `call` in `::Example97` cannot be duplicated
```

True, but the conclusion was wrong. The framework method that #144 needs to model is declared on a *module* (`HttpAuthentication::Token::ControllerMethods`) that `ActionController::Base` includes, so pseudo-code defining it on `ActionController::Base` has a different owner — no duplication — and a class's own method wins over an included module's. Measured both ways:

```
include:  call resolves to ::PPAuth#authenticate      (the class's own)
prepend:  call resolves to ::PPMixin#authenticate     (the module's)
```

That is also exactly what the existing `steep_controller_runtime/action_controller_base.rb` sidecar already does for `redirect_to`, `render` and `head`.
