### PR TITLE
feat: type a block's return from the sites that pass one

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -232,7 +232,10 @@ module RbsInfer
     # overwrite) with the intra-class types: a method called with `String` in
     # one file and `:Symbol` in another should infer `(String | Symbol)`, not
     # the first type seen (felixefelip/rbs_infer#64).
-    cross_class_param_types = infer_method_param_types_from_callers(extract_attr_writer_methods(target_members))
+    cross_class_param_types = infer_method_param_types_from_callers(
+      extract_attr_writer_methods(target_members),
+      block_methods: target_members.select { |m| untyped_block_return?(m) }.map(&:name).to_set
+    )
     cross_class_param_types.each do |method_name, param_types|
       method_param_types[method_name] ||= {}
       param_types.each do |param_name, type|
@@ -309,6 +312,11 @@ module RbsInfer
     # obrigatoriedade e o formato dele — pergunta que só o Steep responde,
     # porque depende de qual sobrecarga se aplica (felixefelip/rbs_infer#149).
     resolve_forwarded_block_requirements(target_members)
+
+    # O que os blocos passados nos call-sites devolvem. É a metade do tipo do
+    # bloco que o corpo do método não responde — ele recebe esse valor, não o
+    # produz (felixefelip/rbs_infer#155).
+    resolve_block_return_types(target_members)
 
     # Identificar parâmetros opcionais do initialize
     optional_params = extract_optional_init_params
@@ -631,6 +639,58 @@ module RbsInfer
     end
   end
 
+  # A block's RETURN is the one half of its type the method cannot answer: it
+  # receives that value rather than producing it, and a method that passes it
+  # through (`block.call(token)`, `yield`) constrains it not at all. So the
+  # evidence is the blocks the call sites pass — the same contract every
+  # inferred parameter type already has, and unioned the same way.
+  #
+  # Sites that Steep cannot type are skipped rather than counted as `untyped`:
+  # unioning one in would erase the answer the others gave.
+  def resolve_block_return_types(target_members)
+    return if @parsed_target.nil?
+
+    members = target_members.select { |m| untyped_block_return?(m) }
+    return if members.empty?
+
+    returns = collect_block_returns(members.map(&:name).to_set)
+    return if returns.empty?
+
+    members.each do |member|
+      observed = returns[member.name]
+      next if observed.nil? || observed.empty?
+
+      member.signature = RbsInfer::Signatures::RbsParserUtil.replace_block_return_type(
+        member.signature, RbsInfer::Inference::TypeMerger.union_types(observed)
+      )
+    end
+  end
+
+  # Method members only, and `to_s` because a member's signature is filled in
+  # by a later pass for some kinds — this runs over every member the collector
+  # produced, not only the ones with a method type.
+  def untyped_block_return?(member)
+    [:method, :class_method].include?(member.kind) && member.signature.to_s.include?("-> untyped }")
+  end
+
+  # Call sites in the target's own file plus every caller file. A receiverless
+  # call here is a self-send, so the target's file needs no receiver check; the
+  # caller files resolve theirs through `NewCallCollector`, which already knows
+  # how (#131).
+  def collect_block_returns(method_names)
+    collector = RbsInfer::Inference::BlockReturnCollector.new(
+      methods: method_names,
+      expression_types: steep_bridge.all_expression_types(@parsed_target.source)
+    )
+    @parsed_target.tree.accept(collector)
+
+    returns = collector.returns
+    @caller_block_returns&.each do |name, types|
+      (returns[name] ||= []).concat(types)
+    end
+    returns
+  end
+
   # ─── Extrair nomes dos keyword params opcionais do initialize ─────
 
   def extract_optional_init_params
@@ -838,7 +898,7 @@ module RbsInfer
 
   # Inferir tipos de parâmetros de métodos via chamadas cross-class
   # Ex: PostPublisher chama notifier.notify(post.user, "msg") → user: User, message: String
-  def infer_method_param_types_from_callers(extra_methods = {})
+  def infer_method_param_types_from_callers(extra_methods = {}, block_methods: Set.new)
     # `extra_methods` are SYNTHETIC writers standing in for `attr_accessor`-
     # generated methods, and name their param after the attr (`user`). A real
     # `def user=(value)` overriding that attr names it `value`, and the def is
@@ -857,7 +917,8 @@ module RbsInfer
       method_type_resolver: method_type_resolver,
       init_positional_params: positional_params,
       target_methods: target_methods,
-      steep_bridge: steep_bridge
+      steep_bridge: steep_bridge,
+      block_methods: block_methods
     )
     referencing = @source_index.files_referencing(@target_class)
 
@@ -879,6 +940,10 @@ module RbsInfer
     end
 
     @extra_caller_sources&.call(analyzer, @target_class, @source_files)
+
+    # Kept for `resolve_block_return_types`, which runs later in the pipeline
+    # (felixefelip/rbs_infer#155).
+    @caller_block_returns = analyzer.method_block_returns
 
     result = {}
     analyzer.method_call_usages.each do |method_name, usages|
@@ -1124,6 +1189,7 @@ require_relative "inference/class_member_collector/extract_params_signature"
 require_relative "inference/class_member_collector/block_signature"
 require_relative "ast/def_collector"
 require_relative "inference/new_call_collector"
+require_relative "inference/block_return_collector"
 require_relative "signatures/method_type_resolver"
 require_relative "inference/caller_file_analyzer"
 require_relative "signatures/rbs_builder"

