### PR TITLE
feat: carry a block's return type through a forward

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -688,7 +688,51 @@ module RbsInfer
     @caller_block_returns&.each do |name, types|
       (returns[name] ||= []).concat(types)
     end
+    propagate_along_forwards(returns, collector.forwards)
     returns
+  end
+
+  # A forwarded block carries the evidence one frame down
+  # (felixefelip/rbs_infer#158):
+  #
+  #   def with_token(&block)
+  #     fetch_token(&block) || deny
+  #   end
+  #
+  # `fetch_token` has no call site with a block of its own — only this forward —
+  # so it had nothing to go on. But every block that reaches it through this edge
+  # is a block that reached `with_token`, whose answer the call sites already
+  # gave. So the forwarder's evidence is the callee's.
+  #
+  # It is the mirror of felixefelip/rbs_infer#149, which walks the same edge the
+  # other way: whether a block is REQUIRED is a demand the callee makes, while
+  # what it RETURNS is evidence the caller supplies.
+  #
+  # A fixpoint because a chain is arbitrarily deep and the members come in no
+  # order; it terminates because the lists only grow and a type is added once.
+  def propagate_along_forwards(returns, forwards)
+    return if forwards.empty?
+
+    loop do
+      changed = false
+
+      forwards.each do |forwarder, callees|
+        observed = returns[forwarder]
+        next if observed.nil? || observed.empty?
+
+        callees.each do |callee|
+          inherited = (returns[callee] ||= [])
+          observed.each do |type|
+            next if inherited.include?(type)
+
+            inherited << type
+            changed = true
+          end
+        end
+      end
+
+      break unless changed
+    end
   end
 
   # ─── Extrair nomes dos keyword params opcionais do initialize ─────

--- a/lib/rbs_infer/inference/block_return_collector.rb
+++ b/lib/rbs_infer/inference/block_return_collector.rb
@@ -27,14 +27,36 @@ module RbsInfer::Inference
       @expression_types = expression_types
       @receiver_check = receiver_check
       @returns = Hash.new { |hash, key| hash[key] = [] }
+      @forwards = Hash.new { |hash, key| hash[key] = [] }
       super()
     end
 
     # `{ "with_token" => ["Example18::User?"] }` — one entry per call site.
     attr_reader :returns
 
+    # `{ "with_token" => ["fetch_token"] }` — who hands their own block on to
+    # whom. A forwarded block is not evidence by itself, but every block that
+    # reaches the callee through this edge is one that reached the forwarder, so
+    # the forwarder's answer is the callee's too. The caller resolves that, since
+    # it needs a fixpoint over the whole set (felixefelip/rbs_infer#158).
+    attr_reader :forwards
+
+    def visit_def_node(node)
+      previous_method, previous_block = @current_method, @current_block_param
+      @current_method = node.name.to_s
+      @current_block_param = node.parameters&.block&.name&.to_s
+      super
+    ensure
+      @current_method, @current_block_param = previous_method, previous_block
+    end
+
     def visit_call_node(node)
-      collect(node) if node.block.is_a?(Prism::BlockNode) && @methods.include?(node.name.to_s)
+      if @methods.include?(node.name.to_s)
+        case node.block
+        when Prism::BlockNode then collect(node)
+        when Prism::BlockArgumentNode then collect_forward(node)
+        end
+      end
       super
     end
 
@@ -45,6 +67,22 @@ module RbsInfer::Inference
 
       type = block_return_type(node.block)
       @returns[node.name.to_s] << type if type
+    end
+
+    # `fetch_token(&block)` inside `def with_token(&block)`. Only the enclosing
+    # method's OWN block counts: `other(&:upcase)` or `other(&some_proc)` says
+    # nothing about what reached this method.
+    def collect_forward(node)
+      return unless @current_method && receiver_matches?(node)
+      return unless forwards_own_block?(node.block)
+
+      @forwards[@current_method] << node.name.to_s
+    end
+
+    def forwards_own_block?(block_argument)
+      expression = block_argument.expression
+      @current_block_param && expression.is_a?(Prism::LocalVariableReadNode) &&
+        expression.name.to_s == @current_block_param
     end
 
     def receiver_matches?(node)

--- a/spec/dummy/sig/rbs_infer/app/models/example18.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example18.rbs
@@ -6,10 +6,10 @@ class Example18
 
   private
 
-  def authenticate: () -> untyped
-  def from_token: () -> untyped
-  def with_token: () { (String) -> Example18::User? } -> untyped
-  def fetch_token: () { (String) -> untyped } -> untyped
+  def authenticate: () -> (Example18::User | bool)
+  def from_token: () -> (Example18::User | bool)
+  def with_token: () { (String) -> Example18::User? } -> (Example18::User | bool)
+  def fetch_token: () { (String) -> Example18::User? } -> Example18::User?
   def deny: () -> bool
   def halt: () -> bool
   def lookup: (String token) -> Example18::User?

--- a/spec/dummy/sig/rbs_infer/app/models/example19.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example19.rbs
@@ -15,7 +15,7 @@ class Example19
   def authenticate: () -> untyped
   def from_token: () -> untyped
   def with_token: () { (String) -> Example19::User? } -> untyped
