### PR TITLE
chore: Example19 closes — the halt crosses into an argument

### DIFF
--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -713,9 +713,21 @@ postconditions:
     may_write:
     - "@name"
 - class: Example19
+  method: authenticate
+  conditional_const_returns:
+    Example19::Registry.user:
+      gate_ivar: "@halted"
+      type: "::Example19::User"
+- class: Example19
   method: fetch_token
   when_true:
     block_truthy: true
+- class: Example19
+  method: from_token
+  conditional_const_returns:
+    Example19::Registry.user:
+      gate_ivar: "@halted"
+      type: "::Example19::User"
 - class: Example19
   method: halt
   unconditional:
@@ -725,6 +737,10 @@ postconditions:
   effects:
     may_write:
     - "@halted"
+- class: Example19
+  method: with_token
+  conditional_block_truthy:
+    gate_ivar: "@halted"
 - class: Example19::Registry
   method: user
   effects:
@@ -1682,6 +1698,14 @@ method_entry_facts:
   method: user
   consts:
     Example18::Registry.user: "::Example18::User"
+- class: Example19
+  method: show
+  consts:
+    Example19::Registry.user: "::Example19::User"
+- class: Example19::Registry
+  method: user
+  consts:
+    Example19::Registry.user: "::Example19::User"
 - class: Example4
   method: run_foo_name
   consts:

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -9,7 +9,6 @@ app/models/concerns/test/filtrable.rb:8:4: [error] Type `(singleton(::Test) & si
 app/models/example10.rb:27:26: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example14.rb:15:17: [error] Type `(::Example14::User | nil)` does not have method `name`
 app/models/example15.rb:25:25: [error] Type `(::Example15::User | nil)` does not have method `name`
-app/models/example19.rb:68:25: [error] Type `(::Example19::User | nil)` does not have method `name`
 app/models/example3.rb:122:11: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:63:13: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:64:26: [error] Type `(::Example3::User | nil)` does not have method `name`


### PR DESCRIPTION
Regenerated output of felixefelip/steep#127.

`Example19` was added to document a gap: `Responder.deny(self, …)` halts the object it was handed, and nothing could see that the caller was the one halted. Now it can, so the rest of the chain — which `Example18` already proved — runs to the end:

```yaml
from_token:   conditional_const_returns: { Registry.user, gate_ivar: "@halted" }
authenticate: the same, carried by the `||`
show:         method_entry_facts consts: Registry.user
```

The baseline **loses** the entry the fixture opened: `show` dereferencing `Registry.user` type-checks. 33 problems → 32.

## What is left

One measured thing, where there were two. The real Rails chain renders through `controller.__send__ :render`, which Steep types as `::BasicObject#__send__`, so the call-graph edge is lost before any of the parameter-halt reasoning applies.

The two fixtures now bracket the problem exactly: `Example18` halts on its own `self` and closes; `Example19` halts through an argument and closes; the framework halts through an argument **reached by `__send__`**, and does not.

## Checks

**879 examples, 0 failures**, against the merged steep branch.
