### PR TITLE
fix: type a setter from the value it assigns

### DIFF
--- a/lib/rbs_infer/inference/type_merger.rb
+++ b/lib/rbs_infer/inference/type_merger.rb
@@ -144,6 +144,7 @@ module RbsInfer::Inference
         #    type already inferred for the ivar (felixefelip/rbs_infer#19)
         if last_stmt.is_a?(Prism::InstanceVariableReadNode) || last_stmt.is_a?(Prism::InstanceVariableWriteNode)
           resolved = ivar_types[last_stmt.name.to_s.sub(/\A@/, "")]
+          resolved = assigned_param_type(last_stmt, method_param_types[method_name] || {}) if resolved.nil? || resolved == "untyped"
           if resolved && resolved != "untyped"
             member.signature = member.signature.sub(/-> untyped\z/, "-> #{RbsInfer::Signatures::RbsParserUtil.parenthesize_union(resolved)}")
             own_return_types[method_name] = resolved
@@ -252,6 +253,33 @@ module RbsInfer::Inference
     end
 
     private
+
+    # `@x = value` evaluates to VALUE — that is what Ruby returns, whatever the
+    # ivar was declared as — so the parameter answers when the ivar map cannot.
+    #
+    # It cannot for a SINGLETON setter, which is where every `-> untyped` setter
+    # in the dummy came from: `def self.user=(value); @user = value; end` writes
+    # a class-instance variable (`self.@user`), a different slot from the
+    # instance ivars this pass is given. Steep types the method
+    # `Example18::User` all along (felixefelip/rbs_infer#154).
+    #
+    # Instance setters reach it too, whenever the ivar map has no answer yet.
+    # The parameter is the more precise source there: an `@user: Widget?` whose
+    # setter takes a `Widget` returns a `Widget`, never nil. The ivar keeps
+    # precedence only because it is the established behaviour for the READ half
+    # of this rule, where it is the right answer.
+    #
+    # Narrow on purpose: only a bare parameter read. `@x = compute(value)` is
+    # someone else's question, and guessing it here would be worse than leaving
+    # the honest `untyped`.
+    def assigned_param_type(node, local_types)
+      return nil unless node.is_a?(Prism::InstanceVariableWriteNode)
+
+      value = node.value
+      return nil unless value.is_a?(Prism::LocalVariableReadNode)
+
+      local_types[value.name.to_s]
+    end
 
     # Bundle the class's own return-type knowledge for call resolution: both
     # kind-split maps plus the enclosing method's kind. Lets a receiver typed

--- a/spec/dummy/sig/rbs_infer/app/models/example10.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example10.rbs
@@ -7,7 +7,7 @@ class Example10
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> untyped
+    def self.name=: (String value) -> String
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example15.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example15.rbs
@@ -23,6 +23,6 @@ class Example15
     self.@user: User?
 
     def self.user: () -> Example15::User?
-    def self.user=: (User value) -> untyped
+    def self.user=: (User value) -> User
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example16.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example16.rbs
@@ -28,6 +28,6 @@ class Example16
     self.@user: User?
 
     def self.user: () -> Example16::User?
-    def self.user=: (User value) -> untyped
+    def self.user=: (User value) -> User
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example18.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example18.rbs
@@ -29,6 +29,6 @@ class Example18
     self.@user: Example18::User?
 
     def self.user: () -> Example18::User?
-    def self.user=: (Example18::User value) -> untyped
+    def self.user=: (Example18::User value) -> Example18::User
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example19.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example19.rbs
@@ -34,6 +34,6 @@ class Example19
     self.@user: Example19::User?
 
     def self.user: () -> Example19::User?
-    def self.user=: (Example19::User value) -> untyped
+    def self.user=: (Example19::User value) -> Example19::User
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example4.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example4.rbs
@@ -8,7 +8,7 @@ class Example4
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: ((String | nil) value) -> untyped
+    def self.name=: ((String | nil) value) -> (String | nil)
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example5.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example5.rbs
@@ -7,7 +7,7 @@ class Example5
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> untyped
+    def self.name=: (String value) -> String
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example6.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example6.rbs
@@ -7,7 +7,7 @@ class Example6
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> untyped
+    def self.name=: (String value) -> String
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example7.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example7.rbs
@@ -8,7 +8,7 @@ class Example7
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> untyped
+    def self.name=: (String value) -> String
   end
 end
 