-  def fetch_token: () { (String) -> untyped } -> untyped
+  def fetch_token: () { (String) -> Example19::User? } -> Example19::User?
   def refuse: () -> untyped
   def lookup: (String token) -> Example19::User?
   def token_value: () -> String

--- a/spec/expectations/models/example18.rbs
+++ b/spec/expectations/models/example18.rbs
@@ -6,10 +6,10 @@ class Example18
 
   private
 
-  def authenticate: () -> untyped
-  def from_token: () -> untyped
-  def with_token: () { (String) -> Example18::User? } -> untyped
-  def fetch_token: () { (String) -> untyped } -> untyped
+  def authenticate: () -> (Example18::User | bool)
+  def from_token: () -> (Example18::User | bool)
+  def with_token: () { (String) -> Example18::User? } -> (Example18::User | bool)
+  def fetch_token: () { (String) -> Example18::User? } -> Example18::User?
   def deny: () -> bool
   def halt: () -> bool
   def lookup: (String token) -> Example18::User?

--- a/spec/expectations/models/example19.rbs
+++ b/spec/expectations/models/example19.rbs
@@ -15,7 +15,7 @@ class Example19
   def authenticate: () -> untyped
   def from_token: () -> untyped
   def with_token: () { (String) -> Example19::User? } -> untyped
-  def fetch_token: () { (String) -> untyped } -> untyped
+  def fetch_token: () { (String) -> Example19::User? } -> Example19::User?
   def refuse: () -> untyped
   def lookup: (String token) -> Example19::User?
   def token_value: () -> String

--- a/spec/lib/rbs_infer/inference/block_return_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/block_return_collector_spec.rb
@@ -62,4 +62,42 @@ RSpec.describe RbsInfer::Inference::BlockReturnCollector do
   it "ignores a call with no block at all" do
     expect(collect("def go; wrap(1); end", methods: ["wrap"], expression_types: { "1:13" => "Integer" })).to be_empty
   end
+
+  # felixefelip/rbs_infer#158: a forwarded block is not evidence, but it is an
+  # EDGE. Every block that reaches the callee through it is one that reached the
+  # forwarder, so the caller propagates the forwarder's answer along it.
+  describe "#forwards" do
+    def forwards_in(source, methods:)
+      collector = described_class.new(methods: Set.new(methods), expression_types: {})
+      Prism.parse(source).value.accept(collector)
+      collector.forwards
+    end
+
+    it "records who hands its own block on to whom" do
+      source = <<~RUBY
+        def with_token(&block)
+          fetch_token(&block) || deny
+        end
+      RUBY
+
+      expect(forwards_in(source, methods: ["fetch_token"])).to eq("with_token" => ["fetch_token"])
+    end
+
+    # `other(&:upcase)` builds a proc on the spot and `other(&some_proc)` passes
+    # somebody else's — neither says anything about what reached this method.
+    it "ignores a block that is not the method's own" do
+      source = <<~RUBY
+        def wrapper(&block)
+          fetch_token(&:upcase)
+          fetch_token(&other_proc)
+        end
+      RUBY
+
+      expect(forwards_in(source, methods: ["fetch_token"])).to be_empty
+    end
+
+    it "ignores a forward from outside any method" do
+      expect(forwards_in("fetch_token(&block)", methods: ["fetch_token"])).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
#155 types a block's return from the sites that pass one. `fetch_token` has no such site — its only call is a forward:

```ruby
def with_token(&block)
  fetch_token(&block) || deny
end
```

so it was left `untyped`. But every block that reaches `fetch_token` through that edge is a block that reached `with_token`, whose answer the call sites already gave. **The forwarder's evidence is the callee's.**

## The mirror of #149

That PR walks the same edge in the other direction, and the pairing explains why:

| | direction | because |
|---|---|---|
| #149 — is a block required? | callee → forwarder | requiredness is a demand the **callee** makes |
| here — what does it return? | forwarder → callee | the return is evidence the **caller** supplies |

The two halves of a block type come from opposite ends, so each travels its own way along the same edge.

## Shape

A fixpoint, since a chain is arbitrarily deep and members come in no order; it terminates because the lists only grow and a type is added once.

Only the enclosing method's **own** block counts as a forward. `other(&:upcase)` builds a proc on the spot and `other(&some_proc)` passes somebody else's — neither says anything about what reached this method. Both are pinned by spec.

## Result

Example18's chain was `untyped` from end to end:

```rbs
fetch_token:  () { (String) -> Example18::User? } -> Example18::User?
with_token:   () { (String) -> Example18::User? } -> (Example18::User | bool)
from_token:   () -> (Example18::User | bool)
authenticate: () -> (Example18::User | bool)
```

The method returns follow the block's: once `block.call(token)` has a type, `fetch_token` has one, and it rises from there.

## Known limit

The edge is followed for self-sends within the target. `Token.authenticate(self, &login_procedure)` crosses classes, so the Rails transcription does not benefit yet — the same boundary #149 has, now on both directions of the edge.

## Checks

**879 examples, 0 failures.** Baseline unchanged at 33.
