### PR TITLE
feat: type a block's parameters from the sites that use it

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -299,6 +299,12 @@ module RbsInfer
     # SteepBridge/env (felixefelip/rbs_infer#46).
     resolve_constant_default_param_types(target_members, method_param_types)
 
+    # Tipar os parâmetros do bloco a partir do que o corpo passa para ele
+    # (`login_procedure.call(token, options)`). O collector deferiu do mesmo
+    # jeito: gravou só as posições, porque quem responde o tipo é o Steep
+    # (felixefelip/rbs_infer#148).
+    resolve_block_param_types(target_members)
+
     # Identificar parâmetros opcionais do initialize
     optional_params = extract_optional_init_params
 
@@ -555,6 +561,42 @@ module RbsInfer
         (method_param_types[member.name] ||= {})[param_name] = type
       end
     end
+  end
+
+  # A block's parameters are whatever the method PASSES to it, so the sites
+  # that use the block are the evidence — and Steep has already typed those
+  # expressions while checking the file. `authenticate` calls
+  # `login_procedure.call(token, options)`, and asking about those two
+  # positions answers `String` and `ActiveSupport::HashWithIndifferentAccess?`
+  # for a block signature that was `{ (untyped, untyped) -> untyped }`.
+  #
+  # Positions come from the collector (structural, no bridge there); the types
+  # come from here, the same division as constant defaults above.
+  def resolve_block_param_types(target_members)
+    return if @parsed_target.nil?
+
+    members = target_members.select do |m|
+      [:method, :class_method].include?(m.kind) && m.block_arg_positions && !m.block_arg_positions.empty?
+    end
+    return if members.empty?
+
+    expression_types = steep_bridge.all_expression_types(@parsed_target.source)
+    return if expression_types.empty?
+
+    members.each do |member|
+      types = member.block_arg_positions.map { |positions| block_param_type(positions, expression_types) }
+      member.signature = RbsInfer::Signatures::RbsParserUtil.replace_block_param_types(member.signature, types)
+    end
+  end
+
+  # One block parameter, across every site that uses the block: a method that
+  # yields an Integer in one branch and a String in another gives its block a
+  # union, exactly as the sites say.
+  def block_param_type(positions, expression_types)
+    types = positions.filter_map { |line, column| expression_types["#{line}:#{column}"] }.uniq
+    return nil if types.empty?
+
+    RbsInfer::Inference::TypeMerger.union_types(types)
   end
 
   # ─── Extrair nomes dos keyword params opcionais do initialize ─────

--- a/lib/rbs_infer/extensions/rails/current_attributes_runtime_generator.rb
+++ b/lib/rbs_infer/extensions/rails/current_attributes_runtime_generator.rb
@@ -201,15 +201,19 @@ module RbsInfer
         def set_with_defs(names)
           kwargs = names.map { |n| "#{n}: nil" }.join(", ")
           # The kwargs assignments are the point: they feed the attribute's type
-          # from `Current.with(user: ...)` call-sites. Ending in `block&.call(nil)`
+          # from `Current.with(user: ...)` call-sites. Ending in the block call
           # (rather than the last assignment) keeps set/with from LEAKING the
           # attribute type into a caller's return — the method infers `-> nil`,
-          # which is harmless (set/with are called for their side effect). The
-          # reopen is now type-checked: `&block` is inferred optional and
-          # single-arg, so the safe-nav covers the optionality and the `nil` the
-          # arity (the pseudo-code never runs).
+          # which is harmless (set/with are called for their side effect).
+          #
+          # No argument, like `CurrentAttributes#set` itself, which plainly
+          # `yield`s. It used to pass `nil` to satisfy a block inference that was
+          # hardcoded to one parameter; the arity now comes from this very line
+          # (felixefelip/rbs_infer#147), so the placeholder became the block's
+          # declared parameter TYPE — `?{ (nil) -> untyped }`, which is no type
+          # for a caller's block parameter to have.
           ["set", "with"].map do |method|
-            ["def self.#{method}(#{kwargs}, &block)", *names.map { |n| "  @#{n} = #{n}" }, "  block&.call(nil)", "end"]
+            ["def self.#{method}(#{kwargs}, &block)", *names.map { |n| "  @#{n} = #{n}" }, "  block&.call", "end"]
           end
         end
 

--- a/lib/rbs_infer/inference/class_member_collector.rb
+++ b/lib/rbs_infer/inference/class_member_collector.rb
@@ -16,7 +16,10 @@ module RbsInfer::Inference
   # `class << self` (attr de singleton, `self.attr x`). Distingue o attr de
   # instância `x` da class-instance variable `@x` escrita em `def self.x`, que
   # compartilham nome mas são slots diferentes (felixefelip/rbs_infer#86).
