### PR TITLE
feat: resolve a concern's `self` at the call sites that scan it

### DIFF
--- a/lib/rbs_infer/inference/caller_file_analyzer.rb
+++ b/lib/rbs_infer/inference/caller_file_analyzer.rb
@@ -133,6 +133,16 @@ module RbsInfer::Inference
           {}
         end
 
+      # A module's instance-method `self` is whoever includes it, which the file
+      # itself does not say — and the annotators already know: `Card::Entropic`
+      # is mixed into `Card`. As a TARGET the file gets the answer injected as an
+      # annotation; as a CALLER it is parsed from disk, so the answer has to be
+      # asked for. Without it `Card::Entropy.for(self)` typed its parameter
+      # `Card::Entropic`, which has no `last_active_at` (felixefelip/rbs_infer#161).
+      module_self_type = RbsInfer::Project::SelfTypeAnnotators.instance_type(
+        path: file, module_name: caller_class_name, source: source
+      )
+
       visitor = NewCallCollector.new(
         target_class: @target_class,
         method_return_types: method_return_types,
@@ -145,6 +155,7 @@ module RbsInfer::Inference
         target_methods: @target_methods,
         match_bare_calls: match_bare,
         self_types_by_method: self_types_by_method,
+        module_self_type: module_self_type,
         established_ivars_by_method: established_ivars_by_method,
         argument_partitions_by_method: argument_partitions_by_method,
         constant_arg_resolver: constant_arg_resolver,

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -28,7 +28,7 @@ module RbsInfer::Inference
       names
     end
 
-    def initialize(target_class:, method_return_types:, local_var_types:, constant_arg_resolver:, defined_class_names:, local_var_read_types: {}, local_var_types_by_method: {}, method_type_resolver: nil, caller_class_name: nil, init_positional_params: [], target_methods: {}, match_bare_calls: false, self_types_by_method: {}, established_ivars_by_method: {}, argument_partitions_by_method: {}, block_methods: Set.new, expression_types: {}, method_owners: {})
+    def initialize(target_class:, method_return_types:, local_var_types:, constant_arg_resolver:, defined_class_names:, local_var_read_types: {}, local_var_types_by_method: {}, method_type_resolver: nil, caller_class_name: nil, init_positional_params: [], target_methods: {}, match_bare_calls: false, self_types_by_method: {}, module_self_type: nil, established_ivars_by_method: {}, argument_partitions_by_method: {}, block_methods: Set.new, expression_types: {}, method_owners: {})
       @target_class = target_class
       # FQNs of classes/modules defined in the file being scanned; disambiguates
       # a relative receiver from a same-simple-name class elsewhere (see
@@ -64,6 +64,10 @@ module RbsInfer::Inference
       # SteepBridge#callback_self_types). Preferred over the lexical class
       # name when resolving `self` inside such a method.
       @self_types_by_method = self_types_by_method
+      # `"Card & Card::Entropic"` — what a module's INSTANCE methods see as
+      # `self`, from the self-type annotators. File-wide, so it applies only to
+      # the module the caller class name names.
+      @module_self_type = module_self_type
       # `{ "set_post" => { "@post" => "(::Post & ::Post::Validated)" } }` — ivars a
       # self-method proves populated once it has run (postconditions sidecar). Applied
       # in source order by `visit_call_node`, so only call sites AFTER the establishing
@@ -93,6 +97,9 @@ module RbsInfer::Inference
       # module's `self` is whoever includes it, so an instance method there
       # cannot claim the module's name (felixefelip/rbs_infer#159).
       @declaration_kinds = []
+      # Enclosing MODULE names, innermost last — only to tell which module the
+      # annotators' self-type answer was about.
+      @module_name_stack = []
       @in_singleton_method = false
       @current_method = nil
     end
@@ -101,9 +108,22 @@ module RbsInfer::Inference
     # the enclosing CLASS — but it does decide what `self` is inside it.
     def visit_module_node(node)
       @declaration_kinds.push(:module)
+      @module_name_stack.push(module_name_for(node))
       super
     ensure
       @declaration_kinds.pop
+      @module_name_stack.pop
+    end
+
+    # A module's FQN, joined with whatever encloses it. Tracked apart from
+    # `@class_name_stack`, which modules deliberately stay out of — a module
+    # name is not a `self` type, and the only thing this answers is WHICH module
+    # the annotators' answer was about (felixefelip/rbs_infer#161).
+    def module_name_for(node)
+      segment = RbsInfer::Analyzer.extract_constant_path(node.constant_path) or return nil
+      outer = @module_name_stack.last || @class_name_stack.last
+
+      outer ? "#{outer}::#{segment}" : segment
     end
 
     def visit_class_node(node)
@@ -671,17 +691,32 @@ module RbsInfer::Inference
         return refined if refined && !refined.empty?
       end
 
-      # Inside a module, an INSTANCE method's `self` is whatever includes it —
-      # unknowable from here, and claiming the module is a lie that reaches the
-      # signature (`Token.authenticate(self, …)` typed its parameter
-      # `ActionController::HttpAuthentication`, which has no `request`).
+      # Inside a module, an INSTANCE method's `self` is whatever includes it.
+      # Unknowable from the nesting — claiming the module is a lie that reaches
+      # the signature (`Token.authenticate(self, …)` typed its parameter
+      # `ActionController::HttpAuthentication`, which has no `request`) — but
+      # not unknowable in general: the self-type annotators answer it for a
+      # covered concern, and that answer is the one the call site should see.
+      # `Card::Entropy.for(self)` needs the `Card` half of `Card & Card::Entropic`
+      # for `last_active_at`. Only for the module the file is named after, so a
+      # sibling module in the same file cannot borrow it.
       # A `def self.x` in a module is different: there `self` IS the module.
-      return "untyped" if !@in_singleton_method && @declaration_kinds.last == :module
+      return module_self_type || "untyped" if !@in_singleton_method && @declaration_kinds.last == :module
 
       base = @class_name_stack.last || @caller_class_name
       return "untyped" unless base
 
       @in_singleton_method ? "singleton(#{base})" : base
+    end
+
+    # The annotators were asked about the file's own module, so the answer holds
+    # for that one and no other: a second module in the same file has its own
+    # includer. An unnameable module (a dynamic constant path) gets the answer
+    # rather than nothing — the file names one concern in every real case.
+    def module_self_type
+      name = @module_name_stack.last
+
+      @module_self_type if name.nil? || name == @caller_class_name
     end
 
     # Resolves a `self.<method>` against the refined `self` type when the

--- a/lib/rbs_infer/project/self_type_annotators.rb
+++ b/lib/rbs_infer/project/self_type_annotators.rb
@@ -61,5 +61,37 @@ module RbsInfer::Project
       end
       target_source
     end
+
+    INSTANCE_ANNOTATION = /\A#\s*@type\s+instance:\s*(?<type>.+?)\s*\z/
+
+    # The type a module's INSTANCE methods see as `self`, or nil when no
+    # annotator covers the file. Same plugins and same entries `apply` injects,
+    # READ instead of injected — a file being scanned for call sites is parsed
+    # as it is on disk, so the annotation is never there, yet its `self` still
+    # has to resolve to something (felixefelip/rbs_infer#161).
+    #
+    # Matched on the anchor, so a file declaring more than one module cannot
+    # borrow a sibling's answer.
+    #
+    # Returned PARENTHESIZED, which the annotation is not: an intersection is
+    # only legal bare in argument position. Measured — `(A & B x) -> void`
+    # parses, `() -> A & B` is a syntax error — and it is the same shape the
+    # callback sidecar already stores (`(::Post & ::Post::Validated)`), so a
+    # type that reaches a return is usable wherever it lands.
+    def instance_type(path:, module_name:, source:)
+      return nil if module_name.nil? || module_name.empty?
+
+      anchor = module_name.split("::").last
+
+      type = @annotators.filter_map do |annotator|
+        annotator.self_type_entries(path: path, module_name: module_name, source: source)
+                 .select { |entry| entry["anchor"] == anchor }
+                 .flat_map { |entry| entry["annotations"] }
+                 .filter_map { |line| line[INSTANCE_ANNOTATION, :type] }
+                 .first
+      end.first
+
+      "(#{type})" if type
+    end
   end
 end

--- a/spec/dummy/app/models/post/tag_digest.rb
+++ b/spec/dummy/app/models/post/tag_digest.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Mirrors Fizzy's `Card::Entropy`: a plain class whose one entry point takes the
+# record a concern hands it, so its parameter type is exactly as good as the
+# `self` that concern resolves to.
+#
+# `published_at` is the HOST's column and `tag_names` is the CONCERN's method,
+# so only `Post & Post::Taggable` has both — the lexical answer `Post::Taggable`
+# is missing half of what the body already uses (felixefelip/rbs_infer#161).
+class Post::TagDigest
+  class << self
+    def for(post)
+      return unless post.published_at
+
+      new(post.title, post.tag_names)
+    end
+  end
+
+  def initialize(title, tag_names)
+    @title = title
+    @tag_names = tag_names
+  end
+
+  def headline
+    "#{@title} (#{@tag_names.size})"
+  end
+end

--- a/spec/dummy/app/models/post/taggable.rb
+++ b/spec/dummy/app/models/post/taggable.rb
@@ -34,6 +34,14 @@ module Post::Taggable
     tags.pluck(:name)
   end
 
+  # The `self` handed out here is the concern's, and a module's instance-method
+  # `self` is whoever includes it — `Post & Post::Taggable`, which the self-type
+  # annotators already say and the call-site scan now asks for. Naming the
+  # module alone loses the host half (felixefelip/rbs_infer#161).
+  def tag_digest
+    Post::TagDigest.for(self)
+  end
+
   def tag_with(name)
     tag = Tag.find_or_create_by!(name: name)
     post_tags.find_or_create_by!(tag: tag)

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -17,6 +17,10 @@ app/models/post/notifiable.rb:
   annotations:
   - "# @type self: singleton(Post) & singleton(Post::Notifiable)"
   - "# @type instance: Post & Post::Notifiable"
+app/models/post/tag_digest.rb:
+  anchor: TagDigest
+  annotations:
+  - "# @type instance: Post & Post::TagDigest"
 app/models/post/taggable.rb:
   anchor: Taggable
   annotations:

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/post/taggable.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/post/taggable.rb
@@ -37,6 +37,14 @@ end
     tags.pluck(:name)
   end
 
+  # The `self` handed out here is the concern's, and a module's instance-method
+  # `self` is whoever includes it — `Post & Post::Taggable`, which the self-type
+  # annotators already say and the call-site scan now asks for. Naming the
+  # module alone loses the host half (felixefelip/rbs_infer#161).
+  def tag_digest
+    Post::TagDigest.for(self)
+  end
+
   def tag_with(name)
     tag = Tag.find_or_create_by!(name: name)
     post_tags.find_or_create_by!(tag: tag)

--- a/spec/dummy/sig/rbs_infer/app/models/post/tag_digest.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/post/tag_digest.rbs
@@ -1,0 +1,8 @@
+class Post
+  class TagDigest
+    def self.for: ((Post & Post::Taggable) post) -> untyped
+
+    def initialize: (untyped title, untyped tag_names) -> untyped
+    def headline: () -> String
+  end
+end

--- a/spec/dummy/sig/rbs_infer/app/models/post/taggable.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/post/taggable.rbs
@@ -10,6 +10,7 @@ class Post
     extend ActiveSupport::Concern
 
     def tag_names: () -> Array[untyped]
+    def tag_digest: () -> untyped
     def tag_with: (untyped name) -> (Tag & Tag::Validated)
     def untag: (untyped name) -> untyped
     def tagged_with?: (untyped name) -> bool

--- a/spec/expectations/models/post/tag_digest.rbs
+++ b/spec/expectations/models/post/tag_digest.rbs
@@ -1,0 +1,8 @@
+class Post
+  class TagDigest
+    def self.for: ((Post & Post::Taggable) post) -> untyped
+
+    def initialize: (untyped title, untyped tag_names) -> untyped
+    def headline: () -> String
+  end
+end

--- a/spec/expectations/models/post/taggable.rbs
+++ b/spec/expectations/models/post/taggable.rbs
@@ -10,6 +10,7 @@ class Post
     extend ActiveSupport::Concern
 
     def tag_names: () -> Array[untyped]
+    def tag_digest: () -> untyped
     def tag_with: (untyped name) -> (Tag & Tag::Validated)
     def untag: (untyped name) -> untyped
     def tagged_with?: (untyped name) -> bool

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -101,6 +101,15 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     assert_snapshot("models/post/archiver", target_class: "Post::Archiver", target_file: "app/models/post/archiver.rb")
   end
 
+  # The same shape one namespace over, and the half `Archiver` cannot show: the
+  # caller is a CONCERN, so `self` is not the enclosing constant but whoever
+  # includes it. The lexical answer `Post::Taggable` has `tag_names` and not
+  # `published_at`; the annotators' `Post & Post::Taggable` has both, and this
+  # snapshot is where the difference shows (felixefelip/rbs_infer#161).
+  it "Post::TagDigest (self handed out by a concern) matches expected RBS" do
+    assert_snapshot("models/post/tag_digest", target_class: "Post::TagDigest", target_file: "app/models/post/tag_digest.rb")
+  end
+
   it "Coupon::Code (constant argument) matches expected RBS" do
     assert_snapshot("models/coupon/code", target_class: "Coupon::Code", target_file: "app/models/coupon/code.rb")
   end

--- a/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
@@ -210,7 +210,8 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
     # should infer the positional `initialize(caderneta)` param as
     # `Caderneta` — `self` resolves to the lexically-enclosing class.
     # Previously `self` fell through to `untyped`.
-    def collect_with_self(source, target_class:, caller_class_name:, init_positional_params:, self_types_by_method: {})
+    def collect_with_self(source, target_class:, caller_class_name:, init_positional_params:,
+                          self_types_by_method: {}, module_self_type: nil)
       result = Prism.parse(source)
       visitor = described_class.new(
         target_class: target_class,
@@ -219,6 +220,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
         caller_class_name: caller_class_name,
         init_positional_params: init_positional_params,
         self_types_by_method: self_types_by_method,
+        module_self_type: module_self_type,
         constant_arg_resolver: null_constant_resolver,
         defined_class_names: described_class.collect_defined_class_names(result.value)
       )
@@ -339,6 +341,75 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
       )
       result.value.accept(visitor)
       expect(visitor.usages.first["owner"]).to eq("untyped")
