### PR TITLE
feat: infer a nested module's methods from their call sites

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -234,7 +234,8 @@ module RbsInfer
     # the first type seen (felixefelip/rbs_infer#64).
     cross_class_param_types = infer_method_param_types_from_callers(
       extract_attr_writer_methods(target_members),
-      block_methods: target_members.select { |m| untyped_block_return?(m) }.map(&:name).to_set
+      block_methods: target_members.select { |m| untyped_block_return?(m) }.map(&:name).to_set,
+      method_owners: nested_method_owners(target_members)
     )
     cross_class_param_types.each do |method_name, param_types|
       method_param_types[method_name] ||= {}
@@ -735,6 +736,20 @@ module RbsInfer
     end
   end
 
+  # `{ "deny" => "Example19::Responder" }` for the target's methods that live in
+  # a nested MODULE. Such a module is emitted inside this target's block rather
+  # than as a target of its own (felixefelip/rbs_infer#22), so its call sites
+  # were matched against the wrong name and its parameters stayed `untyped`
+  # (felixefelip/rbs_infer#159).
+  def nested_method_owners(target_members)
+    target_members.each_with_object({}) do |member, owners|
+      next unless [:method, :class_method].include?(member.kind)
+      next if member.owner.nil? || member.owner.empty?
+
+      owners[member.name] ||= "#{@target_class}::#{member.owner}"
+    end
+  end
+
   # ─── Extrair nomes dos keyword params opcionais do initialize ─────
 
   def extract_optional_init_params
@@ -942,7 +957,7 @@ module RbsInfer
 
   # Inferir tipos de parâmetros de métodos via chamadas cross-class
   # Ex: PostPublisher chama notifier.notify(post.user, "msg") → user: User, message: String
-  def infer_method_param_types_from_callers(extra_methods = {}, block_methods: Set.new)
+  def infer_method_param_types_from_callers(extra_methods = {}, block_methods: Set.new, method_owners: {})
     # `extra_methods` are SYNTHETIC writers standing in for `attr_accessor`-
     # generated methods, and name their param after the attr (`user`). A real
     # `def user=(value)` overriding that attr names it `value`, and the def is
@@ -962,7 +977,8 @@ module RbsInfer
       init_positional_params: positional_params,
       target_methods: target_methods,
       steep_bridge: steep_bridge,
-      block_methods: block_methods
+      block_methods: block_methods,
+      method_owners: method_owners
     )
     referencing = @source_index.files_referencing(@target_class)
 

--- a/lib/rbs_infer/inference/caller_file_analyzer.rb
+++ b/lib/rbs_infer/inference/caller_file_analyzer.rb
@@ -12,7 +12,7 @@ module RbsInfer::Inference
     # covered by `IntraClassCallAnalyzer`. Omitting it would double-count every same-file
     # self-call — the two paths resolve the receiver differently, so the parameter widens
     # into a union instead of failing loudly (required-threaded-deps).
-    def initialize(target_class:, method_type_resolver:, target_file:, init_positional_params: [], target_methods: {}, steep_bridge: nil, block_methods: Set.new)
+    def initialize(target_class:, method_type_resolver:, target_file:, init_positional_params: [], target_methods: {}, steep_bridge: nil, block_methods: Set.new, method_owners: {})
       @target_class = target_class
       @target_file = target_file
       @method_type_resolver = method_type_resolver
@@ -22,6 +22,7 @@ module RbsInfer::Inference
       # felixefelip/rbs_infer#155: methods whose signature carries a block, and
       # what the blocks passed to them at these call sites return.
       @block_methods = block_methods
+      @method_owners = method_owners
       @method_call_usages = Hash.new { |h, k| h[k] = [] }
       @method_block_returns = Hash.new { |h, k| h[k] = [] }
     end
@@ -149,6 +150,7 @@ module RbsInfer::Inference
         constant_arg_resolver: constant_arg_resolver,
         defined_class_names: NewCallCollector.collect_defined_class_names(result.value),
         block_methods: @block_methods,