--- a/lib/rbs_infer/inference/block_return_collector.rb
+++ b/lib/rbs_infer/inference/block_return_collector.rb
@@ -1,0 +1,77 @@
+module RbsInfer::Inference
+  # What the blocks passed at CALL SITES return, per method
+  # (felixefelip/rbs_infer#155).
+  #
+  # A block type has two halves with opposite origins. The parameters are what
+  # the method HANDS to the block, so its own body answers them (#148). The
+  # return is what the method RECEIVES BACK, and a method that merely passes it
+  # through — `block.call(token)`, `yield` — constrains it not at all. Its own
+  # body has nothing to say.
+  #
+  # So the evidence is the callers: whatever blocks are actually passed. That is
+  # the same contract every parameter type in this project already has — a
+  # description of how the code IS used, not of what the method would tolerate —
+  # and unioning across sites is the same answer given there.
+  #
+  # It is an approximation of a genuinely generic method (`[T] () { () -> T } ->
+  # T?`), and it degrades the way a union should: adding a caller widens the
+  # type rather than deleting it. Where a helper turns out to be truly
+  # polymorphic, a two-member union in this position is the signal.
+  class BlockReturnCollector < Prism::Visitor
+    # `methods` — names whose signature carries a block. `expression_types` —
+    # Steep's types for this source, keyed `"line:column"`. `receiver_check` — a
+    # callable answering whether a call's receiver is the target; omit it for
+    # the target's own file, where a receiverless call is a self-send.
+    def initialize(methods:, expression_types:, receiver_check: nil)
+      @methods = methods
+      @expression_types = expression_types
+      @receiver_check = receiver_check
+      @returns = Hash.new { |hash, key| hash[key] = [] }
+      super()
+    end
+
+    # `{ "with_token" => ["Example18::User?"] }` — one entry per call site.
+    attr_reader :returns
+
+    def visit_call_node(node)
+      collect(node) if node.block.is_a?(Prism::BlockNode) && @methods.include?(node.name.to_s)
+      super
+    end
+
+    private
+
+    def collect(node)
+      return unless receiver_matches?(node)
+
+      type = block_return_type(node.block)
+      @returns[node.name.to_s] << type if type
+    end
+
+    def receiver_matches?(node)
+      return node.receiver.nil? unless @receiver_check
+
+      @receiver_check.call(node)
+    end
+
+    def block_return_type(block)
+      self.class.block_return_type(block, @expression_types)
+    end
+
+    # The value of the block's last statement — read from the checker rather
+    # than guessed, so a block ending in `if user = lookup(token) …` answers
+    # with the nilable the `if` really produces.
+    #
+    # Exposed on the class because the cross-file path asks the same question
+    # from `NewCallCollector`, which resolves receivers and so does the walking
+    # itself (#131).
+    def self.block_return_type(block, expression_types)
+      body = block.body or return nil
+      last = body.is_a?(Prism::StatementsNode) ? body.body.last : body
+      return nil unless last
+
+      # Character column: Steep's map comes from Parser, which counts
+      # characters, while Prism also offers bytes (felixefelip/rbs_infer#142).
+      expression_types["#{last.location.start_line}:#{last.location.start_character_column}"]
+    end
+  end
+end

--- a/lib/rbs_infer/inference/caller_file_analyzer.rb
+++ b/lib/rbs_infer/inference/caller_file_analyzer.rb
@@ -5,21 +5,25 @@ module RbsInfer::Inference
   class CallerFileAnalyzer
     include RbsInfer::Signatures::RbsAnnotationParser
 
-    attr_reader :method_call_usages
+    attr_reader :method_call_usages, :method_block_returns
 
     # `target_file`: the file being analyzed. REQUIRED, not defaulted: it gates bare-call
     # matching for a class reopened across files, and the target's own file is already
     # covered by `IntraClassCallAnalyzer`. Omitting it would double-count every same-file
     # self-call — the two paths resolve the receiver differently, so the parameter widens
     # into a union instead of failing loudly (required-threaded-deps).
-    def initialize(target_class:, method_type_resolver:, target_file:, init_positional_params: [], target_methods: {}, steep_bridge: nil)
+    def initialize(target_class:, method_type_resolver:, target_file:, init_positional_params: [], target_methods: {}, steep_bridge: nil, block_methods: Set.new)
       @target_class = target_class
       @target_file = target_file
       @method_type_resolver = method_type_resolver
       @init_positional_params = init_positional_params
       @target_methods = target_methods
       @steep_bridge = steep_bridge
+      # felixefelip/rbs_infer#155: methods whose signature carries a block, and
+      # what the blocks passed to them at these call sites return.
+      @block_methods = block_methods
       @method_call_usages = Hash.new { |h, k| h[k] = [] }
+      @method_block_returns = Hash.new { |h, k| h[k] = [] }
     end
 
     def analyze(file, force_bare: false)
@@ -143,12 +147,18 @@ module RbsInfer::Inference
         established_ivars_by_method: established_ivars_by_method,
         argument_partitions_by_method: argument_partitions_by_method,
         constant_arg_resolver: constant_arg_resolver,
-        defined_class_names: NewCallCollector.collect_defined_class_names(result.value)
+        defined_class_names: NewCallCollector.collect_defined_class_names(result.value),
+        block_methods: @block_methods,
+        expression_types: @block_methods.empty? || @steep_bridge.nil? ? {} : @steep_bridge.all_expression_types(source)
       )
       result.value.accept(visitor)
 
       visitor.method_call_usages.each do |method_name, usages|
         @method_call_usages[method_name].concat(usages)
+      end
+
+      visitor.method_block_returns.each do |method_name, types|
+        @method_block_returns[method_name].concat(types)
       end
 
       visitor.usages

