### PR TITLE
fix: read the return type of a method written in `class << self`

### DIFF
--- a/lib/rbs_infer/signatures/steep_bridge.rb
+++ b/lib/rbs_infer/signatures/steep_bridge.rb
@@ -254,6 +254,12 @@ module RbsInfer::Signatures
     # singleton: {name=>type} }`. `def x` (Prism `:def`) and `def self.x`
     # (`:defs`) used to write the same name-keyed entry, so a homonymous
     # pair leaked one type onto the other (felixefelip/rbs_infer#33).
+    #
+    # A class method has a THIRD spelling, and the node type does not tell it
+    # apart: inside `class << self` it is a plain `:def`. Filed as an instance
+    # method it was then unreachable, because the reader asks by the member's
+    # kind — which is `:class_method` — and every such method stayed `untyped`
+    # while Steep had its type all along (felixefelip/rbs_infer#162).
     def method_return_types_by_kind(source_code)
       typing = type_check(source_code)
       return { instance: {}, singleton: {} } unless typing
@@ -267,12 +273,14 @@ module RbsInfer::Signatures
 
       instance = {}
       singleton = {}
+      singleton_class_defs = singleton_class_def_ids(typing.source.node)
 
       typing.each_typing do |node, _type|
         next unless node.type == :def || node.type == :defs
-        singleton_def = node.type == :defs
-        method_name = singleton_def ? node.children[1].to_s : node.children[0].to_s
-        body = singleton_def ? node.children[3] : node.children[2]
+        plain_def = node.type == :def
+        singleton_def = !plain_def || singleton_class_defs.include?(node.__id__)
+        method_name = plain_def ? node.children[0].to_s : node.children[1].to_s
+        body = plain_def ? node.children[2] : node.children[3]
         next unless body
 
         body_type = typing.type_of(node: body)
@@ -289,6 +297,25 @@ module RbsInfer::Signatures
       end
 
       { instance: instance, singleton: singleton }
+    end
+
+    # Node ids of the `def`s written inside `class << self`.
+    #
+    # `class << obj` is a different thing and is deliberately excluded: those
+    # are singleton methods of THAT object, not of the class. The ivar walker
+    # already treats `:sclass` and `:defs` as one scope for the same reason —
+    # in both, `self` is the class.
+    def singleton_class_def_ids(node, inside: false, result: Set.new)
+      return result unless node.is_a?(Parser::AST::Node)
+
+      case node.type
+      when :sclass then inside = node.children[0]&.type == :self
+      when :class, :module then inside = false
+      when :def then result << node.__id__ if inside
+      end
+
+      node.children.each { |child| singleton_class_def_ids(child, inside: inside, result: result) }
+      result
     end
 
     # Returns { "CONSTANT_NAME" => "Type" } for every `NAME = expr` /

--- a/spec/dummy/sig/rbs_infer/app/models/post/tag_digest.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/post/tag_digest.rbs
@@ -1,6 +1,6 @@
 class Post
   class TagDigest
-    def self.for: ((Post & Post::Taggable) post) -> untyped
+    def self.for: ((Post & Post::Taggable) post) -> Post::TagDigest?
 
     def initialize: (untyped title, untyped tag_names) -> untyped
     def headline: () -> String

--- a/spec/expectations/models/post/tag_digest.rbs
+++ b/spec/expectations/models/post/tag_digest.rbs
@@ -1,6 +1,6 @@
 class Post
   class TagDigest
-    def self.for: ((Post & Post::Taggable) post) -> untyped
+    def self.for: ((Post & Post::Taggable) post) -> Post::TagDigest?
 
     def initialize: (untyped title, untyped tag_names) -> untyped
     def headline: () -> String

--- a/spec/expectations/models/post/taggable.rbs
+++ b/spec/expectations/models/post/taggable.rbs
@@ -10,7 +10,7 @@ class Post
     extend ActiveSupport::Concern
 
     def tag_names: () -> Array[untyped]
-    def tag_digest: () -> untyped
+    def tag_digest: () -> Post::TagDigest?
     def tag_with: (untyped name) -> (Tag & Tag::Validated)
     def untag: (untyped name) -> untyped
     def tagged_with?: (untyped name) -> bool

--- a/spec/lib/rbs_infer/signatures/steep_bridge_spec.rb
+++ b/spec/lib/rbs_infer/signatures/steep_bridge_spec.rb
@@ -346,6 +346,67 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
       # The name-keyed accessor returns instance methods only.
       expect(bridge.method_return_types(code)["tally"]).to eq("Integer")
     end