+        method_owners: @method_owners,
         expression_types: @steep_bridge ? @steep_bridge.all_expression_types(source) : {}
       )
       result.value.accept(visitor)

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -28,7 +28,7 @@ module RbsInfer::Inference
       names
     end
 
-    def initialize(target_class:, method_return_types:, local_var_types:, constant_arg_resolver:, defined_class_names:, local_var_read_types: {}, local_var_types_by_method: {}, method_type_resolver: nil, caller_class_name: nil, init_positional_params: [], target_methods: {}, match_bare_calls: false, self_types_by_method: {}, established_ivars_by_method: {}, argument_partitions_by_method: {}, block_methods: Set.new, expression_types: {})
+    def initialize(target_class:, method_return_types:, local_var_types:, constant_arg_resolver:, defined_class_names:, local_var_read_types: {}, local_var_types_by_method: {}, method_type_resolver: nil, caller_class_name: nil, init_positional_params: [], target_methods: {}, match_bare_calls: false, self_types_by_method: {}, established_ivars_by_method: {}, argument_partitions_by_method: {}, block_methods: Set.new, expression_types: {}, method_owners: {})
       @target_class = target_class
       # FQNs of classes/modules defined in the file being scanned; disambiguates
       # a relative receiver from a same-simple-name class elsewhere (see
@@ -75,6 +75,11 @@ module RbsInfer::Inference
       # felixefelip/rbs_infer#155: names whose signature carries a block, and
       # Steep's types for this file, so a call site can be asked what the block
       # it passes returns. Empty when the caller is analyzed without a bridge.
+      # felixefelip/rbs_infer#159: `{ "deny" => "Example19::Responder" }` — the
+      # target's methods that belong to a nested module, which is emitted in
+      # place rather than as a target of its own, so its call sites are matched
+      # against the OWNER's name instead of the enclosing target's.
+      @method_owners = method_owners
       @block_methods = block_methods
       @expression_types = expression_types
       @usages = []
@@ -84,11 +89,25 @@ module RbsInfer::Inference
       # current method is a singleton (`def self.x`) — used to resolve a
       # `self` argument/receiver to its type.
       @class_name_stack = []
+      # `:class` / `:module` for each enclosing declaration, innermost last. A
+      # module's `self` is whoever includes it, so an instance method there
+      # cannot claim the module's name (felixefelip/rbs_infer#159).
+      @declaration_kinds = []
       @in_singleton_method = false
       @current_method = nil
     end
 
+    # A module declaration does not push a name — `@class_name_stack` is about
+    # the enclosing CLASS — but it does decide what `self` is inside it.
+    def visit_module_node(node)
+      @declaration_kinds.push(:module)
+      super
+    ensure
+      @declaration_kinds.pop
+    end
+
     def visit_class_node(node)
+      @declaration_kinds.push(:class)
       # Pré-coletar tipos de ivars de todos os métodos da classe
       # para que @post definido em set_post esteja disponível em publish
       collect_class_ivar_types(node)
@@ -101,6 +120,7 @@ module RbsInfer::Inference
       @class_name_stack.push(full_name) if full_name
       super
       @class_name_stack.pop if full_name
+      @declaration_kinds.pop
     end
 
     def visit_def_node(node)
@@ -171,7 +191,7 @@ module RbsInfer::Inference
         method_name = node.name.to_s
         if @target_methods.key?(method_name)
           receiver_type = resolve_receiver_type(node.receiver)
-          if receiver_type && match_class?(receiver_type)
+          if receiver_type && (match_class?(receiver_type) || owner_match?(receiver_type, method_name))
             args = extract_cross_class_args(node, @target_methods[method_name])
             @method_call_usages[method_name] << args unless args.empty?
           end
@@ -372,6 +392,24 @@ module RbsInfer::Inference
     # the current nesting, it is that class, not the same-named target
     # elsewhere. Absent such a local definition we keep the unique-name
     # assumption (cross-file), which existing behaviour depends on.