--- a/lib/rbs_infer/inference/caller_file_analyzer.rb
+++ b/lib/rbs_infer/inference/caller_file_analyzer.rb
@@ -149,7 +149,7 @@ module RbsInfer::Inference
         constant_arg_resolver: constant_arg_resolver,
         defined_class_names: NewCallCollector.collect_defined_class_names(result.value),
         block_methods: @block_methods,
-        expression_types: @block_methods.empty? || @steep_bridge.nil? ? {} : @steep_bridge.all_expression_types(source)
+        expression_types: @steep_bridge ? @steep_bridge.all_expression_types(source) : {}
       )
       result.value.accept(visitor)
 

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -739,7 +739,7 @@ module RbsInfer::Inference
           next
         end
 
-        args[param_names[index]] = resolve_value_type(arg)
+        args[param_names[index]] = argument_type(arg)
         index += 1
       end
 
@@ -752,11 +752,36 @@ module RbsInfer::Inference
           next unless elem.is_a?(Prism::AssocNode)
           key = extract_symbol_key(elem.key)
           next unless key
-          args[key] = resolve_value_type(elem.value)
+          args[key] = argument_type(elem.value)
         end
       end
 
       args
+    end
+
+    # The checker's answer for an argument the structural resolver could not
+    # type (felixefelip/rbs_infer#157).
+    #
+    # `self.author_name = value&.full_name` is a call site the collector matches
+    # and then throws away: `value` is the enclosing method's parameter and the
+    # send is safe-navigated, which the structural path does not follow. The
+    # argument came out `untyped`, the Analyzer drops `untyped` usages, and the
+    # attribute stayed untyped though Steep types that expression `String?`.
+    #
+    # Only a fallback: the structural answer wins when it has one, since it
+    # carries the naming conventions (a class name for `Klass.new`, a record for
+    # a hash literal) that a checker type does not.
+    def argument_type(arg)
+      resolved = resolve_value_type(arg)
+      return resolved unless resolved.nil? || resolved == "untyped"
+
+      expression_type(arg) || resolved
+    end
+
+    def expression_type(node)
+      # Character column, like every other lookup into this map — Parser counts
+      # characters where Prism also offers bytes (felixefelip/rbs_infer#142).
+      @expression_types["#{node.location.start_line}:#{node.location.start_character_column}"]
     end
 
     # Whether a keyword hash at the call site is really a positional Hash: no key names a

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -1,6 +1,6 @@
 module RbsInfer::Inference
   class NewCallCollector < Prism::Visitor
-    attr_reader :usages, :method_call_usages
+    attr_reader :usages, :method_call_usages, :method_block_returns
 
     # Collect the fully-qualified names of every class/module DEFINED in a
     # parsed file, so `match_class?` can tell a bare `Foo` written inside
@@ -28,7 +28,7 @@ module RbsInfer::Inference
       names
     end
 
-    def initialize(target_class:, method_return_types:, local_var_types:, constant_arg_resolver:, defined_class_names:, local_var_read_types: {}, local_var_types_by_method: {}, method_type_resolver: nil, caller_class_name: nil, init_positional_params: [], target_methods: {}, match_bare_calls: false, self_types_by_method: {}, established_ivars_by_method: {}, argument_partitions_by_method: {})
+    def initialize(target_class:, method_return_types:, local_var_types:, constant_arg_resolver:, defined_class_names:, local_var_read_types: {}, local_var_types_by_method: {}, method_type_resolver: nil, caller_class_name: nil, init_positional_params: [], target_methods: {}, match_bare_calls: false, self_types_by_method: {}, established_ivars_by_method: {}, argument_partitions_by_method: {}, block_methods: Set.new, expression_types: {})
       @target_class = target_class
       # FQNs of classes/modules defined in the file being scanned; disambiguates
       # a relative receiver from a same-simple-name class elsewhere (see
@@ -72,8 +72,14 @@ module RbsInfer::Inference
       # `{ "render" => [{ param:, pattern:, ivars: }] }` — argument-sensitive partitions
       # (felixefelip/steep#89, #91, #95). Applied per `when` branch by `visit_case_node`.
       @argument_partitions_by_method = argument_partitions_by_method
+      # felixefelip/rbs_infer#155: names whose signature carries a block, and
+      # Steep's types for this file, so a call site can be asked what the block
+      # it passes returns. Empty when the caller is analyzed without a bridge.
+      @block_methods = block_methods
+      @expression_types = expression_types
       @usages = []
       @method_call_usages = Hash.new { |h, k| h[k] = [] }
+      @method_block_returns = Hash.new { |h, k| h[k] = [] }
       # Lexically-enclosing class names (fully qualified) and whether the
       # current method is a singleton (`def self.x`) — used to resolve a
       # `self` argument/receiver to its type.
@@ -172,6 +178,16 @@ module RbsInfer::Inference
         end
       end
 
+      # felixefelip/rbs_infer#155: what the block passed HERE returns. Not gated
+      # on `node.arguments` like the branches above — `with_token do |t| … end`
+      # passes no arguments at all, and the block is the whole point.
+      if !@block_methods.empty? && node.block.is_a?(Prism::BlockNode) && @block_methods.include?(node.name.to_s)
+        if node.receiver.nil? ? @match_bare_calls : block_receiver_matches?(node)
+          type = BlockReturnCollector.block_return_type(node.block, @expression_types)
+          @method_block_returns[node.name.to_s] << type if type
+        end
+      end
+
       # Bare method calls matching target_methods (for included modules, e.g. helpers in ERB views)
       if !@target_methods.empty? && node.receiver.nil? && node.arguments && @match_bare_calls
         method_name = node.name.to_s
@@ -185,6 +201,11 @@ module RbsInfer::Inference
     end
 
     private
