### PR TITLE
feat(rails): desugar dynamic sends in the transcription, and seed the halting tail

### DIFF
--- a/lib/rbs_infer/extensions/rails/controllers/framework_source_transcriber.rb
+++ b/lib/rbs_infer/extensions/rails/controllers/framework_source_transcriber.rb
@@ -60,6 +60,18 @@ module RbsInfer
             Seed.new(
               receiver: "ActionController::HttpAuthentication::Token",
               method_name: :authenticate
+            ),
+            # The `||`'s other operand, and the two frames that carry its halt.
+            # Their TYPES were never in question — what is missing without them
+            # is the proof that reaching this operand RENDERS, which is what
+            # makes the chain's fact sound (felixefelip/steep#126).
+            Seed.new(
+              receiver: "ActionController::HttpAuthentication::Token::ControllerMethods",
+              method_name: :request_http_token_authentication
+            ),
+            Seed.new(
+              receiver: "ActionController::HttpAuthentication::Token",
+              method_name: :authentication_request
             )
           ].freeze
 

--- a/lib/rbs_infer/extensions/rails/controllers/framework_source_transcriber.rb
+++ b/lib/rbs_infer/extensions/rails/controllers/framework_source_transcriber.rb
@@ -107,10 +107,15 @@ module RbsInfer
               #
               # The framework's own source, transcribed from the installed gem so
               # the checker can follow the flow an RBS signature cannot express
-              # (felixefelip/rbs_infer#144). Bodies are verbatim: the
-              # bodies land in the owner they were written in, so their constant
-              # references resolve by the same lexical nesting the gem relies on,
-              # and the file mirrors the gem's own path.
+              # (felixefelip/rbs_infer#144). Bodies land in the owner they were
+              # written in, so their constant references resolve by the same
+              # lexical nesting the gem relies on, and the file mirrors the gem's
+              # own path.
+              #
+              # Verbatim but for one mechanical rewrite: `x.__send__(:foo, …)`
+              # and its `send`/`public_send` siblings are written `x.foo(…)`.
+              # Steep resolves none of the three, so the call would be a dead end
+              # for every fact that depends on what it reached.
 
             HEADER
           end
@@ -125,7 +130,49 @@ module RbsInfer
             return nil unless file && line && File.file?(file)
 
             node = def_node_at(file, line) or return nil
-            [file, owner.split("::"), dedent(node.slice, node.location.start_column)]
+            [file, owner.split("::"), dedent(desugar_dynamic_sends(node), node.location.start_column)]
+          end
+
+          # `controller.__send__ :render, …` → `controller.render …`
+          #
+          # The one deviation from a verbatim body, and a mechanical one: the
+          # same call written without the indirection. Steep resolves none of
+          # `__send__`, `send` or `public_send` — measured, all three type as
+          # their `Kernel`/`BasicObject` declaration returning `untyped` — so the
+          # call-graph edge is lost, and with it every fact that depends on what
+          # the method reached. Rails renders the 401 that way, and that render
+          # is what proves the `||` tail halts (felixefelip/steep#126).
+          #
+          # Only with a LITERAL symbol: with a variable there is no name to put
+          # in its place. And only meaning-preserving while the target is public
+          # — `__send__` reaches private methods, a plain call does not. When it
+          # is not, the transcription reports a visibility error the real code
+          # does not have: wrong, but wrong out loud, which is the trade taken
+          # rather than teaching the checker to read symbols.
+          SEND_ALIASES = %i[__send__ send public_send].freeze
+
+          def desugar_dynamic_sends(node)
+            source = node.slice.dup
+            origin = node.location.start_offset
+
+            edits = RbsInfer::Analyzer.find_all_nodes(node) { |n| dynamic_send?(n) }.flat_map do |call|
+              symbol, *rest = call.arguments.arguments
+              # The argument list loses the symbol; the message keeps its place,
+              # spelled with the symbol's own name.
+              [[call.message_loc.start_offset - origin, call.message_loc.end_offset - origin, symbol.unescaped],
+               [symbol.location.start_offset - origin,
+                (rest.first&.location&.start_offset || symbol.location.end_offset) - origin, ""]]
+            end
+
+            # Back to front, so an earlier edit cannot shift a later offset.
+            edits.sort_by { |start, _, _| -start }.each { |start, finish, text| source[start...finish] = text }
+            source
+          end
+
+          def dynamic_send?(node)
+            return false unless node.is_a?(Prism::CallNode) && SEND_ALIASES.include?(node.name)
+
+            node.arguments&.arguments&.first.is_a?(Prism::SymbolNode)
           end
 
           def resolve(seed)