+    # `Responder.deny(self, "denied")` where `deny` belongs to
+    # `Example19::Responder`, a nested MODULE. Such a module is emitted inside
+    # its enclosing target's block rather than as a target of its own
+    # (felixefelip/rbs_infer#22), so nothing ever asked about its call sites and
+    # its parameters stayed `untyped` — while a nested CLASS three lines away,
+    # being a target, had everything inferred.
+    #
+    # The receiver is matched against the OWNER here, not the enclosing target,
+    # and only for a method that owner actually has.
+    def owner_match?(receiver_type, method_name)
+      owner = @method_owners[method_name] or return false
+
+      receiver_components(receiver_type).any? do |component|
+        normalized = component.sub(/\A::/, "")
+        normalized == owner || relative_receiver_matches_target?(normalized, owner)
+      end
+    end
+
     def relative_receiver_matches_target?(relative_name, target)
       return false unless target.end_with?("::#{relative_name}")
       resolved = resolve_relative_in_file(relative_name)
@@ -633,6 +671,13 @@ module RbsInfer::Inference
         return refined if refined && !refined.empty?
       end
 
+      # Inside a module, an INSTANCE method's `self` is whatever includes it —
+      # unknowable from here, and claiming the module is a lie that reaches the
+      # signature (`Token.authenticate(self, …)` typed its parameter
+      # `ActionController::HttpAuthentication`, which has no `request`).
+      # A `def self.x` in a module is different: there `self` IS the module.
+      return "untyped" if !@in_singleton_method && @declaration_kinds.last == :module
+
       base = @class_name_stack.last || @caller_class_name
       return "untyped" unless base
 
@@ -781,7 +826,13 @@ module RbsInfer::Inference
     def expression_type(node)
       # Character column, like every other lookup into this map — Parser counts
       # characters where Prism also offers bytes (felixefelip/rbs_infer#142).
-      @expression_types["#{node.location.start_line}:#{node.location.start_character_column}"]
+      type = @expression_types["#{node.location.start_line}:#{node.location.start_character_column}"]
+
+      # `self` is a real RBS type, but it means "the receiver of THIS method" —
+      # so carrying it into ANOTHER method's parameter says the argument is a
+      # Token when it is a controller. The checker answers `self` for a `self`
+      # node; here that answer is unusable.
+      type unless type == "self"
     end
 
     # Whether a keyword hash at the call site is really a positional Hash: no key names a

--- a/lib/rbs_infer/signatures/rbs_builder.rb
+++ b/lib/rbs_infer/signatures/rbs_builder.rb
@@ -280,7 +280,12 @@ module RbsInfer::Signatures
           lines << "#{inner_indent}extend #{qualify(ext.name)}"
         end
         mod_members.select { |m| m.kind == :class_method }.each do |m|
-          lines << "#{inner_indent}def self.#{RbsInfer::Signatures::RbsParserUtil.parenthesize_return_type(m.signature)}"
+          # The same substitution the top-level singletons get. Omitting it left
+          # a nested module's `def self.x` carrying the raw structural signature
+          # even once its call sites had been read (felixefelip/rbs_infer#159).
+          sig = m.signature
+          sig = apply_inferred_param_types(sig, method_param_types[m.name]) if method_param_types[m.name]
+          lines << "#{inner_indent}def self.#{RbsInfer::Signatures::RbsParserUtil.parenthesize_return_type(sig)}"
         end
         mod_members.select { |m| m.kind == :singleton_alias }.each do |a|
           lines << "#{inner_indent}alias self.#{a.name} self.#{a.old_name}"

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -738,6 +738,11 @@ postconditions:
     may_write:
     - "@halted"
 - class: Example19
+  method: record
+  effects:
+    may_write:
+    - "@message"
+- class: Example19
   method: with_token
   conditional_block_truthy:
     gate_ivar: "@halted"

--- a/spec/dummy/sig/rbs_infer/app/models/example19.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example19.rbs
@@ -1,22 +1,23 @@
 class Example19
   @halted: true?
+  @message: String?
 
   module Responder
-    def self.deny: (untyped host, untyped message) -> untyped
+    def self.deny: (Example19 host, String message) -> bool
   end
 
   def show: () -> String
   def call: () -> String?
   def halt: () -> bool
-  def record: (untyped message) -> untyped
+  def record: (String? message) -> String?
 
   private
 