+    end
+
+    # felixefelip/rbs_infer#161. A module's instance-method `self` is whoever
+    # includes it, which the module does not say — but the self-type annotators
+    # do, and a file scanned for call sites is parsed without the annotation
+    # they would have injected, so the answer is passed in.
+    describe "self inside a module" do
+      let(:source) do
+        <<~RUBY
+          module Post::Taggable
+            def digest
+              Digest.new(self)
+            end
+          end
+        RUBY
+      end
+
+      it "stays untyped when no annotator covers the module" do
+        usages = collect_with_self(
+          source, target_class: "Digest", caller_class_name: "Post::Taggable", init_positional_params: ["post"]
+        )
+        expect(usages.first["post"]).to eq("untyped")
+      end
+
+      it "uses the includer's type when an annotator answers" do
+        usages = collect_with_self(
+          source, target_class: "Digest", caller_class_name: "Post::Taggable",
+          init_positional_params: ["post"], module_self_type: "(Post & Post::Taggable)"
+        )
+        expect(usages.first["post"]).to eq("(Post & Post::Taggable)")
+      end
+
+      # The annotators were asked about one module; a different one in the same
+      # file has its own includer and must not inherit the answer.
+      it "does not lend the answer to a sibling module" do
+        nested = <<~RUBY
+          module Post
+            module Other
+              def digest
+                Digest.new(self)
+              end
+            end
+          end
+        RUBY
+
+        usages = collect_with_self(
+          nested, target_class: "Digest", caller_class_name: "Post::Taggable",
+          init_positional_params: ["post"], module_self_type: "(Post & Post::Taggable)"
+        )
+        expect(usages.first["post"]).to eq("untyped")
+      end
+
+      # A `def self.x` in a module is not a mixin method: there `self` IS the
+      # module, and the annotators' instance answer does not apply.
+      it "leaves a singleton method resolving to the module itself" do
+        singleton = <<~RUBY
+          module Post::Taggable
+            def self.digest_all
+              Digest.new(self)
+            end
+          end
+        RUBY
+
+        usages = collect_with_self(
+          singleton, target_class: "Digest", caller_class_name: "Post::Taggable",
+          init_positional_params: ["post"], module_self_type: "(Post & Post::Taggable)"
+        )
+        expect(usages.first["post"]).to eq("singleton(Post::Taggable)")
+      end
     end
   end
 