--- a/spec/dummy/.gem_rbs_collection/actionpack/7.2/actioncontroller.rbs
+++ b/spec/dummy/.gem_rbs_collection/actionpack/7.2/actioncontroller.rbs
@@ -101,7 +101,6 @@ module ActionController
       extend ::ActionController::HttpAuthentication::Token
 
       module ControllerMethods
-        def request_http_token_authentication: (?String realm, ?String? message) -> void
       end
 
       def token_and_options: (ActionDispatch::Request request) -> [String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]]?
@@ -116,7 +115,6 @@ module ActionController
 
       def encode_credentials: (String token, ?::Hash[untyped, untyped] options) -> ::String
 
-      def authentication_request: (instance controller, String realm, ?String? message) -> void
     end
   end
 end

--- a/spec/dummy/sig/generated/steep_controller_runtime/action_controller/metal/http_authentication.rb
+++ b/spec/dummy/sig/generated/steep_controller_runtime/action_controller/metal/http_authentication.rb
@@ -26,6 +26,10 @@ module ActionController
         def authenticate_with_http_token(&login_procedure)
           Token.authenticate(self, &login_procedure)
         end
+
+        def request_http_token_authentication(realm = "Application", message = nil)
+          Token.authentication_request(self, realm, message)
+        end
       end
     end
   end
@@ -39,6 +43,12 @@ module ActionController
         unless token.blank?
           login_procedure.call(token, options)
         end