-  Member = Struct.new(:kind, :name, :signature, :visibility, :owner, :value_node, :param_constant_defaults, :old_name, :singleton, keyword_init: true)
+  # `block_arg_positions` = para membros `:method`/`:class_method`, onde ficam
+  # os argumentos que o corpo passa para o bloco, um item por parâmetro do
+  # bloco; o tipo de cada um vem do Steep, no Analyzer (#148).
+  Member = Struct.new(:kind, :name, :signature, :visibility, :owner, :value_node, :param_constant_defaults, :old_name, :singleton, :block_arg_positions, keyword_init: true)
 
   # Metadata extraída de uma chamada `delegate` — tipos são resolvidos depois no Analyzer
   DelegateInfo = Struct.new(:methods, :target, :prefix, :allow_nil, keyword_init: true)
@@ -139,7 +142,8 @@ module RbsInfer::Inference
         owner: current_owner,
         # Only when we synthesized the signature — an explicit `#:`/`@rbs`
         # annotation is authoritative and must not be overridden.
-        param_constant_defaults: sig ? nil : extractor.constant_default_params
+        param_constant_defaults: sig ? nil : extractor.constant_default_params,
+        block_arg_positions: sig ? nil : extractor.block_arg_positions
       )
       super
     end

--- a/lib/rbs_infer/inference/class_member_collector/block_signature.rb
+++ b/lib/rbs_infer/inference/class_member_collector/block_signature.rb
@@ -18,6 +18,12 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
   # view of the callee this object does not have. Recorded rather than guessed
   # at.
   #
+  # The block's PARAMETERS come from the same places: `yield x, y` and
+  # `block.call(x, y)` say how many the block takes, and — once someone types
+  # those expressions — what they are. Only the count is settled here; the
+  # types are looked up in the Analyzer, which owns the checker
+  # (felixefelip/rbs_infer#148).
+  #
   # Declaring every block optional made `block.call` a call on `Proc | nil`, so
   # the checker refused the one line such a method exists for; and a method that
   # only `yield`s declared no block at all, which is how a caller passing one got
@@ -33,7 +39,20 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
     def call
       return nil unless block_param_name || yields?
 
-      required? ? "{ (#{block_params}) -> untyped }" : "?{ (untyped) -> untyped }"
+      "#{"?" unless required?}{ (#{block_params}) -> untyped }"
+    end
+
+    # Where the values the body hands to the block sit in the source, one entry
+    # per block parameter: `[[[line, column], …], …]`, columns in CHARACTERS so
+    # a Parser-based lookup lines up (felixefelip/rbs_infer#142).
+    #
+    # Only the positions: the TYPES there are the checker's answer, and the
+    # checker belongs to the Analyzer. This object is structural, like the rest
+    # of the collector — same split as `constant_default_params`.
+    def arg_positions
+      return [] unless arity
+
+      Array.new(arity) { |slot| use_sites.filter_map { |args| position_of(args[slot]) } }
     end
 
     private
@@ -62,34 +81,49 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
       end
     end
 
-    # The arity the body uses the block with, as `untyped` params. Fixed at one
-    # before, which nothing checked while every block was optional — a required
-    # block IS checked, and `login_procedure.call(token, options)` against a
-    # one-parameter block is `Unexpected positional argument`.
+    # The arity the body uses the block with, as `untyped` params — the types
+    # are filled in later, from the same use sites (see `arg_positions`).
     #
-    # The types are still `untyped`: the arity comes from the use sites, and the
-    # types could come from the same place, which is the next thing to do here.
+    # Fixed at one before, which nothing checked while every block was optional
+    # — a required block IS checked, and `login_procedure.call(token, options)`
+    # against a one-parameter block is `Unexpected positional argument`. An
+    # optional block is just as checkable at the call site, so it reads the body
+    # too rather than keeping the old guess.
     def block_params
-      arities = []
-      walk_nodes do |node|
-        arities << argument_count(node) if node.is_a?(Prism::YieldNode)
-        next unless node.is_a?(Prism::CallNode) && node.name == :call && block_param_name
-        next unless reads_block?(node.receiver, block_param_name)
-
-        arities << argument_count(node)
-      end
-
-      # `*untyped` for both kinds of not-knowing: use sites that disagree, and a
-      # body that only FORWARDS the block, which says nothing about its arity.
-      # Defaulting those to one parameter made the forward itself a mismatch
-      # against a callee that takes two.
-      return "*untyped" if arities.uniq.size != 1
-
-      Array.new(arities.first, "untyped").join(", ")
+      arity ? Array.new(arity, "untyped").join(", ") : "*untyped"
     end
 