--- a/spec/lib/rbs_infer/project/self_type_annotators_spec.rb
+++ b/spec/lib/rbs_infer/project/self_type_annotators_spec.rb
@@ -82,6 +82,57 @@ RSpec.describe RbsInfer::Project::SelfTypeAnnotators do
     end
   end
 
+  # The same entries `.apply` injects, read rather than injected: a file scanned
+  # for call sites is parsed as it is on disk (felixefelip/rbs_infer#161).
+  describe ".instance_type" do
+    def entry(anchor, *annotations)
+      { "anchor" => anchor, "annotations" => annotations }
+    end
+
+    # Parenthesized, unlike the annotation: `() -> A & B` is a syntax error and
+    # `(A & B x) -> void` is not, so the type has to be usable in both.
+    it "reads the instance annotation the module would have been given" do
+      described_class.register(
+        fake_annotator(seen: [], entries: [entry("Entropic",
+                                                 "# @type self: singleton(Card) & singleton(Card::Entropic)",
+                                                 "# @type instance: Card & Card::Entropic")])
+      )
+
+      expect(described_class.instance_type(path: "app/models/card/entropic.rb", module_name: "Card::Entropic", source: ""))
+        .to eq("(Card & Card::Entropic)")
+    end
+
+    # A file may declare more than one module, and each gets its own entry.
+    it "matches on the anchor, so a sibling's answer cannot be borrowed" do
+      described_class.register(
+        fake_annotator(seen: [], entries: [entry("Other", "# @type instance: Card & Card::Other")])
+      )
+
+      expect(described_class.instance_type(path: "x.rb", module_name: "Card::Entropic", source: "")).to be_nil
+    end
+
+    it "is nil when no annotator covers the file" do
+      expect(described_class.instance_type(path: "x.rb", module_name: "Card::Entropic", source: "")).to be_nil
+    end
+
+    it "is nil for an entry that carries no instance line" do
+      described_class.register(
+        fake_annotator(seen: [], entries: [entry("Entropic", "# @type self: singleton(Card)")])
+      )
+
+      expect(described_class.instance_type(path: "x.rb", module_name: "Card::Entropic", source: "")).to be_nil
+    end
+
+    it "never calls annotators when module_name is blank" do
+      seen = []
+      described_class.register(fake_annotator(seen: seen, entries: [entry("Bar", "# @type instance: X")]))
+
+      expect(described_class.instance_type(path: "x.rb", module_name: nil, source: "")).to be_nil
+      expect(described_class.instance_type(path: "x.rb", module_name: "", source: "")).to be_nil
+      expect(seen).to be_empty
+    end
+  end
+
   describe "default registrations" do
     it "registers the Rails self-type annotators at require time" do
       # Outside the around hook's teardown these are the real registrations.