+
+    def block_receiver_matches?(node)
+      receiver_type = resolve_receiver_type(node.receiver)
+      receiver_type && match_class?(receiver_type)
+    end
 
     # Lookup the type of an `:ivar` reference. Tries the `@`-prefixed
     # key first (the convention used by `ErbCallerResolver` to keep

--- a/lib/rbs_infer/signatures/rbs_parser_util.rb
+++ b/lib/rbs_infer/signatures/rbs_parser_util.rb
@@ -294,6 +294,26 @@ module RbsInfer::Signatures
       !type.nil? && type != "untyped"
     end
 
+    # Fills in what the block RETURNS, which is the one part of a block type
+    # that the method's own body cannot answer: it is what the method receives
+    # FROM the block, not what it hands to it. The evidence is the blocks the
+    # call sites actually pass (felixefelip/rbs_infer#155).
+    #
+    # Only an `untyped` return is rewritten — a block type refined by anything
+    # else was settled by better evidence, and an explicit annotation must not
+    # be overridden.
+    #
+    # A union is PARENTHESIZED here, unlike in the parameter list: `{ () -> A | B }`
+    # is a syntax error, while `{ (A | B) -> untyped }` is fine. Measured, not
+    # assumed — the two positions really do differ.
+    BLOCK_RETURN = /(?<open>\??\{ \([^)]*\) -> )untyped(?<close> \})/
+
+    def replace_block_return_type(method_sig, type)
+      return method_sig unless method_sig && usable_type?(type)
+
+      method_sig.sub(BLOCK_RETURN) { "#{Regexp.last_match[:open]}#{parenthesize_compound(type)}#{Regexp.last_match[:close]}" }
+    end
+
     # Turns the "I only forward it" block into the callee's own — required, and
     # shaped like whatever the callee declares (#149).
     #

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -101,11 +101,25 @@ postconditions:
     may_write:
     - "@account"
 - class: Current
+  method: author_name
+  effects:
+    returns_ivar: "@author_name"
+- class: Current
+  method: author_name=
+  unconditional:
+    establishes_consts:
+      author_name: "::String"
+  effects:
+    may_write:
+    - "@author_name"
+- class: Current
   method: set
   effects:
     may_write:
     - "@account"
+    - "@author_name"
     - "@user"
+    - "@viewer_name"
 - class: Current
   method: user
   effects:
@@ -119,6 +133,18 @@ postconditions:
     may_write:
     - "@user"
 - class: Current
+  method: viewer_name
+  effects:
+    returns_ivar: "@viewer_name"
+- class: Current
+  method: viewer_name=
+  unconditional:
+    establishes_consts:
+      viewer_name: "::String"
+  effects:
+    may_write:
+    - "@viewer_name"
+- class: Current
   method: with
   unconditional:
     ivars:
@@ -126,7 +152,9 @@ postconditions:
   effects:
     may_write:
     - "@account"
+    - "@author_name"
     - "@user"
+    - "@viewer_name"
 - class: DashboardController
   method: __rbs_infer__run_show
   unconditional:
@@ -259,6 +287,20 @@ postconditions:
   effects:
     may_write:
     - "@name"
+- class: Example10::Sink
+  method: last
+  effects:
+    returns_ivar: "@last"
+- class: Example10::Sink
+  method: last=
+  unconditional:
+    ivars:
+      "@last": "::Example10::Bar"
+    establishes_consts:
+      last: "::Example10::Bar"
+  effects:
+    may_write:
+    - "@last"
 - class: Example11::Partial
   method: initialize
   effects:

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -101,11 +101,6 @@ postconditions:
     may_write:
     - "@account"
 - class: Current
-  method: author_name=
-  unconditional:
-    establishes_consts:
-      author_name: "::String"
-- class: Current
   method: set
   effects:
     may_write:

--- a/spec/dummy/sig/rbs_infer/app/jobs/profile_formatter_job.rbs
+++ b/spec/dummy/sig/rbs_infer/app/jobs/profile_formatter_job.rbs
@@ -1,3 +1,3 @@
 class ProfileFormatterJob < ApplicationJob
-  def perform: () -> nil
+  def perform: () -> ProfileFormatter?
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example.rbs
@@ -1,7 +1,7 @@
 class Column
   attr_accessor board: Board?
   attr_accessor column_name: String
-  attr_accessor user_name: untyped
+  attr_accessor user_name: String?
 
   def initialize: (column_name: String) -> void
   def set_default_user_name: () -> String

--- a/spec/dummy/sig/rbs_infer/app/models/example10.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example10.rbs
@@ -1,5 +1,5 @@
 class Example10
-  def run: () -> untyped
+  def run: () -> Example10::Bar
 end
 
 class Example10
@@ -13,8 +13,10 @@ end
 
 class Example10
   class Sink
-    def self.last: () -> untyped
-    def self.last=: (untyped value) -> untyped
+    self.@last: Example10::Bar?
+
+    def self.last: () -> Example10::Bar?
+    def self.last=: (Example10::Bar value) -> Example10::Bar
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example13.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example13.rbs
@@ -30,7 +30,7 @@ class Example13
     def initialize: (name: String) -> bool
     def current_user: () -> Example13Viewer?
     def halt: () -> bool
-    def with_format: () ?{ (Symbol) -> untyped } -> untyped
+    def with_format: () ?{ (Symbol) -> bool } -> bool?
     def guard_supported: () -> Example13Viewer?
     def run_supported: () -> String?
     def act_supported: () -> String
@@ -49,7 +49,7 @@ class Example13
     def guard_block_halt: () -> untyped
     def run_block_halt: () -> String?
     def act_block_halt: () -> String
-    def guard_composite: () -> untyped
+    def guard_composite: () -> bool?
     def run_composite: () -> String?
     def act_composite: () -> String
   end