-  def authenticate: () -> untyped
-  def from_token: () -> untyped
-  def with_token: () { (String) -> Example19::User? } -> untyped
+  def authenticate: () -> (Example19::User | bool)
+  def from_token: () -> (Example19::User | bool)
+  def with_token: () { (String) -> Example19::User? } -> (Example19::User | bool)
   def fetch_token: () { (String) -> Example19::User? } -> Example19::User?
-  def refuse: () -> untyped
+  def refuse: () -> bool
   def lookup: (String token) -> Example19::User?
   def token_value: () -> String
 end

--- a/spec/expectations/models/example19.rbs
+++ b/spec/expectations/models/example19.rbs
@@ -1,22 +1,23 @@
 class Example19
   @halted: true?
+  @message: String?
 
   module Responder
-    def self.deny: (untyped host, untyped message) -> untyped
+    def self.deny: (Example19 host, String message) -> bool
   end
 
   def show: () -> String
   def call: () -> String?
   def halt: () -> bool
-  def record: (untyped message) -> untyped
+  def record: (String? message) -> String?
 
   private
 
-  def authenticate: () -> untyped
-  def from_token: () -> untyped
-  def with_token: () { (String) -> Example19::User? } -> untyped
+  def authenticate: () -> (Example19::User | bool)
+  def from_token: () -> (Example19::User | bool)
+  def with_token: () { (String) -> Example19::User? } -> (Example19::User | bool)
   def fetch_token: () { (String) -> Example19::User? } -> Example19::User?
-  def refuse: () -> untyped
+  def refuse: () -> bool
   def lookup: (String token) -> Example19::User?
   def token_value: () -> String
 end


### PR DESCRIPTION
```rbs
module Responder
  def self.deny: (untyped host, untyped message) -> untyped
end
```

three lines above a nested **class** whose every parameter was typed. The difference was never about evidence — running the pipeline by hand with `target_class: "Example19::Responder"` answers:

```
{"deny" => {"host" => "Example19", "message" => "String"}}
```

It was that nobody asked.

## Why nobody asked

A nested module is excluded from `declaration_targets` **on purpose**: the owner mechanism emits it inside its enclosing target's block (#22). The side effect went unrecorded — never being a target, it never goes through inference either, while a nested class does.

## Three links, each found by measuring

1. **The call-site receiver** was matched against the enclosing target (`Example19`), never against the owner (`Example19::Responder`), so `Responder.deny(…)` matched nothing. `owner_match?` matches the owner, and only for a method that owner actually has.

2. **The emission** wrote a nested module's `def self.x` signature RAW, skipping the substitution its top-level counterpart does. So even once the call sites were read, nothing landed.

3. **`self` inside a MODULE** resolved to the file's class name. That is false for a mixin, and the baseline caught it: `Token.authenticate(self, &login_procedure)` typed its parameter `ActionController::HttpAuthentication`, which has no `request` — two new errors. A module's instance method has no knowable `self` (whoever includes it decides); a `def self.x` in a module does, and it is the module.

And a fourth, which the checker fallback let through: Steep answers `self` for a `self` node. That is a real RBS type meaning "the receiver of **this** method" — carried into another method's parameter it claims the argument is a `Token` when it is a controller. Refused.

## Result

```diff
-    def self.deny: (untyped host, untyped message) -> untyped
+    def self.deny: (Example19 host, String message) -> bool
-  def record: (untyped message) -> untyped
+  def record: (String? message) -> String?
-  def refuse: () -> untyped
+  def refuse: () -> bool
-  def authenticate: () -> untyped
+  def authenticate: () -> (Example19::User | bool)
```

Baseline unchanged at 32 — the transcription's `(untyped controller)` is back where it belongs, which is what item 3 is about.

## A note on #127

With this, `host` in `Responder.deny(host, message)` is `Example19`, so `host.halt` would now resolve by declaration — the by-name collection steep#127 introduced is no longer the only route **in this fixture**. It still is for Rails, where the collection declares `authentication_request: (instance controller, …)` and the parameter carries no usable type. The design earns its keep; it just stops being the sole option here.

## Checks

**879 examples, 0 failures.**
