### PR TITLE
test: Example19 — the halt lands on an argument

### DIFF
--- a/spec/dummy/app/models/example19.rb
+++ b/spec/dummy/app/models/example19.rb
@@ -1,0 +1,131 @@
+# Example18, with the ONE change that keeps the real Rails chain open: the halt
+# happens on an object passed as an ARGUMENT.
+#
+# Example18 closes end to end because `deny` writes `@halted` on its own `self`.
+# Rails does not do that. `request_http_token_authentication` hands `self` to a
+# module function, and that function renders on the controller it received:
+#
+#   def request_http_token_authentication(realm = "Application", message = nil)
+#     Token.authentication_request(self, realm, message)     # <- passes self
+#   end
+#
+#   def authentication_request(controller, realm, message = nil)   # self = the Token module
+#     controller.__send__ :render, plain: message, status: :unauthorized
+#   end
+#
+# `Responder.deny` below is that function in miniature. The halt is real and it
+# is unconditional — but it lands on `host`, a parameter, while the method's own
+# `self` is the `Responder` module. `always_halting_ivar` reads the ivars a
+# method refines on ITS self, so nothing here proves the tail of a `||` halts,
+# and the whole chain stops (felixefelip/steep#126).
+#
+# The contrast to keep in mind is `fetch_token`: the block's answer crosses the
+# very same object boundary without trouble, because a RETURN VALUE travels back
+# through a call whoever the receiver was. A side effect does not — which object
+# received it is the whole question.
+#
+# Deliberately NOT reproduced here: Rails reaches `render` through
+# `__send__ :render`, which Steep does not resolve (it types as
+# `::BasicObject#__send__`). That is a second, independent obstacle, measured in
+# #126, and mixing it in would leave the fixture proving two things at once. The
+# Basic and Digest variants of the same Rails file write the 401 with plain
+# `controller.status = 401`, no `__send__` anywhere, and they would be equally
+# stuck — which is what makes the parameter, not the `__send__`, the subject.
+#
+# `halt` is public for the same reason `render` is: something outside the object
+# calls it.
+#
+# Until #126 lands, `show` is a type error. That is the point of the fixture.
+class Example19
+  class User
+    attr_reader :name
+
+    def initialize(name:)
+      @name = name
+    end
+  end
+
+  class Registry
+    def self.user
+      @user
+    end
+
+    def self.user=(value)
+      @user = value
+    end
+  end
+
+  # The framework's own module, acting on the host it was handed — the shape of
+  # `ActionController::HttpAuthentication::Token`.
+  module Responder
+    def self.deny(host, message)
+      host.record(message)
+      host.halt
+    end
+  end
+
+  def show
+    "Hi, #{Registry.user.name.upcase}!"
+  end
+
+  def call
+    authenticate
+
+    return if @halted
+
+    show
+  end
+
+  # Public because `Responder.deny` calls it from outside.
+  def halt
+    @halted = true
+  end
+
+  def record(message)
+    @message = message
+  end
+
+  private
+
+  def authenticate
+    from_token || refuse
+  end
+
+  # The establishment still happens inside a block, exactly as in Example18.
+  def from_token
+    with_token do |token|
+      if user = lookup(token)
+        Registry.user = user
+      end
+    end
+  end
+
+  # And the framework still answers with the block or gives up — but giving up
+  # now goes through the argument, and that is what cannot be proven.
+  def with_token(&block)
+    fetch_token(&block) || refuse
+  end
+
+  def fetch_token(&block)
+    token = token_value
+
+    unless token.empty?
+      block.call(token)
+    end
+  end
+
+  # The frame that passes `self`. The argument is written right here, on the
+  # line — which is why the check #126 proposes is syntactic rather than an
+  # alias analysis.
+  def refuse
+    Responder.deny(self, "denied")
+  end
+
+  def lookup(token)
+    User.new(name: "token") if token.start_with?("t")
+  end
+
+  def token_value
+    ENV.fetch("EXAMPLE19_TOKEN", "")
+  end
+end

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -675,6 +675,38 @@ postconditions:
   effects:
     may_write:
     - "@name"