--- a/spec/dummy/sig/rbs_infer/app/models/example17.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example17.rbs
@@ -1,12 +1,12 @@
 class Example17
-  def with_token: () { (String) -> untyped } -> untyped
+  def with_token: () { (String) -> String } -> String
   def with_optional: () ?{ (String) -> untyped } -> untyped
   def with_yield: () { (String) -> untyped } -> untyped
   def with_pair: () { (String, Integer) -> untyped } -> untyped
   def with_either: (untyped flag) { (String | Integer) -> untyped } -> untyped
-  def forward_required: () { (String) -> untyped } -> untyped
+  def forward_required: () { (String) -> untyped } -> String
   def forward_optional: () ?{ (*untyped) -> untyped } -> untyped
-  def forward_guarded: () ?{ (*untyped) -> untyped } -> untyped
+  def forward_guarded: () ?{ (*untyped) -> untyped } -> String?
   def name: () -> String
-  def run: () -> untyped
+  def run: () -> String
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example18.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example18.rbs
@@ -8,7 +8,7 @@ class Example18
 
   def authenticate: () -> untyped
   def from_token: () -> untyped
-  def with_token: () { (String) -> untyped } -> untyped
+  def with_token: () { (String) -> Example18::User? } -> untyped
   def fetch_token: () { (String) -> untyped } -> untyped
   def deny: () -> bool
   def halt: () -> bool

--- a/spec/dummy/sig/rbs_infer/app/models/example19.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example19.rbs
@@ -14,7 +14,7 @@ class Example19
 
   def authenticate: () -> untyped
   def from_token: () -> untyped
-  def with_token: () { (String) -> untyped } -> untyped
+  def with_token: () { (String) -> Example19::User? } -> untyped
   def fetch_token: () { (String) -> untyped } -> untyped
   def refuse: () -> untyped
   def lookup: (String token) -> Example19::User?

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs
@@ -1,33 +1,37 @@
 class Current
   self.@user: ((User & User::Validated) | User)?
+  self.@author_name: String?
   self.@account: (Account & Account::Validated)?
+  self.@viewer_name: String?
   self.@__rbs_infer_instance: Current?
 
   @user: ((User & User::Validated) | User)?
+  @author_name: String?
   @account: (Account & Account::Validated)?
+  @viewer_name: String?
 
   module GeneratedAttributeMethods
     def user: () -> ((User & User::Validated) | User)?
     def user=: (((User & User::Validated)? | User?) value) -> ((User & User::Validated) | User)?
-    def author_name: () -> untyped
-    def author_name=: (untyped value) -> untyped
+    def author_name: () -> String?
+    def author_name=: (String? value) -> String?
     def account: () -> (Account & Account::Validated)?
     def account=: ((Account & Account::Validated)? value) -> (Account & Account::Validated)?
-    def viewer_name: () -> untyped
-    def viewer_name=: (untyped value) -> untyped
+    def viewer_name: () -> String?
+    def viewer_name=: (String? value) -> String?
   end
 
   include GeneratedAttributeMethods
 
   def self.user: () -> ((User & User::Validated) | User)?
   def self.user=: (((User & User::Validated)? | User?) value) -> ((User & User::Validated)? | User?)
-  def self.author_name: () -> untyped
-  def self.author_name=: (untyped value) -> untyped
+  def self.author_name: () -> String?
+  def self.author_name=: (String? value) -> String?
   def self.account: () -> (Account & Account::Validated)?
   def self.account=: ((Account & Account::Validated)? value) -> (Account & Account::Validated)?
-  def self.viewer_name: () -> untyped
-  def self.viewer_name=: (untyped value) -> untyped
+  def self.viewer_name: () -> String?
+  def self.viewer_name=: (String? value) -> String?
   def self.__rbs_infer_instance: () -> Current
-  def self.set: (?user: ((User & User::Validated) | User)?, ?author_name: untyped, ?account: (Account & Account::Validated)?, ?viewer_name: untyped) ?{ () -> untyped } -> untyped
-  def self.with: (?user: (User & User::Validated)?, ?author_name: untyped, ?account: (Account & Account::Validated)?, ?viewer_name: untyped) ?{ () -> ProfileFormatter } -> ProfileFormatter?
+  def self.set: (?user: ((User & User::Validated) | User)?, ?author_name: String?, ?account: (Account & Account::Validated)?, ?viewer_name: String?) ?{ () -> untyped } -> untyped
+  def self.with: (?user: (User & User::Validated)?, ?author_name: String?, ?account: (Account & Account::Validated)?, ?viewer_name: String?) ?{ () -> ProfileFormatter } -> ProfileFormatter?
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs
@@ -4,14 +4,13 @@ class Current
   self.@__rbs_infer_instance: Current?
 
   @user: ((User & User::Validated) | User)?
-  @author_name: String?
   @account: (Account & Account::Validated)?
 
   module GeneratedAttributeMethods
     def user: () -> ((User & User::Validated) | User)?
     def user=: (((User & User::Validated)? | User?) value) -> ((User & User::Validated) | User)?
-    def author_name: () -> String?
-    def author_name=: (String? value) -> String?
+    def author_name: () -> untyped
+    def author_name=: (untyped value) -> untyped
     def account: () -> (Account & Account::Validated)?
     def account=: ((Account & Account::Validated)? value) -> (Account & Account::Validated)?
     def viewer_name: () -> untyped
@@ -22,13 +21,13 @@ class Current
 
   def self.user: () -> ((User & User::Validated) | User)?
   def self.user=: (((User & User::Validated)? | User?) value) -> ((User & User::Validated)? | User?)
