### PR TITLE
test: Example18 — the auth chain with the establishment inside a block

### DIFF
--- a/spec/dummy/app/models/example18.rb
+++ b/spec/dummy/app/models/example18.rb
@@ -1,0 +1,118 @@
+# The authentication chain again, with the one thing Example16 leaves out: the
+# establishment happens INSIDE A BLOCK.
+#
+# Example16 is this same shape written with direct calls, and it closes end to
+# end (felixefelip/steep#121, #122). Example17 has blocks, but only as a
+# question about signatures — no fact ever crosses one. Nothing until now had
+# both, which is exactly the gap felixefelip/rbs_infer#144 is about: an app
+# writes
+#
+#   authenticate_or_request_with_http_token do |token|
+#     Current.identity = identity if identity = Identity.find_by_token(token)
+#   end
+#
+# and what makes the fact true lives in the gem, three methods away.
+#
+# So `with_token` and `fetch_token` below are that gem, in miniature. They are
+# not a model of Rails — the real source is transcribed elsewhere (#146). They
+# are here because the real one halts by rendering on a controller it received
+# as an ARGUMENT, and proving that is an aliasing question with nothing to do
+# with blocks. `deny` halts on its own `self`, so the block boundary is the only
+# unsolved thing in this file.
+#
+# What each link needs:
+#
+#   1. `fetch_token` — its value IS the block's call (#123, stage 2a).
+#   2. `with_token`  — answers with the block or halts, so the fact is gated on
+#      the halt (stage 2b).
+#   3. `from_token`  — the call site: a truthy answer means the block ran and
+#      answered truthy, so what the BLOCK established holds. This is stage 3,
+#      and it is the one that does not exist yet.
+#   4. `show`        — dereferences in another method, past the halt check, so
+#      the fact has to survive as an entry fact.
+#
+# Until 3 lands, `show` is a type error. That is the point of the fixture.
+class Example18
+  class User
+    attr_reader :name
+
+    def initialize(name:)
+      @name = name
+    end
+  end
+
+  class Registry
+    def self.user
+      @user
+    end
+
+    def self.user=(value)
+      @user = value
+    end
+  end
+
+  # The action. Runs only past the halt check, and derefs what the chain left.
+  def show
+    "Hi, #{Registry.user.name.upcase}!"
+  end
+
+  # The runner: guard, halt check, action.
+  def call
+    authenticate
+
+    return if @halted
+
+    show
+  end
+
+  private
+
+  # The app level: establish, or halt. Same `|| deny` the framework uses one
+  # frame down — Rails has both, and so does a real app.
+  def authenticate
+    from_token || deny
+  end
+
+  # THE POINT OF THE FIXTURE. The write sits inside a block handed to somebody
+  # else, and nothing about this method's own body says whether it ran.
+  def from_token
+    with_token do |token|
+      if user = lookup(token)
+        Registry.user = user
+      end
+    end
+  end
+
+  # The framework, in miniature: answers with the block, or halts.
+  def with_token(&block)
+    fetch_token(&block) || deny
+  end
+
+  # Its value IS the block's value — the `unless` only adds a falsy way out.
+  def fetch_token(&block)
+    token = token_value
+
+    unless token.empty?
+      block.call(token)
+    end
+  end
+
+  def deny
+    halt
+  end
+
+  def halt
+    @halted = true
+  end
+
+  # The name is a literal, as in Example16: the ONLY nilability this fixture is
+  # about is `Registry.user`. Feeding the token through would make `name`
+  # nilable too, and `show` would then fail for two reasons that read alike.
+  def lookup(token)
+    User.new(name: "token") if token.start_with?("t")
+  end
+
+  def token_value
+    ENV.fetch("EXAMPLE18_TOKEN", "")
+  end
+end

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -611,6 +611,60 @@ postconditions:
   method: with_yield
   when_true:
     block_truthy: true