+- class: Example19
+  method: fetch_token
+  when_true:
+    block_truthy: true
+- class: Example19
+  method: halt
+  unconditional:
+    ivars:
+      "@halted": 'true'
+    self: "::Example19 & ::Example19::AfterHalt"
+  effects:
+    may_write:
+    - "@halted"
+- class: Example19::Registry
+  method: user
+  effects:
+    returns_ivar: "@user"
+- class: Example19::Registry
+  method: user=
+  unconditional:
+    ivars:
+      "@user": "::Example19::User"
+    establishes_consts:
+      user: "::Example19::User"
+  effects:
+    may_write:
+    - "@user"
+- class: Example19::User
+  method: initialize
+  effects:
+    may_write:
+    - "@name"
 - class: Example2::Foo
   method: user=
   unconditional:

--- a/spec/dummy/sig/rbs_infer/app/models/example19.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example19.rbs
@@ -1,0 +1,39 @@
+class Example19
+  @halted: true?
+
+  module Responder
+    def self.deny: (untyped host, untyped message) -> untyped
+  end
+
+  def show: () -> String
+  def call: () -> String?
+  def halt: () -> bool
+  def record: (untyped message) -> untyped
+
+  private
+
+  def authenticate: () -> untyped
+  def from_token: () -> untyped
+  def with_token: () { (String) -> untyped } -> untyped
+  def fetch_token: () { (String) -> untyped } -> untyped
+  def refuse: () -> untyped
+  def lookup: (String token) -> Example19::User?
+  def token_value: () -> String
+end
+
+class Example19
+  class User
+    attr_reader name: String
+
+    def initialize: (name: String) -> void
+  end
+end
+
+class Example19
+  class Registry
+    self.@user: Example19::User?
+
+    def self.user: () -> Example19::User?
+    def self.user=: (Example19::User value) -> untyped
+  end
+end