-    def argument_count(node)
-      node.arguments&.arguments&.size || 0
+    # `nil` for both kinds of not-knowing: use sites that disagree, and a body
+    # that only FORWARDS the block, which says nothing about its arity.
+    # Defaulting those to one parameter made the forward itself a mismatch
+    # against a callee that takes two — `*untyped` is the honest answer.
+    def arity
+      arities = use_sites.map(&:size).uniq
+
+      arities.first if arities.size == 1
+    end
+
+    # Every place the body hands values to the block, as its argument nodes.
+    # `block&.call` counts here though it does not count as *requiring* a block:
+    # a guarded call still shows what the block is called WITH.
+    def use_sites
+      @use_sites ||= [].tap do |sites|
+        walk_nodes do |node|
+          sites << arguments_of(node) if node.is_a?(Prism::YieldNode)
+          next unless node.is_a?(Prism::CallNode) && node.name == :call && block_param_name
+          next unless reads_block?(node.receiver, block_param_name)
+
+          sites << arguments_of(node)
+        end
+      end
+    end
+
+    def arguments_of(node)
+      node.arguments&.arguments || []
+    end
+
+    def position_of(node)
+      [node.location.start_line, node.location.start_character_column] if node
     end
 
     # Anything that asks whether the block is there.

--- a/lib/rbs_infer/inference/class_member_collector/extract_params_signature.rb
+++ b/lib/rbs_infer/inference/class_member_collector/extract_params_signature.rb
@@ -15,6 +15,13 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
     # value-position constant itself (felixefelip/rbs_infer#56).
     def constant_resolver = nil
 
+    # Where the body's block arguments sit, for the Analyzer to type by the
+    # same deferral: the block's parameters are emitted `untyped` here and
+    # filled from the checker there (felixefelip/rbs_infer#148).
+    def block_arg_positions
+      block_signature.arg_positions
+    end
+
     # `body` decides whether a block is required, and whether a method that only
     # `yield`s takes one at all — neither is visible from the parameters alone.
     def initialize(params, body: nil)
@@ -101,11 +108,15 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
 
     # The block half lives in its own object: it is decided by the BODY, not
     # by the parameter list, and it is about to learn more (the callee's own
-    # requirement, the types at the use sites) that has no business here.
+    # requirement) that has no business here.
     def block_sig
       return @block_sig if defined?(@block_sig)
 
-      @block_sig = BlockSignature.new(@params, body: @body).call
+      @block_sig = block_signature.call
+    end
+
+    def block_signature
+      @block_signature ||= BlockSignature.new(@params, body: @body)
     end
   end
 end

--- a/lib/rbs_infer/signatures/rbs_parser_util.rb
+++ b/lib/rbs_infer/signatures/rbs_parser_util.rb
@@ -262,6 +262,44 @@ module RbsInfer::Signatures
       found
     end
 