-  def self.author_name: () -> String?
-  def self.author_name=: (String? value) -> String?
+  def self.author_name: () -> untyped
+  def self.author_name=: (untyped value) -> untyped
   def self.account: () -> (Account & Account::Validated)?
   def self.account=: ((Account & Account::Validated)? value) -> (Account & Account::Validated)?
   def self.viewer_name: () -> untyped
   def self.viewer_name=: (untyped value) -> untyped
   def self.__rbs_infer_instance: () -> Current
-  def self.set: (?user: ((User & User::Validated) | User)?, ?author_name: String?, ?account: (Account & Account::Validated)?, ?viewer_name: untyped) ?{ () -> untyped } -> nil
-  def self.with: (?user: (User & User::Validated)?, ?author_name: String?, ?account: (Account & Account::Validated)?, ?viewer_name: untyped) ?{ () -> untyped } -> nil
+  def self.set: (?user: ((User & User::Validated) | User)?, ?author_name: untyped, ?account: (Account & Account::Validated)?, ?viewer_name: untyped) ?{ () -> untyped } -> untyped
+  def self.with: (?user: (User & User::Validated)?, ?author_name: untyped, ?account: (Account & Account::Validated)?, ?viewer_name: untyped) ?{ () -> ProfileFormatter } -> ProfileFormatter?
 end

--- a/spec/expectations/jobs/profile_formatter_job.rbs
+++ b/spec/expectations/jobs/profile_formatter_job.rbs
@@ -1,3 +1,3 @@
 class ProfileFormatterJob < ApplicationJob
-  def perform: () -> nil
+  def perform: () -> ProfileFormatter?
 end

--- a/spec/expectations/models/example.rbs
+++ b/spec/expectations/models/example.rbs
@@ -1,7 +1,7 @@
 class Column
   attr_accessor board: Board?
   attr_accessor column_name: String
-  attr_accessor user_name: untyped
+  attr_accessor user_name: String?
 
   def initialize: (column_name: String) -> void
   def set_default_user_name: () -> String

--- a/spec/expectations/models/example10.rbs
+++ b/spec/expectations/models/example10.rbs
@@ -1,5 +1,5 @@
 class Example10
-  def run: () -> untyped
+  def run: () -> Example10::Bar
 end
 
 class Example10
@@ -13,8 +13,10 @@ end
 
 class Example10
   class Sink
-    def self.last: () -> untyped
-    def self.last=: (untyped value) -> untyped
+    self.@last: Example10::Bar?
+
+    def self.last: () -> Example10::Bar?
+    def self.last=: (Example10::Bar value) -> Example10::Bar
   end
 end
 

--- a/spec/expectations/models/example13.rbs
+++ b/spec/expectations/models/example13.rbs
@@ -30,7 +30,7 @@ class Example13
     def initialize: (name: String) -> bool
     def current_user: () -> Example13Viewer?
     def halt: () -> bool
-    def with_format: () ?{ (Symbol) -> untyped } -> untyped
+    def with_format: () ?{ (Symbol) -> bool } -> bool?
     def guard_supported: () -> Example13Viewer?
     def run_supported: () -> String?
     def act_supported: () -> String
@@ -49,7 +49,7 @@ class Example13
     def guard_block_halt: () -> untyped
     def run_block_halt: () -> String?
     def act_block_halt: () -> String
-    def guard_composite: () -> untyped
+    def guard_composite: () -> bool?
     def run_composite: () -> String?
     def act_composite: () -> String
   end

--- a/spec/expectations/models/example17.rbs
+++ b/spec/expectations/models/example17.rbs
@@ -1,12 +1,12 @@
 class Example17
-  def with_token: () { (String) -> untyped } -> untyped
+  def with_token: () { (String) -> String } -> String
   def with_optional: () ?{ (String) -> untyped } -> untyped
   def with_yield: () { (String) -> untyped } -> untyped
   def with_pair: () { (String, Integer) -> untyped } -> untyped
   def with_either: (untyped flag) { (String | Integer) -> untyped } -> untyped
-  def forward_required: () { (String) -> untyped } -> untyped
+  def forward_required: () { (String) -> untyped } -> String
   def forward_optional: () ?{ (*untyped) -> untyped } -> untyped
-  def forward_guarded: () ?{ (*untyped) -> untyped } -> untyped
+  def forward_guarded: () ?{ (*untyped) -> untyped } -> String?
   def name: () -> String
-  def run: () -> untyped
+  def run: () -> String
 end

--- a/spec/expectations/models/example18.rbs
+++ b/spec/expectations/models/example18.rbs
@@ -8,7 +8,7 @@ class Example18
 
   def authenticate: () -> untyped
   def from_token: () -> untyped
-  def with_token: () { (String) -> untyped } -> untyped
+  def with_token: () { (String) -> Example18::User? } -> untyped
   def fetch_token: () { (String) -> untyped } -> untyped
   def deny: () -> bool
   def halt: () -> bool

--- a/spec/expectations/models/example19.rbs
+++ b/spec/expectations/models/example19.rbs
@@ -14,7 +14,7 @@ class Example19
 
   def authenticate: () -> untyped
   def from_token: () -> untyped
-  def with_token: () { (String) -> untyped } -> untyped
+  def with_token: () { (String) -> Example19::User? } -> untyped
   def fetch_token: () { (String) -> untyped } -> untyped
   def refuse: () -> untyped
   def lookup: (String token) -> Example19::User?