--- a/spec/expectations/models/example19.rbs
+++ b/spec/expectations/models/example19.rbs
@@ -1,0 +1,39 @@
+class Example19
+  @halted: true?
+
+  module Responder
+    def self.deny: (untyped host, untyped message) -> untyped
+  end
+
+  def show: () -> String
+  def call: () -> String?
+  def halt: () -> bool
+  def record: (untyped message) -> untyped
+
+  private
+
+  def authenticate: () -> untyped
+  def from_token: () -> untyped
+  def with_token: () { (String) -> untyped } -> untyped
+  def fetch_token: () { (String) -> untyped } -> untyped
+  def refuse: () -> untyped
+  def lookup: (String token) -> Example19::User?
+  def token_value: () -> String
+end
+
+class Example19
+  class User
+    attr_reader name: String
+
+    def initialize: (name: String) -> void
+  end
+end
+
+class Example19
+  class Registry
+    self.@user: Example19::User?
+
+    def self.user: () -> Example19::User?
+    def self.user=: (Example19::User value) -> untyped
+  end
+end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -9,6 +9,7 @@ app/models/concerns/test/filtrable.rb:8:4: [error] Type `(singleton(::Test) & si
 app/models/example10.rb:27:26: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example14.rb:15:17: [error] Type `(::Example14::User | nil)` does not have method `name`
 app/models/example15.rb:25:25: [error] Type `(::Example15::User | nil)` does not have method `name`
+app/models/example19.rb:68:25: [error] Type `(::Example19::User | nil)` does not have method `name`
 app/models/example3.rb:122:11: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:63:13: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:64:26: [error] Type `(::Example3::User | nil)` does not have method `name`

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -9,7 +9,6 @@ app/models/concerns/test/filtrable.rb:8:4: [error] Type `(singleton(::Test) & si
 app/models/example10.rb:27:26: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example14.rb:15:17: [error] Type `(::Example14::User | nil)` does not have method `name`
 app/models/example15.rb:25:25: [error] Type `(::Example15::User | nil)` does not have method `name`
-app/models/example18.rb:56:25: [error] Type `(::Example18::User | nil)` does not have method `name`
 app/models/example3.rb:122:11: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:63:13: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:64:26: [error] Type `(::Example3::User | nil)` does not have method `name`

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -426,6 +426,27 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     expect(rbs.chomp).to eq(expected_rbs(name).chomp)
   end
 
+  # Example18 with the one change that keeps the real Rails chain open: the halt
+  # lands on an object passed as an ARGUMENT (felixefelip/steep#126). What it
+  # pins here is that the block half still works across that same boundary —
+  # `fetch_token` keeps its required, `String`-shaped block — so a reader can
+  # see that what fails is the halt, not the block.
+  it "example19" do
+    name = "models/example19"
+    rbs = RbsInfer::Analyzer.new(
+      target_file: "app/models/example19.rb",
+      source_files: source_files
+    ).generate_rbs
+
+    if ENV["UPDATE_EXPECTATIONS"]
+      path = expectations_dir.join("#{name}.rbs")
+      path.dirname.mkpath
+      path.write(rbs)
+    end
+
+    expect(rbs.chomp).to eq(expected_rbs(name).chomp)
+  end
+
   # Blocks, whose signature is decided by the body rather than the parameter
   # list: required or not (#147), the parameter types read off the sites that
   # use it (#148), and — for a body that only forwards — the callee's own


### PR DESCRIPTION
A fixture for felixefelip/steep#126 — the one piece between the block work and `Current.identity` in the app.

## The change from Example18

Exactly one thing. There, `deny` writes `@halted` on its own `self`, and the chain closes end to end. Rails does not do that:

```ruby
def request_http_token_authentication(realm = "Application", message = nil)
  Token.authentication_request(self, realm, message)          # passes self
end

def authentication_request(controller, realm, message = nil)  # self = the module
  controller.__send__ :render, plain: message, status: :unauthorized
end
```

`Responder.deny(host, message)` is that function in miniature. The halt is real and unconditional — it just lands on `host`, a parameter, while the method's own `self` is the module. `always_halting_ivar` reads the ivars a method refines on **its** self, so nothing proves the tail of the `||` halts, and the chain stops.

## What the fixture is for

The contrast, and the generated facts show it without needing a word of explanation:

```yaml
fetch_token:  when_true: { block_truthy: true }     # crosses the object boundary
with_token:   (nothing)                             # does not
```

A return value travels back through a call whoever the receiver was. A side effect does not, and which object received it is the whole question. That is why stage 2a sails through frame ④ of the real chain and stage 2b stops at frame ⑥, though the two have identical structure.

One new baseline entry: `show` dereferencing a nilable `Registry.user`, exactly as Example18 read before steep#125 closed it.

## Deliberately left out

Rails reaches `render` through `__send__ :render`, which Steep types as `::BasicObject#__send__` — a second, independent obstacle, measured in steep#126. Mixing it in would leave the fixture proving two things at once. The Basic and Digest variants of the same Rails file write the 401 with plain `controller.status = 401`, no `__send__` anywhere, and would be **equally stuck** — which is what makes the parameter, not the `__send__`, the subject.

Recorded in the fixture's own header so nobody "fixes" it later by adding one.

## The first commit is not this work

`f039159` restores a line the squash of #152 dropped. That PR removed Example18's baseline entry — `show` type-checks since steep#125 — but the merge carried only the sidecar half:

```
git show <merge> --stat                              → .steep_postconditions.yml | 18 +++++
git show <merge> -- spec/expectations/steep_baseline.txt → (empty)
```

`main` was left claiming an error the checker no longer reports, which fails the baseline spec in the "errors gone" direction. It is a separate commit because folding it into a fixture PR would hide it — and it may be worth checking whether other squashed PRs lost pieces the same way.

## Checks

**863 examples, 0 failures.**