+
+    # felixefelip/rbs_infer#162. The third spelling of a class method, and the
+    # node type does not tell it apart: inside `class << self` it is a plain
+    # `:def`. Filed as an instance method it became unreachable, because the
+    # reader asks by the member's kind — which is `:class_method`.
+    it "files a `class << self` def as a singleton method" do
+      code = <<~RUBY
+        class Foo
+          class << self
+            def tally
+              "big"
+            end
+          end
+
+          def tally
+            42
+          end
+        end
+      RUBY
+
+      by_kind = bridge.method_return_types_by_kind(code)
+      expect(by_kind[:singleton]["tally"]).to eq("String")
+      expect(by_kind[:instance]["tally"]).to eq("Integer")
+    end
+
+    # `class << obj` opens THAT object's singleton class, so its methods are
+    # not the enclosing class's.
+    it "leaves a `class << other` def where it was" do
+      code = <<~RUBY
+        class Foo
+          OTHER = Object.new
+
+          class << OTHER
+            def tally
+              "big"
+            end
+          end
+        end
+      RUBY
+
+      expect(bridge.method_return_types_by_kind(code)[:singleton]).not_to have_key("tally")
+    end
+
+    # A class body inside the singleton class is out of it again.
+    it "stops at a nested class body" do
+      code = <<~RUBY
+        class Foo
+          class << self
+            class Inner
+              def tally
+                42
+              end
+            end
+          end
+        end
+      RUBY
+
+      by_kind = bridge.method_return_types_by_kind(code)
+      expect(by_kind[:instance]["tally"]).to eq("Integer")
+      expect(by_kind[:singleton]).not_to have_key("tally")
+    end
   end
 
   describe "#method_return_types block generic resolution" do


### PR DESCRIPTION
#33 split Steep's return types by receiver kind, so a `def self.x` and a homonymous `def x` stop clobbering each other. The split reads the node type:

```ruby
singleton_def = node.type == :defs
```

A class method has a **third** spelling, and the node type does not tell it apart. Inside `class << self` it is a plain `:def`, so it was filed as an instance method — and then unreachable, because the reader asks by the member's kind:

```ruby
def steep_returns_for(member, steep_returns)
  member.kind == :class_method ? steep_returns[:singleton] : steep_returns[:instance]
end
```

The two halves disagreed about what counts as a class method, and the type fell through the gap.

## Measured

Steep had the answer the whole time. On the dummy's fixture:

```
{instance: {"for" => "Post::TagDigest", "headline" => "String"}, singleton: {}}
```

```rbs
def self.for: ((Post & Post::Taggable) post) -> untyped
```

Isolated by varying only the spelling, everything else held constant:

| form | result |
|---|---|
| `class << self` + `def build` | `-> untyped` |
| `def self.for` | reads Steep's type |
| `class << self` + `def for` | `-> untyped` |

So it is not the method being named `for` — a keyword, and my first suspicion — and not the early return. Only the `class << self`.

## The fix

Route a `:def` nested in `class << self` to the singleton map.

`class << obj` deliberately stays where it was: those are singleton methods of THAT object, not of the class, and filing them here would trade one error for another. The ivar walker in the same file already treats `:sclass` and `:defs` as one scope for the same reason — in both, `self` is the class. A `class`/`module` body opened inside the singleton class is out of it again.

## Result

```rbs
- def self.for: ((Post & Post::Taggable) post) -> untyped
+ def self.for: ((Post & Post::Taggable) post) -> Post::TagDigest?

- def tag_digest: () -> untyped
+ def tag_digest: () -> Post::TagDigest?
```

The second line is the caller, one file over: the type propagates.

## Worth checking on a real app

Fizzy's `Card::Entropy.for` is also written in `class << self` and currently reads `-> self?`. With the singleton map empty for that class, that value cannot have come from this pass — so it comes from the pre-Steep pass, which has no equivalent guard. If so it is wrong in a second way: on a class method, RBS `self` means `singleton(Card::Entropy)`, not an instance. `self_return?`'s own comment says Steep rejects exactly that body. This PR should turn it into `-> ::Card::Entropy?`; a hypothesis until a real run says otherwise.

## Checks

**900 examples, 0 failures.** One expectation moved beyond the fixture itself — `Post::Taggable`, above — and Steep's dummy baseline is unchanged.