--- a/spec/expectations/steep_current_runtime/current.rbs
+++ b/spec/expectations/steep_current_runtime/current.rbs
@@ -1,0 +1,37 @@
+class Current
+  self.@user: ((User & User::Validated) | User)?
+  self.@author_name: String?
+  self.@account: (Account & Account::Validated)?
+  self.@viewer_name: String?
+  self.@__rbs_infer_instance: Current?
+
+  @user: ((User & User::Validated) | User)?
+  @author_name: String?
+  @account: (Account & Account::Validated)?
+  @viewer_name: String?
+
+  module GeneratedAttributeMethods
+    def user: () -> ((User & User::Validated) | User)?
+    def user=: (((User & User::Validated)? | User?) value) -> ((User & User::Validated) | User)?
+    def author_name: () -> String?
+    def author_name=: (String? value) -> String?
+    def account: () -> (Account & Account::Validated)?
+    def account=: ((Account & Account::Validated)? value) -> (Account & Account::Validated)?
+    def viewer_name: () -> String?
+    def viewer_name=: (String? value) -> String?
+  end
+
+  include GeneratedAttributeMethods
+
+  def self.user: () -> ((User & User::Validated) | User)?
+  def self.user=: (((User & User::Validated)? | User?) value) -> ((User & User::Validated)? | User?)
+  def self.author_name: () -> String?
+  def self.author_name=: (String? value) -> String?
+  def self.account: () -> (Account & Account::Validated)?
+  def self.account=: ((Account & Account::Validated)? value) -> (Account & Account::Validated)?
+  def self.viewer_name: () -> String?
+  def self.viewer_name=: (String? value) -> String?
+  def self.__rbs_infer_instance: () -> Current
+  def self.set: (?user: ((User & User::Validated) | User)?, ?author_name: String?, ?account: (Account & Account::Validated)?, ?viewer_name: String?) ?{ () -> untyped } -> untyped
+  def self.with: (?user: (User & User::Validated)?, ?author_name: String?, ?account: (Account & Account::Validated)?, ?viewer_name: String?) ?{ () -> ProfileFormatter } -> ProfileFormatter?
+end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -547,6 +547,17 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     it "Devise runtime" do
       assert_runtime_rbs("steep_devise_runtime")
     end
+
+    # The only runtime sidecar that had no snapshot, and the one that most needed
+    # it: `Current`'s attributes are typed entirely from call sites in other
+    # files, so its RBS moves whenever that inference moves. Two things went
+    # unseen for want of this — a `-> nil` on `self.with` that was the previous
+    # generation's own output feeding itself (felixefelip/rbs_infer#156), and an
+    # `author_name: String?` that no source could justify. Both would have read
+    # as a diff here.
+    it "Current runtime" do
+      assert_runtime_rbs("steep_current_runtime")
+    end
   end
 
   # Class-instance variables (felixefelip/rbs_infer#86). A `@x` written in a

--- a/spec/lib/rbs_infer/inference/block_return_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/block_return_collector_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+require "rbs_infer"
+
+RSpec.describe RbsInfer::Inference::BlockReturnCollector do
+  # Steep's map is keyed `"line:column"`; the fixtures below state it directly so
+  # the collector's own job — finding the block's last statement and looking it
+  # up — is what gets tested, not the bridge.
+  def collect(source, methods:, expression_types:, receiver_check: nil)
+    collector = described_class.new(
+      methods: Set.new(methods), expression_types: expression_types, receiver_check: receiver_check
+    )
+    Prism.parse(source).value.accept(collector)
+    collector.returns
+  end
+
+  it "reads the type of the block's last statement" do
+    source = <<~RUBY
+      def go
+        with_token do |token|
+          lookup(token)
+        end
+      end
+    RUBY
+
+    expect(collect(source, methods: ["with_token"], expression_types: { "3:4" => "User?" }))
+      .to eq("with_token" => ["User?"])
+  end
+
+  it "records one entry per call site, for the caller to union" do
+    source = <<~RUBY
+      def go
+        wrap { 1 }
+        wrap { "x" }
+      end
+    RUBY
+
+    expect(collect(source, methods: ["wrap"], expression_types: { "2:9" => "Integer", "3:9" => "String" }))
+      .to eq("wrap" => ["Integer", "String"])
+  end
+
+  # A call with a receiver is somebody else's method until proven otherwise. The
+  # target's own file passes no check, where a receiverless call is a self-send.
+  it "ignores a call on a receiver when no check is supplied" do
+    source = "def go; other.wrap { 1 }; end"
+
+    expect(collect(source, methods: ["wrap"], expression_types: { "1:21" => "Integer" })).to be_empty
+  end
+
+  it "asks the supplied check about a receiver" do
+    source = "def go; other.wrap { 1 }; end"
+
+    expect(collect(source, methods: ["wrap"], expression_types: { "1:21" => "Integer" }, receiver_check: ->(_node) { true }))
+      .to eq("wrap" => ["Integer"])
+  end
+
+  it "says nothing about a site the checker could not type" do
+    source = "def go; wrap { compute }; end"
+
+    expect(collect(source, methods: ["wrap"], expression_types: {})).to be_empty
+  end
+
+  it "ignores a call with no block at all" do
+    expect(collect("def go; wrap(1); end", methods: ["wrap"], expression_types: { "1:13" => "Integer" })).to be_empty
+  end
+end

--- a/spec/lib/rbs_infer/signatures/rbs_parser_util_spec.rb
+++ b/spec/lib/rbs_infer/signatures/rbs_parser_util_spec.rb
@@ -432,6 +432,39 @@ RSpec.describe RbsInfer::Signatures::RbsParserUtil do
     end
   end
 