+- class: Example18
+  method: authenticate
+  effects:
+    may_write:
+    - "@halted"
+- class: Example18
+  method: call
+  effects:
+    may_write:
+    - "@halted"
+- class: Example18
+  method: deny
+  effects:
+    may_write:
+    - "@halted"
+- class: Example18
+  method: fetch_token
+  when_true:
+    block_truthy: true
+- class: Example18
+  method: halt
+  unconditional:
+    ivars:
+      "@halted": 'true'
+    self: "::Example18 & ::Example18::AfterHalt"
+  effects:
+    may_write:
+    - "@halted"
+- class: Example18
+  method: with_token
+  effects:
+    may_write:
+    - "@halted"
+  conditional_block_truthy:
+    gate_ivar: "@halted"
+- class: Example18::Registry
+  method: user
+  effects:
+    returns_ivar: "@user"
+- class: Example18::Registry
+  method: user=
+  unconditional:
+    ivars:
+      "@user": "::Example18::User"
+    establishes_consts:
+      user: "::Example18::User"
+  effects:
+    may_write:
+    - "@user"
+- class: Example18::User
+  method: initialize
+  effects:
+    may_write:
+    - "@name"
 - class: Example2::Foo
   method: user=
   unconditional:

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -32,6 +32,14 @@ postconditions:
   effects:
     may_write:
     - "@__rbs_infer__performed"
+- class: ActionController::HttpAuthentication::Token
+  method: authenticate
+  when_true:
+    block_truthy: true
+- class: ActionController::HttpAuthentication::Token::ControllerMethods
+  method: authenticate_with_http_token
+  when_true:
+    block_truthy: true
 - class: ApplicationController
   method: authenticate_user
   effects:
@@ -575,6 +583,34 @@ postconditions:
   effects:
     may_write:
     - "@name"
+- class: Example17
+  method: forward_guarded
+  when_true:
+    block_truthy: true
+- class: Example17
+  method: forward_optional
+  when_true:
+    block_truthy: true
+- class: Example17
+  method: forward_required
+  when_true:
+    block_truthy: true
+- class: Example17
+  method: with_optional
+  when_true:
+    block_truthy: true
+- class: Example17
+  method: with_pair
+  when_true:
+    block_truthy: true
+- class: Example17
+  method: with_token
+  when_true:
+    block_truthy: true
+- class: Example17
+  method: with_yield
+  when_true:
+    block_truthy: true
 - class: Example2::Foo
   method: user=
   unconditional:

--- a/spec/dummy/sig/rbs_infer/app/models/example18.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example18.rbs
@@ -1,0 +1,34 @@
+class Example18
+  @halted: true?
+
+  def show: () -> String
+  def call: () -> String?
+
+  private
+
+  def authenticate: () -> untyped
+  def from_token: () -> untyped
+  def with_token: () { (String) -> untyped } -> untyped
+  def fetch_token: () { (String) -> untyped } -> untyped
+  def deny: () -> bool
+  def halt: () -> bool
+  def lookup: (String token) -> Example18::User?
+  def token_value: () -> String
+end
+
+class Example18
+  class User
+    attr_reader name: String
+
+    def initialize: (name: String) -> void
+  end
+end
+
+class Example18
+  class Registry
+    self.@user: Example18::User?
+
+    def self.user: () -> Example18::User?
+    def self.user=: (Example18::User value) -> untyped
+  end
+end