### PR DESCRIPTION
#159 made a module's instance-method `self` honestly `untyped`: whoever includes it is unknowable from the nesting, and claiming the module is a lie that reaches the signature.

Unknowable from the **nesting** — not unknowable. The self-type annotators already answer it, and the answer was sitting unread. In Fizzy, side by side:

```yaml
# sig/generated/.steep_module_self_types.yml
app/models/card/entropic.rb:
  annotations:
  - "# @type instance: Card & Card::Entropic"
```

```rbs
# sig/generated/app/models/card/entropy.rbs
def self.for: (Card::Entropic card) -> self?
```

from

```ruby
module Card::Entropic
  def entropy
    Card::Entropy.for(self)
  end
end
```

`Card::Entropy.for` reads `card.last_active_at` — the **host's** column. `Card::Entropic` does not have it.

## Why the answer never arrived

`Analyzer` applies the annotators to the **target** file, injecting the annotation before the parse. A file scanned for **call sites** is parsed as it is on disk, so the annotation is never there — and that is precisely the file whose `self` becomes somebody else's parameter.

So the fix is not a new source of truth, it is a second reader of the existing one:

- `SelfTypeAnnotators.instance_type(path:, module_name:, source:)` reads what `apply` injects, matched on the same anchor so a second module in the file cannot borrow a sibling's answer.
- `CallerFileAnalyzer` asks it per caller file and hands it to the collector.
- `NewCallCollector#self_type` consults it exactly where the module rule used to give up. No answer, still `untyped` — #159 stays the honest fallback.