+      end
+
+      def authentication_request(controller, realm, message = nil)
+        message ||= "HTTP Token: Access denied.\n"
+        controller.headers["WWW-Authenticate"] = %(Token realm="#{realm.tr('"', "")}")
+        controller.render plain: message, status: :unauthorized
       end
     end
   end

--- a/spec/dummy/sig/generated/steep_controller_runtime/action_controller/metal/http_authentication.rb
+++ b/spec/dummy/sig/generated/steep_controller_runtime/action_controller/metal/http_authentication.rb
@@ -5,10 +5,15 @@
 #
 # The framework's own source, transcribed from the installed gem so
 # the checker can follow the flow an RBS signature cannot express
-# (felixefelip/rbs_infer#144). Bodies are verbatim: the
-# bodies land in the owner they were written in, so their constant
-# references resolve by the same lexical nesting the gem relies on,
-# and the file mirrors the gem's own path.
+# (felixefelip/rbs_infer#144). Bodies land in the owner they were
+# written in, so their constant references resolve by the same
+# lexical nesting the gem relies on, and the file mirrors the gem's
+# own path.
+#
+# Verbatim but for one mechanical rewrite: `x.__send__(:foo, …)`
+# and its `send`/`public_send` siblings are written `x.foo(…)`.
+# Steep resolves none of the three, so the call would be a dead end
+# for every fact that depends on what it reached.
 
 module ActionController
   module HttpAuthentication

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/action_controller/metal/http_authentication.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/action_controller/metal/http_authentication.rbs
@@ -3,9 +3,11 @@ module ActionController
     module Token::ControllerMethods
       def authenticate_or_request_with_http_token: (?String realm, ?untyped message) { (String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?) -> untyped } -> untyped
       def authenticate_with_http_token: () { (String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?) -> untyped } -> untyped
+      def request_http_token_authentication: (?String realm, ?untyped message) -> untyped
     end
     module Token
       def authenticate: (untyped controller) { (String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?) -> untyped } -> untyped
+      def authentication_request: (untyped controller, String realm, ?untyped message) -> untyped
     end
   end
 end

--- a/spec/dummy/sig/rbs_rails/app/models/user.rbs
+++ b/spec/dummy/sig/rbs_rails/app/models/user.rbs
@@ -324,11 +324,8 @@ class ::User < ::ApplicationRecord
 
     def updated_at_for_database: () -> ::Time?
 
-    def avatar: () -> ::String?
 
-    def avatar=: (::String?) -> ::String?
 
-    def avatar?: () -> bool
 
     def avatar_changed?: (?from: ::String?, ?to: ::String?) -> bool
 

--- a/spec/dummy/sig/rbs_rails/app/models/user.rbs
+++ b/spec/dummy/sig/rbs_rails/app/models/user.rbs
@@ -324,8 +324,11 @@ class ::User < ::ApplicationRecord
 
     def updated_at_for_database: () -> ::Time?
 
+    def avatar: () -> ::String?
 
+    def avatar=: (::String?) -> ::String?
 
+    def avatar?: () -> bool
 
     def avatar_changed?: (?from: ::String?, ?to: ::String?) -> bool
 

--- a/spec/expectations/steep_controller_runtime/action_controller/metal/http_authentication.rbs
+++ b/spec/expectations/steep_controller_runtime/action_controller/metal/http_authentication.rbs
@@ -3,9 +3,11 @@ module ActionController
     module Token::ControllerMethods
       def authenticate_or_request_with_http_token: (?String realm, ?untyped message) { (String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?) -> untyped } -> untyped
       def authenticate_with_http_token: () { (String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?) -> untyped } -> untyped
+      def request_http_token_authentication: (?String realm, ?untyped message) -> untyped
     end
     module Token
       def authenticate: (untyped controller) { (String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?) -> untyped } -> untyped
+      def authentication_request: (untyped controller, String realm, ?untyped message) -> untyped
     end
   end
 end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -533,6 +533,31 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
       assert_runtime_rbs("steep_controller_runtime")
     end
 
+    # The transcription's own pseudo-code, which nothing else compared with a
+    # fresh generation: `assert_runtime_rbs` derives the `.rbs` FROM the
+    # checked-in `.rb`, so a stale body yields a consistent, stale signature and
+    # the suite stays green. The Devise generator has had this guard all along
+    # (felixefelip/rbs_infer#160).
+    it "emits the transcription checked into the dummy" do
+      # Inside the example, not at the top: the seeds are reflected off real
+      # constants, so the framework has to be loaded — and loading it from a
+      # file's top level is what made `transcribe_framework:` a parameter rather
+      # than a detection in the first place (felixefelip/rbs_infer#146).
+      require "action_controller"
+      require "rbs_infer/extensions/rails/controllers/framework_source_transcriber"
+
+      files = RbsInfer::Extensions::Rails::Controllers::FrameworkSourceTranscriber.new.build
+      expect(files).not_to be_empty
+
+      aggregate_failures do
+        files.each do |file|
+          checked_in = Pathname.new("sig/generated/steep_controller_runtime").join(file[:filename])
+          expect(file[:source]).to eq(checked_in.read),
+                                   "#{checked_in} is stale — re-run `rake rbs_infer:controller_runtime:all`"
+        end
+      end
+    end
+
     it "view runtime" do
       assert_runtime_rbs("steep_actionview_runtime")
     end

--- a/spec/lib/rbs_infer/extensions/rails/controllers/framework_source_transcriber_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/controllers/framework_source_transcriber_spec.rb
@@ -92,4 +92,42 @@ RSpec.describe RbsInfer::Extensions::Rails::Controllers::FrameworkSourceTranscri
 
     expect(described_class.new.build).to be_empty
   end
+
+  # felixefelip/rbs_infer#160. The one deviation from a verbatim body, applied
+  # because Steep resolves NONE of `__send__`, `send`, `public_send` — all three
+  # type as their `Kernel`/`BasicObject` declaration and return `untyped`, so the
+  # call is a dead end for the flow the transcription exists to expose.
+  describe "desugaring a dynamic send" do
+    def desugar(ruby)
+      node = RbsInfer::Analyzer.find_all_nodes(Prism.parse(ruby).value) { |n| n.is_a?(Prism::DefNode) }.first
+      described_class.new.send(:desugar_dynamic_sends, node)
+    end
+
+    it "writes the call without the indirection, keeping the other arguments" do
+      expect(desugar(<<~RUBY)).to include("controller.render plain: message, status: :unauthorized")
+        def authentication_request(controller, message)
+          controller.__send__ :render, plain: message, status: :unauthorized
+        end
+      RUBY
+    end
+
+    it "covers `send` and `public_send`, which resolve no better" do
+      expect(desugar("def a(c); c.send(:render, 1); end")).to include("c.render(1)")
+      expect(desugar("def a(c); c.public_send(:render, 1); end")).to include("c.render(1)")
+    end
+
+    it "handles a call whose only argument is the symbol" do
+      expect(desugar("def a(c); c.__send__(:reset); end")).to include("c.reset()")
+    end
+
+    # With a variable there is no name to put in the message's place, so the
+    # call stays as written — and stays a dead end, honestly.
+    it "leaves a dynamic name alone" do
+      expect(desugar("def a(c, name); c.__send__(name, 1); end")).to include("c.__send__(name, 1)")
+    end
+
+    it "leaves an ordinary call alone" do
+      expect(desugar("def a(c); c.render(1); end")).to include("c.render(1)")
+    end
+  end
 end

--- a/spec/lib/rbs_infer/extensions/rails/controllers/framework_source_transcriber_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/controllers/framework_source_transcriber_spec.rb
@@ -3,6 +3,7 @@ require "rbs_infer"
 require "action_controller"
 require "tmpdir"
 require "rbs_infer/extensions/rails/controllers/framework_source_transcriber"
+require "rbs_infer/extensions/rails/controllers/runtime_generator"
 
 RSpec.describe RbsInfer::Extensions::Rails::Controllers::FrameworkSourceTranscriber do
   subject(:source) { files.map { |f| f[:source] }.join("\n") }
@@ -56,6 +57,31 @@ RSpec.describe RbsInfer::Extensions::Rails::Controllers::FrameworkSourceTranscri
     expect(source).to include("module Token\n      module ControllerMethods\n")
     expect(source).to include("def authenticate_or_request_with_http_token")
     expect(source).to include("def authenticate_with_http_token")
+  end
+
+  # The `||`'s other operand, and the frame that hands `self` to it. Their TYPES
+  # were never in question — what is missing without them is the proof that
+  # reaching this operand RENDERS, which is what makes the fact the block
+  # establishes sound on every other exit (felixefelip/steep#126).
+  it "transcribes the halting tail of the chain" do
+    expect(source).to include("def request_http_token_authentication")
+
+    real_body("ActionController::HttpAuthentication::Token", :authentication_request).lines.each do |line|
+      next if line.strip.empty?
+
+      expect(source).to include(line.strip)
+    end
+  end
+
+  # And the rewrite is not hypothetical: that render is written as a dynamic
+  # send, so a verbatim transcription would be a dead end at exactly the point
+  # where the halt has to be seen.
+  it "leaves no dynamic send behind" do
+    # The header names the rewrite, so the assertion is about the code below it.
+    code = source.lines.reject { |line| line.start_with?("#") }.join
+
+    expect(code).to include("controller.render")
+    expect(code).not_to include("__send__")
   end
 
   it "rewrites nothing, not even a def line" do

--- a/spec/lib/rbs_infer/extensions/rails/controllers/framework_source_transcriber_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/controllers/framework_source_transcriber_spec.rb
@@ -25,11 +25,15 @@ RSpec.describe RbsInfer::Extensions::Rails::Controllers::FrameworkSourceTranscri
     node = RbsInfer::Analyzer.find_all_nodes(result.value) { |n| n.is_a?(Prism::DefNode) }
                              .find { |n| n.location.start_line == line }
     margin = node.location.start_column
-    first, *rest = node.slice.lines
+    # Desugared like the transcription itself, so a dynamic send does not read
+    # as a discrepancy: the body is the gem's MODULO the one declared rewrite
+    # (felixefelip/rbs_infer#160). Without this the assertion below turns into a
+    # landmine — it passes only while no seed's body contains a `__send__`.
+    first, *rest = described_class.new.send(:desugar_dynamic_sends, node).lines
     ([first] + rest.map { |l| l.strip.empty? ? l : l.sub(/\A {0,#{margin}}/, "") }).join
   end
 
-  it "transcribes the body verbatim from the installed gem" do
+  it "transcribes the body from the installed gem, modulo the declared rewrite" do
     body = real_body(
       "ActionController::HttpAuthentication::Token::ControllerMethods",
       :authenticate_or_request_with_http_token


### PR DESCRIPTION
Rails renders the 401 that gates the whole auth chain through a dynamic send:

```ruby
controller.__send__ :render, plain: message, status: :unauthorized
```

and Steep resolves none of the three spellings. Measured:

```
"abc".upcase                 decls=["::String#upcase"]         ::String
"abc".__send__(:upcase)      decls=["::BasicObject#__send__"]   untyped
"abc".send(:upcase)          decls=["::Kernel#send"]            untyped
"abc".public_send(:upcase)   decls=["::Kernel#public_send"]     untyped
```

So the call is a dead end for every fact that depends on what it reached — and what it reaches here is the render that proves the `||` tail halts (felixefelip/steep#126).

## The rewrite

The transcription now writes the call without the indirection: `x.__send__(:foo, …)` → `x.foo(…)`, and the same for `send`/`public_send`.

This is the **one** deviation from a verbatim body, and it is mechanical — one universal rewrite, in the spirit of the macro desugaring the pipeline already does. It is not a hand-written account of what Rails "effectively does", which is what #144 exists to avoid.

Only with a **literal symbol**. With a variable there is no name to put in the message's place, and the call stays as written — a dead end, honestly.

## The caveat, stated in the code

Meaning is preserved while the target is **public**, which `render` is — measured on `ActionController::Base` and `ActionController::API`.

Where a target is private, the transcription would report a visibility error the real code does not have: wrong, but wrong **out loud**, and far cheaper than the alternative — teaching the checker to read symbols, which is a core change covering three methods with three different visibility semantics.

The generated file's header says all this, because a transcription that diverges from the gem has to say where.

## The seeds that make it non-inert

The rewrite landed with nothing to rewrite: the seed list stopped at `Token.authenticate`, so it never reached the method containing the `__send__`. The last commit adds the two frames that do — the `||`'s other operand:

```ruby
authenticate_with_http_token(realm, message, &login_procedure) ||
  request_http_token_authentication(realm, message)
```

`request_http_token_authentication` hands `self` to `Token.authentication_request`, which renders on the controller it was given. Their **types** were never in question; what is missing without them is the proof that reaching this operand **halts**, which is what makes the fact the block establishes sound on every other exit.

The sidecar now carries `controller.render plain: message, status: :unauthorized`.

**Depends on felixefelip/gem_rbs_collection#5**, which removes the two matching declarations exactly as #4 did for the first three — RBS refuses two declarations of one method on one owner, and a body cannot move.

## Where this leaves #144

| | | |
|---|---|---|
| 1 | two missing seeds | **this PR** |
| 2 | `authentication_request: (instance controller, …)` in the collection fork | **collection#5** |
| 3 | `__send__` opaque | **this PR** |
| 4 | the call-site rule does not see a block nested in conditionals | open, and blocks first |

Measured in the dummy: Steep stays at its **32-problem baseline** — the transcribed bodies introduce no errors.

The halt is still not *proven*, and the reason is now a new one, worth naming: `authentication_request`'s parameter comes out `untyped`, because `self` inside a mixin module has no type to give it (#159 made that honest), and felixefelip/steep#128 needs a **resolved** declaration to see the render. The next lever is a self-type for `Token::ControllerMethods` — machinery rbs_infer already has in `module_self_type_generator.rb`.

## Checks

**885 examples, 0 failures.**