@@ -17,7 +17,7 @@ class Example7
     self.@value: Integer?
 
     def self.value: () -> Integer?
-    def self.value=: (Integer value) -> untyped
+    def self.value=: (Integer value) -> Integer
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example9.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example9.rbs
@@ -8,7 +8,7 @@ class Example9
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> untyped
+    def self.name=: (String value) -> String
   end
 end
 
@@ -17,7 +17,7 @@ class Example9
     self.@value: Integer?
 
     def self.value: () -> Integer?
-    def self.value=: (Integer value) -> untyped
+    def self.value=: (Integer value) -> Integer
   end
 end
 

--- a/spec/expectations/models/example10.rbs
+++ b/spec/expectations/models/example10.rbs
@@ -7,7 +7,7 @@ class Example10
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> untyped
+    def self.name=: (String value) -> String
   end
 end
 

--- a/spec/expectations/models/example18.rbs
+++ b/spec/expectations/models/example18.rbs
@@ -29,6 +29,6 @@ class Example18
     self.@user: Example18::User?
 
     def self.user: () -> Example18::User?
-    def self.user=: (Example18::User value) -> untyped
+    def self.user=: (Example18::User value) -> Example18::User
   end
 end

--- a/spec/expectations/models/example19.rbs
+++ b/spec/expectations/models/example19.rbs
@@ -34,6 +34,6 @@ class Example19
     self.@user: Example19::User?
 
     def self.user: () -> Example19::User?
-    def self.user=: (Example19::User value) -> untyped
+    def self.user=: (Example19::User value) -> Example19::User
   end
 end

--- a/spec/expectations/models/example4.rbs
+++ b/spec/expectations/models/example4.rbs
@@ -8,7 +8,7 @@ class Example4
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: ((String | nil) value) -> untyped
+    def self.name=: ((String | nil) value) -> (String | nil)
   end
 end
 

--- a/spec/expectations/models/example5.rbs
+++ b/spec/expectations/models/example5.rbs
@@ -7,7 +7,7 @@ class Example5
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> untyped
+    def self.name=: (String value) -> String
   end
 end
 

--- a/spec/expectations/models/example6.rbs
+++ b/spec/expectations/models/example6.rbs
@@ -7,7 +7,7 @@ class Example6
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> untyped
+    def self.name=: (String value) -> String
   end
 end
 

--- a/spec/expectations/models/example7.rbs
+++ b/spec/expectations/models/example7.rbs
@@ -8,7 +8,7 @@ class Example7
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> untyped
+    def self.name=: (String value) -> String
   end
 end
 
@@ -17,7 +17,7 @@ class Example7
     self.@value: Integer?
 
     def self.value: () -> Integer?
-    def self.value=: (Integer value) -> untyped
+    def self.value=: (Integer value) -> Integer
   end
 end
 

--- a/spec/expectations/models/example9.rbs
+++ b/spec/expectations/models/example9.rbs
@@ -8,7 +8,7 @@ class Example9
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> untyped
+    def self.name=: (String value) -> String
   end
 end
 
@@ -17,7 +17,7 @@ class Example9
     self.@value: Integer?
 
     def self.value: () -> Integer?
-    def self.value=: (Integer value) -> untyped
+    def self.value=: (Integer value) -> Integer
   end
 end
 

--- a/spec/integration/steep_scenarios_spec.rb
+++ b/spec/integration/steep_scenarios_spec.rb
@@ -371,7 +371,7 @@ RSpec.describe "rbs_infer -> Steep precondition scenarios" do
       class Widget
         attr_reader user: Widget?
 
-        def user=: (Widget value) -> untyped
+        def user=: (Widget value) -> Widget
         def use: () -> Widget
 
         class AfterUse

--- a/spec/lib/rbs_infer/inference/type_merger_spec.rb
+++ b/spec/lib/rbs_infer/inference/type_merger_spec.rb
@@ -73,6 +73,60 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
   end
 
   describe "#resolve_method_return_types_from_attrs" do