## Three things that only showed up by measuring

**`module Post::Taggable` pushes no name onto the class name stack.** Only `class` does. My first guard ("only for the file's own module") was therefore vacuous — any module in the file would take the answer. Module names are now tracked on their own stack, rather than widening what the class stack means: a module name is not a `self` type, and the only question this answers is *which* module the annotators were asked about.

**An intersection is only legal bare in argument position.**

```
(A & B x) -> void    parses
() -> A & B          Syntax error: unexpected token `&`
```

So `instance_type` returns it parenthesized — the same shape the callback sidecar already stores (`(::Post & ::Post::Validated)`), which keeps the type usable wherever it lands.

**`Post::Digest` collides with the stdlib.** Renamed to `Post::TagDigest`.

## The fixture

`Post::TagDigest`, one namespace over from `Post::Archiver` and showing the half Archiver cannot: Archiver's caller is a class, so its `self` was already right. TagDigest's caller is a **concern**, and its body needs both halves — `published_at` is the host's column, `tag_names` is the concern's method.

```rbs
def self.for: ((Post & Post::Taggable) post) -> untyped
```

Before this branch: `(untyped post)`.

## Blast radius

Not local: every concern that hands `self` to something else changes signature with it. In the dummy nothing else moved, but the dummy has exactly one such shape (the one added here) — the real measurement is a full `rbs_infer` run on an app.

## A pre-existing wart noticed on the way

The module self-type generator emits entries for **classes** too — `post/archiver.rb` and `coupon/code.rb` already had them, and the new `tag_digest.rb` gets `# @type instance: Post & Post::TagDigest`. Harmless here, because the new consultation happens only on the `:module` branch. Not fixed in this PR.

## Next

This is step 1 of two. Step 2 is the same machinery pointed at the framework: `ActionController::Base` includes `HttpAuthentication::Token::ControllerMethods` and `API` does not (measured, `base.rb:261`), so the transcription can record the includer it observes at generation time. That is what gives `Token.authentication_request(self, …)` a real controller, lets `controller.render` resolve, and lets felixefelip/steep#128 see the halt — item 1 of what is left in #144.

## Checks

**897 examples, 0 failures.** Steep's dummy baseline unchanged.