+    # Fills in a block's parameter types on a whole method signature
+    # (`name: (params) { (untyped, untyped) -> untyped } -> ret`), which is how
+    # the collector emits them: the arity comes from the body's use sites, the
+    # types from the checker, and only the Analyzer has the checker (#148).
+    #
+    # Deliberately narrow. It only rewrites a list that is still entirely
+    # `untyped` and whose length matches — anything else (an `*untyped` block of
+    # unknown arity, a signature already refined, a hand-written `#:`
+    # annotation) is left exactly as it is rather than guessed at.
+    BLOCK_PARAM_LIST = /(?<open>\??\{ \()(?<params>untyped(?:, untyped)*)(?<close>\) -> )/
+
+    def replace_block_param_types(method_sig, types)
+      return method_sig if method_sig.nil? || types.nil? || types.none? { |type| usable_type?(type) }
+
+      method_sig.sub(BLOCK_PARAM_LIST) do
+        match = Regexp.last_match
+        next match[0] unless match[:params].split(", ").size == types.size
+
+        # A block's parameter list is unambiguous — `(String | Integer, Integer)`
+        # is two parameters, not one — so a union needs none of the wrapping a
+        # RETURN type does (there a bare `|` is an overload separator). Types
+        # arrive pre-wrapped from `TypeMerger.union_types`, and keeping that
+        # would emit `((String | Integer))`.
+        filled = types.map { |type| usable_type?(type) ? unparenthesized(type) : "untyped" }
+        "#{match[:open]}#{filled.join(", ")}#{match[:close]}"
+      end
+    end
+
+    def usable_type?(type)
+      !type.nil? && type != "untyped"
+    end
+
+    # Drops one redundant outer pair. `(A & B)?` and `Array[A | B]` are not
+    # outer-parenthesized, so they pass through untouched.
+    def unparenthesized(type)
+      outer_parenthesized?(type) ? type[1..-2] : type
+    end
+
     # Appends `?` to a type, parenthesizing compounds first — a bare
     # `A & B?` binds the `?` to the LAST component only (semantically
     # wrong) and is a syntax error in return position. No-op when the

--- a/spec/dummy/app/models/example17.rb
+++ b/spec/dummy/app/models/example17.rb
@@ -15,6 +15,11 @@
 # `with_optional` is the contrast the fix has to respect: guarded by `if block`,
 # optional is the correct answer there. And `with_yield` shows a second gap —
 # a method that yields is inferred as taking no block at all.
+#
+# The block's PARAMETERS come from the same evidence: whatever the body hands
+# to the block is what the block receives. `with_pair` and `with_either` below
+# pin that (felixefelip/rbs_infer#148) — including the case where the argument
+# is not a literal, which is the shape the Rails chain has.
 class Example17
   # Required: called unconditionally.
   def with_token(&block)
@@ -29,6 +34,29 @@ class Example17
   # Yields rather than naming the block.
   def with_yield
     yield "token"
+  end
+
+  # The block's PARAMETER TYPES are whatever the method passes to it, which is
+  # a question about expressions the checker has already typed — here a local
+  # assigned from a call, not a literal, which is the shape Rails' own
+  # `login_procedure.call(token, options)` has.
+  def with_pair(&block)
+    label = name.upcase
+    block.call(label, label.length)
+  end
+
+  # Two sites, two types, one block parameter: the union is what both sites
+  # agree the block must accept.
+  def with_either(flag)
+    if flag
+      yield "text"
+    else
+      yield 42
+    end
+  end
+
+  def name
+    "example"
   end
 
   def run

--- a/spec/dummy/sig/generated/steep_current_runtime/current.rb
+++ b/spec/dummy/sig/generated/steep_current_runtime/current.rb
@@ -77,7 +77,7 @@ class Current
     @author_name = author_name
     @account = account
     @viewer_name = viewer_name
-    block&.call(nil)
+    block&.call
   end
 
   def self.with(user: nil, author_name: nil, account: nil, viewer_name: nil, &block)
@@ -85,6 +85,6 @@ class Current
     @author_name = author_name
     @account = account
     @viewer_name = viewer_name
-    block&.call(nil)
+    block&.call
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example13.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example13.rbs
@@ -30,7 +30,7 @@ class Example13
     def initialize: (name: String) -> bool
     def current_user: () -> Example13Viewer?
     def halt: () -> bool
-    def with_format: () ?{ (untyped) -> untyped } -> untyped
+    def with_format: () ?{ (Symbol) -> untyped } -> untyped
     def guard_supported: () -> Example13Viewer?
     def run_supported: () -> String?
     def act_supported: () -> String

--- a/spec/dummy/sig/rbs_infer/app/models/example16.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example16.rbs
@@ -6,7 +6,7 @@ class Example16
 
   private
 
-  def authenticate: () -> untyped
+  def authenticate: () -> (Example16::User | bool)
   def resume: () -> Example16::User?
   def from_token: () -> (Example16::User | bool)
   def deny: () -> bool

--- a/spec/dummy/sig/rbs_infer/app/models/example17.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example17.rbs
@@ -1,6 +1,9 @@
 class Example17
-  def with_token: () { (untyped) -> untyped } -> untyped
-  def with_optional: () ?{ (untyped) -> untyped } -> untyped
-  def with_yield: () { (untyped) -> untyped } -> untyped
+  def with_token: () { (String) -> untyped } -> untyped
+  def with_optional: () ?{ (String) -> untyped } -> untyped
+  def with_yield: () { (String) -> untyped } -> untyped
+  def with_pair: () { (String, Integer) -> untyped } -> untyped
+  def with_either: (untyped flag) { (String | Integer) -> untyped } -> untyped
+  def name: () -> String
   def run: () -> untyped
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/action_controller/metal/http_authentication.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/action_controller/metal/http_authentication.rbs
@@ -1,11 +1,11 @@
 module ActionController
   module HttpAuthentication
     module Token::ControllerMethods
-      def authenticate_or_request_with_http_token: (?String realm, ?untyped message) ?{ (untyped) -> untyped } -> untyped
-      def authenticate_with_http_token: () ?{ (untyped) -> untyped } -> untyped
+      def authenticate_or_request_with_http_token: (?String realm, ?untyped message) ?{ (*untyped) -> untyped } -> untyped
+      def authenticate_with_http_token: () ?{ (*untyped) -> untyped } -> untyped
     end
     module Token
-      def authenticate: (untyped controller) { (untyped, untyped) -> untyped } -> untyped
+      def authenticate: (untyped controller) { (String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?) -> untyped } -> untyped
     end
   end
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs
@@ -29,6 +29,6 @@ class Current
   def self.viewer_name: () -> untyped
   def self.viewer_name=: (untyped value) -> untyped
   def self.__rbs_infer_instance: () -> Current
-  def self.set: (?user: ((User & User::Validated) | User)?, ?author_name: String?, ?account: (Account & Account::Validated)?, ?viewer_name: untyped) ?{ (untyped) -> untyped } -> nil
-  def self.with: (?user: (User & User::Validated)?, ?author_name: String?, ?account: (Account & Account::Validated)?, ?viewer_name: untyped) ?{ (untyped) -> untyped } -> nil
+  def self.set: (?user: ((User & User::Validated) | User)?, ?author_name: String?, ?account: (Account & Account::Validated)?, ?viewer_name: untyped) ?{ () -> untyped } -> nil
+  def self.with: (?user: (User & User::Validated)?, ?author_name: String?, ?account: (Account & Account::Validated)?, ?viewer_name: untyped) ?{ () -> untyped } -> nil
 end

--- a/spec/expectations/lib/rails_ext/active_storage_authorization.rbs
+++ b/spec/expectations/lib/rails_ext/active_storage_authorization.rbs
@@ -21,7 +21,7 @@ module ActiveStorage
     def bearer_token_authenticatable_request?: () -> bool
     def publicly_accessible_blob?: () -> untyped
     def ensure_accessible: () -> untyped
-    def http_cache_forever: (?public: untyped) ?{ (untyped) -> untyped } -> untyped
+    def http_cache_forever: (?public: untyped) ?{ (*untyped) -> untyped } -> untyped
   end
 end
 

--- a/spec/expectations/models/example13.rbs
+++ b/spec/expectations/models/example13.rbs
@@ -30,7 +30,7 @@ class Example13
     def initialize: (name: String) -> bool
     def current_user: () -> Example13Viewer?
     def halt: () -> bool
-    def with_format: () ?{ (untyped) -> untyped } -> untyped
+    def with_format: () ?{ (Symbol) -> untyped } -> untyped
     def guard_supported: () -> Example13Viewer?
     def run_supported: () -> String?
     def act_supported: () -> String

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -30,4 +30,4 @@ app/services/profile_formatter.rb:31:4: [error] `format_nickname` requires `self
 app/services/profile_formatter.rb:37:13: [error] Type `(::String | nil)` does not have method `upcase`
 app/services/tag_destroy.rb:110:6: [error] Cannot allow method body have type `(void | ::String)` because declared as type `(::String | nil)`
 app/services/tag_destroy.rb:98:7: [error] Type `::TagDestroy` does not have method `untyped`
-sig/generated/steep_controller_runtime/action_controller/metal/http_authentication.rb:22:35: [warning] Cannot pass a value of type `(^(untyped) -> untyped | nil)` as a block-pass-argument of type `^(untyped, untyped) -> untyped`
+sig/generated/steep_controller_runtime/action_controller/metal/http_authentication.rb:22:35: [warning] Cannot pass a value of type `(^(*untyped) -> untyped | nil)` as a block-pass-argument of type `^(::String, (::ActiveSupport::HashWithIndifferentAccess[untyped, untyped] | nil)) -> untyped`

--- a/spec/expectations/steep_controller_runtime/action_controller/metal/http_authentication.rbs
+++ b/spec/expectations/steep_controller_runtime/action_controller/metal/http_authentication.rbs
@@ -1,11 +1,11 @@
 module ActionController
   module HttpAuthentication
     module Token::ControllerMethods
-      def authenticate_or_request_with_http_token: (?String realm, ?untyped message) ?{ (untyped) -> untyped } -> untyped
-      def authenticate_with_http_token: () ?{ (untyped) -> untyped } -> untyped
+      def authenticate_or_request_with_http_token: (?String realm, ?untyped message) ?{ (*untyped) -> untyped } -> untyped
+      def authenticate_with_http_token: () ?{ (*untyped) -> untyped } -> untyped
     end
     module Token
-      def authenticate: (untyped controller) { (untyped, untyped) -> untyped } -> untyped
+      def authenticate: (untyped controller) { (String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?) -> untyped } -> untyped
     end
   end
 end

--- a/spec/expectations/steep_current_runtime/current.rb
+++ b/spec/expectations/steep_current_runtime/current.rb
@@ -77,7 +77,7 @@ class Current
     @author_name = author_name
     @account = account
     @viewer_name = viewer_name
-    block&.call(nil)
+    block&.call
   end
 
   def self.with(user: nil, author_name: nil, account: nil, viewer_name: nil, &block)
@@ -85,6 +85,6 @@ class Current
     @author_name = author_name
     @account = account
     @viewer_name = viewer_name
-    block&.call(nil)
+    block&.call
   end
 end

--- a/spec/lib/rbs_infer/analyzer_spec.rb
+++ b/spec/lib/rbs_infer/analyzer_spec.rb
@@ -994,10 +994,15 @@ RSpec.describe RbsInfer::Analyzer do
         rbs = analyzer.generate_rbs
 
         aggregate_failures do
-          # Block should be outside parentheses
-          expect(rbs).to include("def wrapper: (id: untyped, name: untyped, ?data: untyped, **untyped) ?{ (untyped) -> untyped } -> untyped")
-          expect(rbs).to include("def simple_yield: () ?{ (untyped) -> untyped } -> untyped")
-          expect(rbs).to include("def mixed: (untyped items, label: untyped) ?{ (untyped) -> untyped } -> untyped")
+          # Block should be outside parentheses.
+          #
+          # Its arity is read off the body: a forwarded block
+          # (`tag.section(&block)`, `items.each(&block)`) says nothing about how
+          # it gets called, hence `*untyped`, while a bare `yield` says plainly
+          # that it is called with nothing.
+          expect(rbs).to include("def wrapper: (id: untyped, name: untyped, ?data: untyped, **untyped) ?{ (*untyped) -> untyped } -> untyped")
+          expect(rbs).to include("def simple_yield: () ?{ () -> untyped } -> untyped")
+          expect(rbs).to include("def mixed: (untyped items, label: untyped) ?{ (*untyped) -> untyped } -> untyped")
 
           # Block must NEVER be inside parentheses
           expect(rbs).not_to include(", ?{")
@@ -1026,9 +1031,10 @@ RSpec.describe RbsInfer::Analyzer do
         rbs = analyzer.generate_rbs
 
         aggregate_failures do
-          # Return types should be resolved correctly
-          expect(rbs).to include("def wrapper: () ?{ (untyped) -> untyped } -> String")
-          expect(rbs).to include("def count_items: (untyped items) ?{ (untyped) -> untyped } -> Integer")
+          # Return types should be resolved correctly. Neither body ever calls
+          # its block, so there is no arity to read — `*untyped`.
+          expect(rbs).to include("def wrapper: () ?{ (*untyped) -> untyped } -> String")
+          expect(rbs).to include("def count_items: (untyped items) ?{ (*untyped) -> untyped } -> Integer")
 
           # The -> untyped inside the block must not be replaced
           expect(rbs).not_to include("-> String }")

--- a/spec/lib/rbs_infer/inference/class_member_collector/block_signature_spec.rb
+++ b/spec/lib/rbs_infer/inference/class_member_collector/block_signature_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe RbsInfer::Inference::ClassMemberCollector::BlockSignature do
     # Passing a nil block along is legal Ruby, and a helper that forwards to
     # `tag.section` or `items.each` is called without one all the time.
     it "is optional when the body only FORWARDS the block" do
-      expect(signature_for("def m(&block); other(&block); end")).to eq("?{ (untyped) -> untyped }")
+      expect(signature_for("def m(&block); other(&block); end")).to eq("?{ (*untyped) -> untyped }")
     end
   end
 
@@ -61,6 +61,35 @@ RSpec.describe RbsInfer::Inference::ClassMemberCollector::BlockSignature do
       expect(signature_for("def m(&block); block.call(1); block.call(1, 2); end"))
         .to eq("{ (*untyped) -> untyped }")
     end
+
+    # A guarded block is just as callable, so the body decides its arity too —
+    # this read `?{ (untyped) -> untyped }` whatever the body did.
+    it "reads the body for an OPTIONAL block as well" do
+      expect(signature_for("def m(&block); block.call(1, 2) if block; end"))
+        .to eq("?{ (untyped, untyped) -> untyped }")
+    end
+  end
+
+  # The types at those sites are the checker's answer, so this only records
+  # where to look — line and CHARACTER column, which is what a Parser-based
+  # lookup is keyed by.
+  describe "#arg_positions" do
+    def positions_for(source)
+      def_node = Prism.parse(source).value.statements.body.first
+      described_class.new(def_node.parameters, body: def_node.body).arg_positions
+    end
+
+    it "points at each argument the body passes to the block" do
+      expect(positions_for("def m(&block)\n  block.call(x, y)\nend")).to eq([[[2, 13]], [[2, 16]]])
+    end
+
+    it "collects every site for the same parameter, so they can be unioned" do
+      expect(positions_for("def m\n  yield 1\n  yield 2\nend")).to eq([[[2, 8], [3, 8]]])
+    end
+
+    it "has nothing to say when the arity itself is unknown" do
+      expect(positions_for("def m(&block); other(&block); end")).to eq([])
+    end
   end
 
   it "is absent when the method neither takes nor yields a block" do
@@ -69,6 +98,6 @@ RSpec.describe RbsInfer::Inference::ClassMemberCollector::BlockSignature do
 
   it "reads the body, not the parameter list: no body means no answer to give" do
     def_node = Prism.parse("def m(&block); end").value.statements.body.first
-    expect(described_class.new(def_node.parameters, body: nil).call).to eq("?{ (untyped) -> untyped }")
+    expect(described_class.new(def_node.parameters, body: nil).call).to eq("?{ (*untyped) -> untyped }")
   end
 end

--- a/spec/lib/rbs_infer/inference/class_member_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/class_member_collector_spec.rb
@@ -378,7 +378,9 @@ RSpec.describe RbsInfer::Inference::ClassMemberCollector do
 
     collector = collect(source)
     member = collector.members.find { |m| m.name == "tag" }
-    expect(member.signature).to eq("tag: (id: untyped, name: untyped, **untyped) ?{ (untyped) -> untyped } -> untyped")
+    # `*untyped`: an empty body never calls the block, so there is no arity to
+    # read off it — this example is about WHERE the block goes.
+    expect(member.signature).to eq("tag: (id: untyped, name: untyped, **untyped) ?{ (*untyped) -> untyped } -> untyped")
     expect(member.signature).not_to include(", ?{")
   end
 
@@ -392,7 +394,7 @@ RSpec.describe RbsInfer::Inference::ClassMemberCollector do
 
     collector = collect(source)
     member = collector.members.find { |m| m.name == "each" }
-    expect(member.signature).to eq("each: () ?{ (untyped) -> untyped } -> untyped")
+    expect(member.signature).to eq("each: () ?{ (*untyped) -> untyped } -> untyped")
   end
 
   it "gera assinatura com params posicionais e bloco" do
@@ -405,7 +407,7 @@ RSpec.describe RbsInfer::Inference::ClassMemberCollector do
 
     collector = collect(source)
     member = collector.members.find { |m| m.name == "map" }
-    expect(member.signature).to eq("map: (untyped items) ?{ (untyped) -> untyped } -> untyped")
+    expect(member.signature).to eq("map: (untyped items) ?{ (*untyped) -> untyped } -> untyped")
   end
 
   it "não sobrescreve superclass com a de uma classe aninhada" do

--- a/spec/lib/rbs_infer/inference/type_merger_spec.rb
+++ b/spec/lib/rbs_infer/inference/type_merger_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
       collector = RbsInfer::Inference::ClassMemberCollector.new(comments: result.comments, lines: source.lines)
       result.value.accept(collector)
       member = collector.members.find { |candidate| candidate.name == "write" }
-      expect(member.signature).to include("?{ (untyped) -> untyped } -> untyped")
+      expect(member.signature).to include("?{ (*untyped) -> untyped } -> untyped")
 
       resolver = instance_double("MethodTypeResolver")
       allow(resolver).to receive(:resolve).with("Session", "signed_id").and_return("String")
@@ -133,7 +133,7 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
 
       # The BLOCK's `-> untyped` has to survive; only the final return changes.
       expect(member.signature)
-        .to eq("write: (untyped session) ?{ (untyped) -> untyped } -> { value: String, httponly: bool }")
+        .to eq("write: (untyped session) ?{ (*untyped) -> untyped } -> { value: String, httponly: bool }")
     end
 
     it "does not corrupt a block-bearing signature when resolving the return type" do
@@ -153,9 +153,9 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
       result.value.accept(collector)
 
       member = collector.members.find { |m| m.name == "wrapper" }
-      # Signature should have block: "wrapper: () ?{ (untyped) -> untyped } -> String"
+      # Signature should have block: "wrapper: () ?{ (*untyped) -> untyped } -> String"
       # The block's -> untyped should NOT be replaced
-      expect(member.signature).to include("?{ (untyped) -> untyped } -> String")
+      expect(member.signature).to include("?{ (*untyped) -> untyped } -> String")
       expect(member.signature).not_to include("-> untyped } -> String } -> String")
     end
   end

--- a/spec/lib/rbs_infer/signatures/rbs_parser_util_spec.rb
+++ b/spec/lib/rbs_infer/signatures/rbs_parser_util_spec.rb
@@ -376,4 +376,59 @@ RSpec.describe RbsInfer::Signatures::RbsParserUtil do
       expect(described_class.nilablize(nil)).to be_nil
     end
   end
+
+  describe ".replace_block_param_types" do
+    it "fills in the block's parameters, leaving the rest of the signature alone" do
+      expect(described_class.replace_block_param_types(
+        "authenticate: (untyped controller) { (untyped, untyped) -> untyped } -> untyped",
+        ["String", "ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?"]
+      )).to eq("authenticate: (untyped controller) { (String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?) -> untyped } -> untyped")
+    end
+
+    it "fills an optional block too" do
+      expect(described_class.replace_block_param_types("m: () ?{ (untyped) -> untyped } -> untyped", ["String"]))
+        .to eq("m: () ?{ (String) -> untyped } -> untyped")
+    end
+
+    # A parameter no site could type stays `untyped` rather than dragging the
+    # whole block down with it.
+    it "fills the parameters it knows and keeps the others" do
+      expect(described_class.replace_block_param_types("m: () { (untyped, untyped) -> untyped } -> untyped", [nil, "Integer"]))
+        .to eq("m: () { (untyped, Integer) -> untyped } -> untyped")
+    end
+
+    # A parameter list is unambiguous, unlike return position, so the wrapping
+    # `TypeMerger` adds is redundant here — `(String | Integer, Integer)` reads
+    # as two parameters either way.
+    it "drops the redundant parens a merged union arrives with" do
+      expect(described_class.replace_block_param_types("m: () { (untyped, untyped) -> untyped } -> untyped", ["(String | Integer)", "Integer"]))
+        .to eq("m: () { (String | Integer, Integer) -> untyped } -> untyped")
+    end
+
+    it "keeps parens that are part of the type" do
+      expect(described_class.replace_block_param_types("m: () { (untyped) -> untyped } -> untyped", ["(A & B)?"]))
+        .to eq("m: () { ((A & B)?) -> untyped } -> untyped")
+    end
+
+    # Narrow on purpose: anything that isn't the shape the collector emits is
+    # someone else's answer, and overwriting it would be a regression.
+    it "leaves alone what it cannot account for" do
+      [
+        # arity unknown
+        ["m: () { (*untyped) -> untyped } -> untyped", ["String"]],
+        # length disagrees with the types on offer
+        ["m: () { (untyped, untyped) -> untyped } -> untyped", ["String"]],
+        # already refined, or hand-written
+        ["m: () { (String) -> untyped } -> untyped", ["Integer"]],
+        # no block at all
+        ["m: (untyped a) -> untyped", ["String"]],
+        # nothing to say
+        ["m: () { (untyped) -> untyped } -> untyped", [nil]],
+        ["m: () { (untyped) -> untyped } -> untyped", ["untyped"]],
+        ["m: () { (untyped) -> untyped } -> untyped", []]
+      ].each do |sig, types|
+        expect(described_class.replace_block_param_types(sig, types)).to eq(sig)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Follows #147, which made a block required when the body cannot run without one. The arity came from the body there; the types come from the same place here.

## The problem

A block's parameters were always `untyped`, so the checker knew the shape of a block and nothing about what it receives:

```rbs
def authenticate: (untyped controller) { (untyped, untyped) -> untyped } -> untyped
```

The evidence was never missing. A block's parameters are whatever the method **passes** to it, and Steep has already typed those expressions while checking the file:

```
35:31   token     → String
35:38   options   → ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?
```

## The split

The collector is structural by design — it declares `constant_resolver = nil` and is built in five places, three of them with no SteepBridge at all. So this follows the division already used for constant defaults: `BlockSignature` records only **where** the arguments sit, and the Analyzer, which owns the checker, resolves them and fills the signature in.

Positions are line + **character** column, so a Parser-based lookup lines up with a Prism node (#142). Sites that disagree union, exactly as disagreeing arities widen to `*untyped`.

```rbs
def authenticate: (untyped controller) { (String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?) -> untyped } -> untyped
```

## The optional branch reads the body too

Its arity was hardcoded at one parameter whatever the body did, so `b.call(x, y) if b` declared a one-parameter block. It now shares the same calculation — which also makes a forwarder honest about knowing nothing:

| body | before | after |
|---|---|---|
| `b.call(x, y) if b` | `?{ (untyped) … }` | `?{ (untyped, untyped) … }` |
| `yield if block_given?` | `?{ (untyped) … }` | `?{ () … }` |
| `tag.section(&block)` | `?{ (untyped) … }` | `?{ (*untyped) … }` |

## A placeholder this turned into a type

The `Current` sidecar generated `block&.call(nil)`, written to satisfy the old fixed arity — its own comment said so. With the arity now read from that very line, the placeholder became the block's declared parameter **type**: `?{ (nil) -> untyped }`, which is no type for a caller's block parameter to have.

`CurrentAttributes#set` plainly `yield`s, so the pseudo-code now does the same and the signature is `?{ () -> untyped }`. Without this the PR would ship a regression.

## Result

`example17` gains the two readings this has to get right — an argument that is **not a literal** (the shape the Rails chain has) and two sites that disagree:

```rbs
def with_pair:   ()             { (String, Integer) -> untyped } -> untyped
def with_either: (untyped flag) { (String | Integer) -> untyped } -> untyped
```

Elsewhere in the dummy, `example13#with_format` → `?{ (Symbol) … }`.

The baseline moves by one line — the same warning, now with real types on both sides:

```diff
- Cannot pass `(^(untyped) -> untyped | nil)` as a block-pass-argument of type `^(untyped, untyped) -> untyped`
+ Cannot pass `(^(*untyped) -> untyped | nil)` as a block-pass-argument of type `^(::String, (::ActiveSupport::HashWithIndifferentAccess[untyped, untyped] | nil)) -> untyped`
```

The arity half of that mismatch is gone. What remains is the `| nil` — the transitive requirement #147 left open: forwarding into a callee that requires a block should make the forwarder require one. That is the next piece, and it closes the transcription.

Suite: **852 examples, 0 failures**.