+    # `@x = value` evaluates to VALUE. The ivar map cannot answer for a
+    # SINGLETON setter — `self.@user` is a class-instance variable, a different
+    # slot from the instance ivars this pass receives — which is why every
+    # singleton setter in the dummy read `-> untyped` (felixefelip/rbs_infer#154).
+    it "types a singleton setter from the parameter it assigns" do
+      source = <<~RUBY
+        class Registry
+          def self.user=(value)
+            @user = value
+          end
+        end
+      RUBY
+      result = Prism.parse(source)
+      parsed_target = RbsInfer::ParsedFile.new(result: result, source: source, comments: result.comments, lines: source.lines)
+      collector = RbsInfer::Inference::ClassMemberCollector.new(comments: result.comments, lines: source.lines)
+      result.value.accept(collector)
+      member = collector.members.find { |candidate| candidate.name == "user=" }
+
+      merger.resolve_method_return_types_from_attrs(
+        collector.members,
+        {},
+        parsed_target: parsed_target,
+        method_param_types: { "user=" => { "value" => "User" } }
+      )
+
+      expect(member.signature).to end_with("-> User")
+    end
+
+    # Narrow on purpose: anything but a bare parameter read is someone else's
+    # question, and `untyped` is the honest answer rather than a guess.
+    it "leaves a setter whose assignment is computed alone" do
+      source = <<~RUBY
+        class Registry
+          def self.user=(value)
+            @user = normalize(value)
+          end
+        end
+      RUBY
+      result = Prism.parse(source)
+      parsed_target = RbsInfer::ParsedFile.new(result: result, source: source, comments: result.comments, lines: source.lines)
+      collector = RbsInfer::Inference::ClassMemberCollector.new(comments: result.comments, lines: source.lines)
+      result.value.accept(collector)
+      member = collector.members.find { |candidate| candidate.name == "user=" }
+
+      merger.resolve_method_return_types_from_attrs(
+        collector.members,
+        {},
+        parsed_target: parsed_target,
+        method_param_types: { "user=" => { "value" => "User" } }
+      )
+
+      expect(member.signature).to end_with("-> untyped")
+    end
+
     it "refines record fields in the RHS of an indexed assignment" do
       source = <<~RUBY
         class CookieWriter


### PR DESCRIPTION
`def self.user=(value); @user = value; end` was generated `-> untyped`, though Steep types it exactly — measured on the real file:

```
singleton: {"user" => "Example18::User?", "user=" => "Example18::User"}
```

## Why it fell through

Three passes each declined it, and each was right on its own:

| pass | why it declined |
|---|---|
| `ClassMemberCollector#infer_return_type` | sees an `InstanceVariableWriteNode`, which is no literal |
| `improve_method_return_types` (both halves) | skips **every** setter by name, deliberately: its maps are name-keyed, so a homonymous setter elsewhere would leak (#22, #33) |
| `TypeMerger` — where setters belong, being owner-aware | its ivar rule reads the INSTANCE ivar map, which cannot answer for `self.@user`, a class-instance variable in a different slot |

So the setter fell into the gap between them. The split is visible across the dummy: `registry_instance.user = value` (a `CallNode`) typed fine all along, `@user = value` did not.

## The fix

Read what Ruby actually returns: the **assigned value**. Narrow on purpose — only a bare parameter read, since `@x = compute(value)` is someone else's question and guessing it would be worse than the honest `untyped`. Pinned in both directions by specs.

## Result

Twelve signatures across the dummy, all singleton setters:

```diff
- def self.user=: (Example18::User value) -> untyped
+ def self.user=: (Example18::User value) -> Example18::User
```

And one **instance** setter in a Steep scenario, which is the more interesting case:

```diff
- def user=: (Widget value) -> untyped
+ def user=: (Widget value) -> Widget
```

The ivar there is `Widget?`, but a setter taking a `Widget` returns a `Widget`, never nil — the parameter is the more precise source. The ivar keeps precedence anyway, because in the READ half of the same rule (`def user; @user; end`) it is the right answer; changing that order is a separate decision, not this one.

No other signature moved, and the steep baseline did not drift.

## On the impact, for calibration

Ruby's assignment syntax evaluates to the RHS, not to the method's return — `type_merger.rb` already records this ("only `send`/`super` observe it"). So the old `untyped` was observable through an explicit `send(:user=, v)` and by whoever reads the RBS, and was never a type error waiting to happen. This is precision in generated output, not a bug fix.

## Checks

**865 examples, 0 failures.**