+  describe ".replace_block_return_type" do
+    it "fills in what the block returns, leaving its parameters alone" do
+      expect(described_class.replace_block_return_type("m: () { (String) -> untyped } -> untyped", "User"))
+        .to eq("m: () { (String) -> User } -> untyped")
+    end
+
+    # The mirror image of the parameter list, and measured rather than assumed:
+    # `{ () -> A | B }` is a SYNTAX ERROR, while `{ (A | B) -> untyped }` is fine.
+    it "parenthesizes a union, which is invalid bare in this position" do
+      expect(described_class.replace_block_return_type("m: () { () -> untyped } -> untyped", "String | Integer"))
+        .to eq("m: () { () -> (String | Integer) } -> untyped")
+    end
+
+    it "leaves alone what it cannot account for" do
+      [
+        # already refined, or hand-written
+        ["m: () { (String) -> User } -> untyped", "Post"],
+        # no block at all
+        ["m: (untyped a) -> untyped", "User"],
+        # nothing to say
+        ["m: () { (String) -> untyped } -> untyped", nil],
+        ["m: () { (String) -> untyped } -> untyped", "untyped"]
+      ].each { |sig, type| expect(described_class.replace_block_return_type(sig, type)).to eq(sig) }
+    end
+
+    # The method's own return sits outside the braces and is somebody else's
+    # answer — a `-> untyped` there must survive.
+    it "touches only the return inside the braces" do
+      expect(described_class.replace_block_return_type("m: () ?{ () -> untyped } -> untyped", "Post"))
+        .to eq("m: () ?{ () -> Post } -> untyped")
+    end
+  end
+
   describe ".require_block" do
     it "adopts the callee's block: required, and shaped like theirs" do
       expect(described_class.require_block("m: () ?{ (*untyped) -> untyped } -> untyped", ["String", "Integer"]))


### PR DESCRIPTION
A block type has two halves with opposite origins. The **parameters** are what the method hands to the block, so its own body answers them (#148). The **return** is what the method receives back, and a method that passes it through — `block.call(token)`, `yield` — constrains it not at all:

```ruby
def fetch_token(&block)
  token = token_value
  unless token.empty?
    block.call(token)      # returns the block's value, without looking at it
  end
end
```

Its body has nothing to say, which is why that half stayed `untyped`.

## Where the answer comes from

The callers: whatever blocks are actually passed, unioned across sites. That is the contract every parameter type in this project already has — a description of how the code **is** used, not of what the method would tolerate — and treating this one position by a different rule would be the anomaly.

```rbs
example17#with_token   { (String) -> String } -> String
example18#with_token   { (String) -> Example18::User? }
example13#with_format  ?{ (Symbol) -> bool } -> bool?
Current.with           ?{ () -> ProfileFormatter } -> ProfileFormatter?
```

The method's own return follows where it forwards the block's value, so `ProfileFormatterJob#perform` gains `-> ProfileFormatter?` and `example13#guard_composite` gains `-> bool?`.

## Two things measured rather than assumed

**Steep gives the caller the DECLARED type, never the block's.** With `() { () -> (Integer | String) } -> (Integer | String)`, a call passing a block that returns `Integer` still types as the union; only a type variable ties the two:

```
wrap_union { 1 }     -> (::Integer | ::String)
wrap_generic { 1 }   -> ::Integer
```

So this is an approximation of a genuinely generic method (`[T] () { () -> T } -> T?`), and it degrades the way a union should — a second caller widens the type rather than deleting it. A two-member union in this position is the signal that a helper wants generics.

**`{ () -> A | B }` is a syntax error while `{ (A | B) -> untyped }` is fine.** So a union is parenthesized here and stripped in the parameter list. The two positions really do differ; both checked against the RBS parser.

## The `-> nil` this uncovered

`Current.with` declared `-> nil` while its body now returned `ProfileFormatter?` — a contradiction that survived two full generations. The nil was not inference: it was the **previous generation's own output**, fed back as a known type by `ReturnTypeResolver#improve_method_return_types` and re-supplying itself every pass. Traced by instrumenting `Member#signature=`. Regenerating that file from scratch produces the consistent `-> ProfileFormatter?`.

## A second commit: the argument type the walk could not reach

Regenerating that sidecar first LOST `author_name: String?`, and it did not come back — that type was self-perpetuating in the same way, and nothing could derive it. Rather than ship the loss, the second commit finds why.

`self.author_name = value&.full_name` is a call site the collector matches and then throws away. It resolves the receiver to `Current` and finds the method — then types the argument `untyped`, because `value` is the enclosing method's parameter and the send is safe-navigated, neither of which the structural path follows. The Analyzer drops `untyped` usages, so the attribute went untyped though Steep types that very expression `String?`:

```
18: self.author_name = value&.full_name
     18:23 -> String?
```

The map was already in hand — the same `all_expression_types` this branch plumbed in for block returns. Consulting it when the structural resolver comes back empty is exactly the evidence the walk was missing, and it stays a **fallback**: the structural answer wins wherever it has one, since it carries conventions a checker type does not (a class name for `Klass.new`, a record for a hash literal).

So `author_name: String?` returns as something **derived** rather than inherited — which is the state it was really in. `viewer_name` gains the same, along with the `set`/`with` keywords and the attributes' ivars; elsewhere `Example#user_name` gains `String?` and `Example10::Registry.last` its accessor pair.

The mechanism that hid this — the previous run's output trusted as inference — is filed as felixefelip/rbs_infer#156 and remains open.

## A third commit: the snapshot that was missing

`assert_runtime_rbs` already guards the controller, view, ActiveRecord and Devise sidecars. `steep_current_runtime` had none — and it is the one that most needed it, since `Current`'s attributes are typed entirely from call sites in other files, so its RBS moves whenever that inference moves.

Both problems above would have read as a diff on that snapshot, at the commit that caused them, instead of being found by accident three changes later.

## Checks

**876 examples, 0 failures.** Baseline unchanged at 33.