--- a/spec/expectations/models/example18.rbs
+++ b/spec/expectations/models/example18.rbs
@@ -1,0 +1,34 @@
+class Example18
+  @halted: true?
+
+  def show: () -> String
+  def call: () -> String?
+
+  private
+
+  def authenticate: () -> untyped
+  def from_token: () -> untyped
+  def with_token: () { (String) -> untyped } -> untyped
+  def fetch_token: () { (String) -> untyped } -> untyped
+  def deny: () -> bool
+  def halt: () -> bool
+  def lookup: (String token) -> Example18::User?
+  def token_value: () -> String
+end
+
+class Example18
+  class User
+    attr_reader name: String
+
+    def initialize: (name: String) -> void
+  end
+end
+
+class Example18
+  class Registry
+    self.@user: Example18::User?
+
+    def self.user: () -> Example18::User?
+    def self.user=: (Example18::User value) -> untyped
+  end
+end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -9,6 +9,7 @@ app/models/concerns/test/filtrable.rb:8:4: [error] Type `(singleton(::Test) & si
 app/models/example10.rb:27:26: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example14.rb:15:17: [error] Type `(::Example14::User | nil)` does not have method `name`
 app/models/example15.rb:25:25: [error] Type `(::Example15::User | nil)` does not have method `name`
+app/models/example18.rb:56:25: [error] Type `(::Example18::User | nil)` does not have method `name`
 app/models/example3.rb:122:11: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:63:13: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:64:26: [error] Type `(::Example3::User | nil)` does not have method `name`

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -431,6 +431,28 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
   # use it (#148), and — for a body that only forwards — the callee's own
   # requirement (#149). The three readings sit side by side in one class
   # precisely because a fix for any of them can break the others.
+  # The authentication chain with the establishment inside a BLOCK — the gap
+  # felixefelip/rbs_infer#144 is about, and the fixture stage 3 will be built
+  # against. What it pins here is the premise: the framework pair carries a
+  # required, `String`-shaped block, and `Registry.user` is nilable, so the
+  # deref in `show` is a type error for ONE reason. The facts themselves live in
+  # `.steep_postconditions.yml`, and the error in the steep baseline.
+  it "example18" do
+    name = "models/example18"
+    rbs = RbsInfer::Analyzer.new(
+      target_file: "app/models/example18.rb",
+      source_files: source_files
+    ).generate_rbs
+
+    if ENV["UPDATE_EXPECTATIONS"]
+      path = expectations_dir.join("#{name}.rbs")
+      path.dirname.mkpath
+      path.write(rbs)
+    end
+
+    expect(rbs.chomp).to eq(expected_rbs(name).chomp)
+  end
+
   it "example17" do
     name = "models/example17"
     rbs = RbsInfer::Analyzer.new(


### PR DESCRIPTION
The dummy-side half of felixefelip/steep#123 and #124: the regenerated sidecar, and the fixture that gives those facts their first end-to-end evidence.

## The gap

`Example16` is the authentication chain written with direct calls, and it closes end to end. `Example17` has blocks, but only as a question about signatures — no fact ever crosses one. **Nothing had both**, which is exactly the gap #144 is about, and the reason stage 3 had no target to be built against:

```ruby
authenticate_or_request_with_http_token do |token|
  Current.identity = identity if identity = Identity.find_by_token(token)
end
```

## Example18

The same chain as Example16, with the establishment moved inside a block. `with_token` and `fetch_token` are the framework in miniature — here rather than the real transcription (#146) because Rails halts by rendering on a controller it received as an **argument**, and proving that is an aliasing question with nothing to do with blocks. `deny` halts on its own `self`, so the block boundary is the only unsolved thing in the file.

Four links, numbered in the fixture's own header:

| | |
|---|---|
| `fetch_token` — its value IS the block's call | stage 2a ✅ |
| `with_token` — answers with the block or halts | stage 2b ✅ |
| `from_token` — the call site | **stage 3, missing** |
| `show` — derefs past the halt check | needs 3 |

## What it proves today

The first end-to-end evidence for #124, in the GATED form the real chain needs rather than the easy ungated one:

```yaml
- class: Example18
  method: fetch_token
  when_true:
    block_truthy: true
- class: Example18
  method: with_token
  conditional_block_truthy:
    gate_ivar: "@halted"
```

That also answers a question the merged PR left open: #124 had only unit tests, so it was not known whether it fired on a whole project. It does — what was missing before was a target whose halt is provable at all.

## What it leaves open, on purpose

One new baseline entry:

```
app/models/example18.rb:56: Type `(::Example18::User | nil)` does not have method `name`
```

`show` dereferencing a nilable `Registry.user` — exactly as Example16 read before it closed, and for **one** reason. The user's name is a literal on purpose: feeding the token through made `name` nilable too, and `show` would then have failed for two reasons that read alike. Example16's header warns about precisely that confusion.

## Also in here

The sidecar regeneration for #123 (36 lines, additions only), whose point is the two entries on the transcribed Rails source: `Token.authenticate` directly, and `authenticate_with_http_token` one forward away.

Suite: **862 examples, 0 failures**, verified against the merged steep branch.
