### PR TITLE
feat: take a module's `self` from the includes that are written

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -101,7 +101,8 @@ module RbsInfer
     # `source` that the pipeline parses.
     if @target_class
       source = RbsInfer::Project::SelfTypeAnnotators.apply(
-        source, detect_source: original_source, path: @target_file, module_name: @target_class
+        source, detect_source: original_source, path: @target_file, module_name: @target_class,
+        mixin_index: mixin_index
       )
     end
 
@@ -978,7 +979,8 @@ module RbsInfer
       target_methods: target_methods,
       steep_bridge: steep_bridge,
       block_methods: block_methods,
-      method_owners: method_owners
+      method_owners: method_owners,
+      mixin_index: mixin_index
     )
     referencing = @source_index.files_referencing(@target_class)
 

--- a/lib/rbs_infer/extensions/rails/class_methods_implements.rb
+++ b/lib/rbs_infer/extensions/rails/class_methods_implements.rb
@@ -27,14 +27,15 @@ module RbsInfer
       #
       # Detection reuses `ClassMethodsExpander.class_methods_block?` so the
       # sidecar and the RBS desugar agree on exactly what a `class_methods`
-      # block is. The including class is derived by the same rule
-      # `ModuleSelfTypeAnnotator` uses for the concern self-type.
+      # block is. The hosts come from the same `ModuleSelfTypeAnnotator.hosts_for`
+      # the concern self-type uses, so the two halves of one concern cannot end
+      # up mixed into different classes.
       module ClassMethodsImplements
         CALL = "class_methods"
 
         module_function
 
-        # @param path [String] source path (for the including-class rule)
+        # @param path [String] source path (for the presumed-host convention)
         # @param module_name [String] the concern's FQN from the AST (e.g.
         #   "Post::Taggable")
         # @param source [String] the file's source
@@ -42,7 +43,7 @@ module RbsInfer
         #   "::<FQN>::ClassMethods"[, "self" => "singleton(::<Includer>) &
         #   ::<FQN>::ClassMethods"] }]` when `source` has at least one
         #   receiverless `class_methods do` block, else `[]`. `self` is omitted
-        #   when no including class can be derived (e.g. a top-level concern).
+        #   when no host is known (e.g. a top-level concern nobody includes).
         def blocks_for(path:, module_name:, source:, mixin_index: nil)
           return [] if module_name.nil? || module_name.empty?
           return [] unless source.include?(CALL)
@@ -59,9 +60,9 @@ module RbsInfer
           entry = { "call" => CALL, "implements" => class_methods }
           # Same resolution the instance self-type uses, so the two halves of a
           # concern cannot end up mixed into different classes.
-          including = ModuleSelfTypeAnnotator.including_classes_for(path, module_name, mixin_index)
-          unless including.empty?
-            singletons = including.map { |klass| "singleton(::#{klass})" }
+          hosts = ModuleSelfTypeAnnotator.hosts_for(path, module_name, mixin_index)
+          unless hosts.empty?
+            singletons = hosts.map { |host| "singleton(::#{host})" }
             entry["self"] = (singletons + [class_methods]).join(" & ")
           end
           [entry]

--- a/lib/rbs_infer/extensions/rails/class_methods_implements.rb
+++ b/lib/rbs_infer/extensions/rails/class_methods_implements.rb
@@ -43,7 +43,7 @@ module RbsInfer
         #   ::<FQN>::ClassMethods"] }]` when `source` has at least one
         #   receiverless `class_methods do` block, else `[]`. `self` is omitted
         #   when no including class can be derived (e.g. a top-level concern).
-        def blocks_for(path:, module_name:, source:)
+        def blocks_for(path:, module_name:, source:, mixin_index: nil)
           return [] if module_name.nil? || module_name.empty?
           return [] unless source.include?(CALL)
 
@@ -57,8 +57,12 @@ module RbsInfer
 
           class_methods = "::#{module_name}::ClassMethods"
           entry = { "call" => CALL, "implements" => class_methods }
-          if (including = ModuleSelfTypeAnnotator.including_class_for(path, module_name))
-            entry["self"] = "singleton(::#{including}) & #{class_methods}"
+          # Same resolution the instance self-type uses, so the two halves of a
+          # concern cannot end up mixed into different classes.
+          including = ModuleSelfTypeAnnotator.including_classes_for(path, module_name, mixin_index)
+          unless including.empty?
+            singletons = including.map { |klass| "singleton(::#{klass})" }
+            entry["self"] = (singletons + [class_methods]).join(" & ")
           end
           [entry]
         end
@@ -80,8 +84,9 @@ module RbsInfer
         # @return [Hash, nil] `{ "anchor" => "ClassMethods", "annotations" =>
         #   ["# @type instance: singleton(::<Includer>) & ::<FQN>::ClassMethods"] }`,
         #   or nil when there's no `class_methods` block or no derivable includer.
-        def self_type_entry(path:, module_name:, source:)
-          self_type = blocks_for(path: path, module_name: module_name, source: source).first&.fetch("self", nil)
+        def self_type_entry(path:, module_name:, source:, mixin_index: nil)
+          self_type = blocks_for(path: path, module_name: module_name, source: source, mixin_index: mixin_index)
+                      .first&.fetch("self", nil)
           return nil unless self_type
 
           {
@@ -92,8 +97,8 @@ module RbsInfer
 
         # SelfTypeAnnotators plugin contract: the desugared `ClassMethods`
         # submodule self-type as a (possibly empty) list of inject-ready entries.
-        def self_type_entries(path:, module_name:, source:)
-          entry = self_type_entry(path: path, module_name: module_name, source: source)
+        def self_type_entries(path:, module_name:, source:, mixin_index: nil)
+          entry = self_type_entry(path: path, module_name: module_name, source: source, mixin_index: mixin_index)
           entry ? [entry] : []
         end
       end

--- a/lib/rbs_infer/extensions/rails/module_self_type_annotator.rb
+++ b/lib/rbs_infer/extensions/rails/module_self_type_annotator.rb
@@ -17,7 +17,6 @@ module RbsInfer
       # Registers on `RbsInfer::Project::SelfTypeAnnotators` so the core injects
       # it without naming this Rails extension (felixefelip/rbs_infer#60).
       module ModuleSelfTypeAnnotator
-        MODELS_PREFIX = "app/models/"
         HELPERS_PREFIX = "app/helpers/"
         CONTROLLER_CONCERNS_PREFIX = "app/controllers/concerns/"
 
@@ -62,22 +61,24 @@ module RbsInfer
           Array(presumed_host_for(path, module_name))
         end
 
-        # The class a concern/module is PRESUMED to be mixed into, by Rails
-        # convention — nothing here reads an `include`. Helpers and controller
-        # concerns are presumed to mix into ApplicationController; a model
-        # concern into its enclosing namespace (`Post::Taggable` → `Post`).
-        # Returns nil when the file isn't under a covered root, or a model
-        # concern has no namespace to guess from.
-        def presumed_host_for(path, module_name)
+        # The class a module is PRESUMED to be mixed into — nothing here reads
+        # an `include`, which is why it only answers where no `include` exists
+        # to read: Rails mixes helpers and controller concerns in itself, and
+        # nobody writes those anywhere.
+        #
+        # There is deliberately no rule for a model concern. Its host is always
+        # written down (`class Card; include Card::Entropic`), so guessing it
+        # from the namespace only ever spoke where the guess was wrong: for
+        # `Test::Filtrable` it answered `Test`, a directory; for the CLASSES
+        # under `app/models/` — `Post::Archiver`, `Coupon::Code` — it claimed an
+        # instance of one is also an instance of its namespace, which nothing
+        # makes true (felixefelip/rbs_infer#163).
+        def presumed_host_for(path, _module_name)
           path = path.to_s
           return "ApplicationController" if path.include?(HELPERS_PREFIX)
           return "ApplicationController" if path.include?(CONTROLLER_CONCERNS_PREFIX)
-          return nil unless path.include?(MODELS_PREFIX)
 
-          parts = module_name.split("::")
-          return nil if parts.size < 2
-
-          parts[0..-2].join("::")
+          nil
         end
 
         def annotations(module_name, hosts, is_concern)

--- a/lib/rbs_infer/extensions/rails/module_self_type_annotator.rb
+++ b/lib/rbs_infer/extensions/rails/module_self_type_annotator.rb
@@ -25,33 +25,48 @@ module RbsInfer
 
         # SelfTypeAnnotators plugin contract: the concern/module self-type as a
         # (possibly empty) list of inject-ready entries.
-        def self_type_entries(path:, module_name:, source:)
-          entry = entry_for(path: path, module_name: module_name, source: source)
+        def self_type_entries(path:, module_name:, source:, mixin_index: nil)
+          entry = entry_for(path: path, module_name: module_name, source: source, mixin_index: mixin_index)
           entry ? [entry] : []
         end
 
         # @param path [String] source path (e.g. "app/models/search/record/sqlite.rb")
         # @param module_name [String] the real FQN from the AST (e.g. "Search::Record::SQLite")
         # @param source [String] the file's source (for concern detection)
+        # @param mixin_index [MixinIndex, nil] the `include`s written in the sources
         # @return [Hash, nil] `{ "anchor" => leaf, "annotations" => [lines] }`, or
-        #   nil when the file isn't a covered module/concern.
-        def entry_for(path:, module_name:, source:)
+        #   nil when nothing says what the module is mixed into.
+        def entry_for(path:, module_name:, source:, mixin_index: nil)
           return nil if module_name.nil? || module_name.empty?
 
-          including_class = including_class_for(path, module_name)
-          return nil unless including_class
+          including_classes = including_classes_for(path, module_name, mixin_index)
+          return nil if including_classes.empty?
 
           anchor = module_name.split("::").last
           is_concern = source.include?("extend ActiveSupport::Concern")
 
-          { "anchor" => anchor, "annotations" => annotations(module_name, including_class, is_concern) }
+          { "anchor" => anchor, "annotations" => annotations(module_name, including_classes, is_concern) }
         end
 
-        # The class a concern/module is mixed into. Helpers and controller
-        # concerns mix into ApplicationController by Rails convention; a model
-        # concern mixes into its enclosing namespace (`Post::Taggable` → `Post`).
-        # Returns nil when the file isn't under a covered root, or a model
-        # concern has no namespace to derive the host from.
+        # Every class a module is mixed into.
+        #
+        # The written `include`s come first: they are what the code says, while
+        # the conventions below are a guess from a file path. The guess stays as
+        # the fallback for what no source shows — a helper is mixed in by Rails
+        # itself, and nobody writes that `include` anywhere
+        # (felixefelip/rbs_infer#163).
+        def including_classes_for(path, module_name, mixin_index)
+          hosts = mixin_index ? mixin_index.hosts_of(module_name) : []
+          return hosts if hosts.any?
+
+          Array(including_class_for(path, module_name))
+        end
+
+        # The class a concern/module is mixed into, by Rails convention.
+        # Helpers and controller concerns mix into ApplicationController; a
+        # model concern mixes into its enclosing namespace (`Post::Taggable` →
+        # `Post`). Returns nil when the file isn't under a covered root, or a
+        # model concern has no namespace to derive the host from.
         def including_class_for(path, module_name)
           path = path.to_s
           return "ApplicationController" if path.include?(HELPERS_PREFIX)
@@ -64,12 +79,12 @@ module RbsInfer
           parts[0..-2].join("::")
         end
 
-        def annotations(module_name, including_class, is_concern)
-          instance = "# @type instance: #{including_class} & #{module_name}"
+        def annotations(module_name, including_classes, is_concern)
+          instance = "# @type instance: #{(including_classes + [module_name]).join(' & ')}"
           return [instance] unless is_concern
 
-          self_line = "# @type self: singleton(#{including_class}) & singleton(#{module_name})"
-          [self_line, instance]
+          singletons = (including_classes + [module_name]).map { |name| "singleton(#{name})" }
+          ["# @type self: #{singletons.join(' & ')}", instance]
         end
       end
 

--- a/lib/rbs_infer/extensions/rails/module_self_type_annotator.rb
+++ b/lib/rbs_infer/extensions/rails/module_self_type_annotator.rb
@@ -8,8 +8,8 @@ module RbsInfer
       # `Steep::Source::ModuleSelfTypes.inject` (felixefelip/rbs_infer#52).
       #
       # This is the Rails-aware half that used to live inside Steep: it knows
-      # the path conventions (models / helpers / controller concerns), the
-      # including-class rule, and concern detection. Unlike the old Steep code
+      # the path conventions (models / helpers / controller concerns), how a
+      # module's hosts are resolved, and concern detection. Unlike the old Steep code
       # it does NOT camelize the file path to get the module name — the caller
       # passes the real name from the AST (`Analyzer#target_class`), so acronyms
       # (`SQLite`, `OAuth`) keep their declared casing.
@@ -39,35 +39,36 @@ module RbsInfer
         def entry_for(path:, module_name:, source:, mixin_index: nil)
           return nil if module_name.nil? || module_name.empty?
 
-          including_classes = including_classes_for(path, module_name, mixin_index)
-          return nil if including_classes.empty?
+          hosts = hosts_for(path, module_name, mixin_index)
+          return nil if hosts.empty?
 
           anchor = module_name.split("::").last
           is_concern = source.include?("extend ActiveSupport::Concern")
 
-          { "anchor" => anchor, "annotations" => annotations(module_name, including_classes, is_concern) }
+          { "anchor" => anchor, "annotations" => annotations(module_name, hosts, is_concern) }
         end
 
         # Every class a module is mixed into.
         #
         # The written `include`s come first: they are what the code says, while
-        # the conventions below are a guess from a file path. The guess stays as
+        # the convention below is a guess from a file path. The guess stays as
         # the fallback for what no source shows — a helper is mixed in by Rails
         # itself, and nobody writes that `include` anywhere
         # (felixefelip/rbs_infer#163).
-        def including_classes_for(path, module_name, mixin_index)
+        def hosts_for(path, module_name, mixin_index)
           hosts = mixin_index ? mixin_index.hosts_of(module_name) : []
           return hosts if hosts.any?
 
-          Array(including_class_for(path, module_name))
+          Array(presumed_host_for(path, module_name))
         end
 
-        # The class a concern/module is mixed into, by Rails convention.
-        # Helpers and controller concerns mix into ApplicationController; a
-        # model concern mixes into its enclosing namespace (`Post::Taggable` →
-        # `Post`). Returns nil when the file isn't under a covered root, or a
-        # model concern has no namespace to derive the host from.
-        def including_class_for(path, module_name)
+        # The class a concern/module is PRESUMED to be mixed into, by Rails
+        # convention — nothing here reads an `include`. Helpers and controller
+        # concerns are presumed to mix into ApplicationController; a model
+        # concern into its enclosing namespace (`Post::Taggable` → `Post`).
+        # Returns nil when the file isn't under a covered root, or a model
+        # concern has no namespace to guess from.
+        def presumed_host_for(path, module_name)
           path = path.to_s
           return "ApplicationController" if path.include?(HELPERS_PREFIX)
           return "ApplicationController" if path.include?(CONTROLLER_CONCERNS_PREFIX)
@@ -79,11 +80,11 @@ module RbsInfer
           parts[0..-2].join("::")
         end
 
-        def annotations(module_name, including_classes, is_concern)
-          instance = "# @type instance: #{(including_classes + [module_name]).join(' & ')}"
+        def annotations(module_name, hosts, is_concern)
+          instance = "# @type instance: #{(hosts + [module_name]).join(' & ')}"
           return [instance] unless is_concern
 
-          singletons = (including_classes + [module_name]).map { |name| "singleton(#{name})" }
+          singletons = (hosts + [module_name]).map { |name| "singleton(#{name})" }
           ["# @type self: #{singletons.join(' & ')}", instance]
         end
       end

--- a/lib/rbs_infer/extensions/rails/module_self_type_generator.rb
+++ b/lib/rbs_infer/extensions/rails/module_self_type_generator.rb
@@ -4,6 +4,10 @@ require "prism"
 require "yaml"
 require "fileutils"
 require_relative "class_methods_implements"
+# The whole gem, not a leaf: this generator now reads the `include`s through
+# `Project::MixinIndex`, which walks sources with the analyzer's own helpers.
+# `rbs_infer.rb` does not load this file, so there is no cycle.
+require "rbs_infer"
 
 module RbsInfer
   module Extensions
@@ -36,6 +40,11 @@ module RbsInfer
         # touching disk conventions twice.
         def build_table
           table = {}
+          # Built here rather than lazily inside `entry_for_file`, whose
+          # `rescue StandardError` would turn a broken index into an empty
+          # table — and an empty table DELETES the sidecar, silently.
+          mixin_index
+
           ROOTS.each do |root|
             Dir.glob(File.join(@app_dir, root, "**/*.rb")).sort.each do |abs|
               rel = relative(abs)
@@ -69,13 +78,29 @@ module RbsInfer
           module_name = extractor.class_name
           return nil unless module_name
 
-          entry = ModuleSelfTypeAnnotator.entry_for(path: rel, module_name: module_name, source: source) || {}
-          blocks = ClassMethodsImplements.blocks_for(path: rel, module_name: module_name, source: source)
+          entry = ModuleSelfTypeAnnotator.entry_for(path: rel, module_name: module_name, source: source,
+                                                    mixin_index: mixin_index) || {}
+          blocks = ClassMethodsImplements.blocks_for(path: rel, module_name: module_name, source: source,
+                                                     mixin_index: mixin_index)
           entry["blocks"] = blocks unless blocks.empty?
 
           entry.empty? ? nil : entry
         rescue StandardError
           nil
+        end
+
+        # The `include`s written across the app, so a module's self-type comes
+        # from what the code says rather than from where its file sits
+        # (felixefelip/rbs_infer#163).
+        #
+        # Globbed wider than ROOTS on purpose — the class that includes a model
+        # concern can live anywhere — and over `sig/` too, so this sidecar and
+        # the in-process annotation read the same sources and cannot disagree.
+        def mixin_index
+          @mixin_index ||= RbsInfer::Project::MixinIndex.new(
+            Dir.glob(File.join(@app_dir, "app/**/*.rb")).sort +
+            Dir.glob(File.join(@app_dir, "sig/**/*.rb")).sort
+          )
         end
 
         def relative(abs)

--- a/lib/rbs_infer/inference/caller_file_analyzer.rb
+++ b/lib/rbs_infer/inference/caller_file_analyzer.rb
@@ -12,7 +12,7 @@ module RbsInfer::Inference
     # covered by `IntraClassCallAnalyzer`. Omitting it would double-count every same-file
     # self-call — the two paths resolve the receiver differently, so the parameter widens
     # into a union instead of failing loudly (required-threaded-deps).
-    def initialize(target_class:, method_type_resolver:, target_file:, init_positional_params: [], target_methods: {}, steep_bridge: nil, block_methods: Set.new, method_owners: {})
+    def initialize(target_class:, method_type_resolver:, target_file:, init_positional_params: [], target_methods: {}, steep_bridge: nil, block_methods: Set.new, method_owners: {}, mixin_index: nil)
       @target_class = target_class
       @target_file = target_file
       @method_type_resolver = method_type_resolver
@@ -23,6 +23,9 @@ module RbsInfer::Inference
       # what the blocks passed to them at these call sites return.
       @block_methods = block_methods
       @method_owners = method_owners
+      # The `include`s written across the sources — what a module's `self` is,
+      # for the files scanned as callers (felixefelip/rbs_infer#163).
+      @mixin_index = mixin_index
       @method_call_usages = Hash.new { |h, k| h[k] = [] }
       @method_block_returns = Hash.new { |h, k| h[k] = [] }
     end
@@ -140,7 +143,7 @@ module RbsInfer::Inference
       # asked for. Without it `Card::Entropy.for(self)` typed its parameter
       # `Card::Entropic`, which has no `last_active_at` (felixefelip/rbs_infer#161).
       module_self_type = RbsInfer::Project::SelfTypeAnnotators.instance_type(
-        path: file, module_name: caller_class_name, source: source
+        path: file, module_name: caller_class_name, source: source, mixin_index: @mixin_index
       )
 
       visitor = NewCallCollector.new(

--- a/lib/rbs_infer/project/mixin_index.rb
+++ b/lib/rbs_infer/project/mixin_index.rb
@@ -18,6 +18,7 @@ module RbsInfer::Project
       @parse_cache = parse_cache || ParseCache.new
       @included_shorts = {}                            # file → Set[short name]
       @files_defining = Hash.new { |h, k| h[k] = [] }  # short name → [file]
+      @includes_by_class = Hash.new { |h, k| h[k] = Set.new } # class FQN → Set[written name]
       build(source_files)
     end
 
@@ -34,6 +35,25 @@ module RbsInfer::Project
         end
       end
       result.to_a
+    end
+
+    # Classes that `include`/`prepend` `module_name`, by FQN — the answer to
+    # "what is `self` inside this module", read off the source instead of
+    # guessed from a naming convention (felixefelip/rbs_infer#163).
+    #
+    # Every one of them, not the first: a module mixed into two classes has two
+    # possible `self`s, and saying one would be a claim the code does not make.
+    #
+    # Matching has to resolve the written name, which is rarely the FQN: Ruby
+    # looks a constant up outward through the enclosing namespaces, so `include
+    # Eventable` inside `class Card` may mean `Card::Eventable` or `::Eventable`.
+    # Every nesting of the host is a candidate.
+    def hosts_of(module_name)
+      target = unqualified(module_name)
+
+      @includes_by_class.filter_map do |host, written|
+        host if written.any? { |name| resolves_to?(name, host, target) }
+      end.sort
     end
 
     private
@@ -67,8 +87,12 @@ module RbsInfer::Project
           next
         end
 
+        written = include_written_names(entry.result.value)
         @files_defining[class_name.split("::").last] << file
-        @included_shorts[file] = include_short_names(entry.result.value)
+        @included_shorts[file] = written.map { |name| name.split("::").last }.to_set
+        # Merged rather than assigned: a class reopened across files carries the
+        # includes of all of them.
+        @includes_by_class[class_name].merge(written)
       end
 
       # A template's bare calls reach whatever its OWNER includes: `post_status_badge(post)`
@@ -83,19 +107,38 @@ module RbsInfer::Project
       end
     end
 
-    # Short names from the arguments of `include A, B::C` / `prepend A`.
-    def include_short_names(root)
-      shorts = Set.new
+    # Whether `written`, as it appears inside `host`, names `target`.
+    def resolves_to?(written, host, target)
+      name = unqualified(written)
+      return true if name == target
+
+      nestings(host).any? { |prefix| "#{prefix}::#{name}" == target }
+    end
+
+    # `"A::B::C"` → `["A", "A::B", "A::B::C"]`, the namespaces a constant
+    # written inside `A::B::C` is looked up against, innermost aside.
+    def nestings(name)
+      parts = name.split("::")
+      parts.each_index.map { |i| parts[0..i].join("::") }
+    end
+
+    def unqualified(name)
+      name.to_s.sub(/\A::/, "")
+    end
+
+    # Names as WRITTEN in the arguments of `include A, B::C` / `prepend A`.
+    def include_written_names(root)
+      names = Set.new
       RbsInfer::Analyzer.find_all_nodes(root) do |n|
         n.is_a?(Prism::CallNode) && n.receiver.nil? &&
           (n.name == :include || n.name == :prepend) && n.arguments
       end.each do |call|
         call.arguments.arguments.each do |arg|
           name = RbsInfer::Analyzer.extract_constant_path(arg)
-          shorts << name.split("::").last if name
+          names << name if name
         end
       end
-      shorts
+      names
     end
   end
 end

--- a/lib/rbs_infer/project/mixin_index.rb
+++ b/lib/rbs_infer/project/mixin_index.rb
@@ -1,18 +1,25 @@
 module RbsInfer::Project
-  # For a target module (concern), resolves the files whose *bare* calls (no
-  # receiver) can reach the module's instance methods.
+  # The project's mixin graph. One pass over every source file, recording what
+  # each one DEFINES and what it `include`s/`prepend`s, to answer the two
+  # questions a mixin raises.
   #
-  # A concern's methods are mixed into the host and called without a receiver —
-  # not only in the host's own file, but in the host's *other* concerns too:
-  # sibling modules share the host's `self`, so a bare `track_event :x` in
-  # `Card::Statuses` reaches `Eventable#track_event` because `Card` includes
-  # both. Those sibling files never name the concern, so the constant-reference
-  # index (`SourceIndex`) doesn't find them.
+  # **Who can call into this module** — `files_reaching`. A concern's methods
+  # are mixed into the host and called without a receiver, not only in the
+  # host's own file but in the host's *other* concerns: sibling modules share
+  # the host's `self`, so a bare `track_event :x` in `Card::Statuses` reaches
+  # `Eventable#track_event` because `Card` includes both. Those sibling files
+  # never name the concern, so the constant-reference index (`SourceIndex`)
+  # doesn't find them. The answer is host files ∪ the files of every sibling
+  # module those hosts also include.
   #
-  # This index parses each file once, recording per file: the class/module it
-  # defines and the short names it `include`s/`prepend`s. From that it answers
-  # `files_reaching(module_name)` = host files (that include the module) ∪ the
-  # files of every sibling module those hosts also include.
+  # **What `self` is inside it** — `hosts_of`, the classes that include it
+  # (felixefelip/rbs_infer#163).
+  #
+  # The two match names differently, on purpose. Reachability keys on the short
+  # name: a false positive only widens a search that is then filtered by what
+  # the calls actually resolve to. A self-type cannot afford one — naming the
+  # wrong host puts a wrong type in a signature — so `hosts_of` resolves the
+  # written name to an FQN the way Ruby does.
   class MixinIndex
     def initialize(source_files, parse_cache: nil)
       @parse_cache = parse_cache || ParseCache.new

--- a/lib/rbs_infer/project/self_type_annotators.rb
+++ b/lib/rbs_infer/project/self_type_annotators.rb
@@ -49,11 +49,12 @@ module RbsInfer::Project
     # returns the annotated source. `detect_source` is what annotators inspect
     # (the original file); `target_source` is what gets parsed (post-expansion).
     # A no-op (no annotators, no matches) returns `target_source` unchanged.
-    def apply(target_source, detect_source:, path:, module_name:)
+    def apply(target_source, detect_source:, path:, module_name:, mixin_index: nil)
       return target_source if module_name.nil? || module_name.empty?
 
       @annotators.each do |annotator|
-        annotator.self_type_entries(path: path, module_name: module_name, source: detect_source).each do |entry|
+        entries_from(annotator, path: path, module_name: module_name,
+                                source: detect_source, mixin_index: mixin_index).each do |entry|
           target_source = Steep::Source::ModuleSelfTypes.inject(
             target_source, annotations: entry["annotations"], anchor: entry["anchor"]
           )
@@ -78,20 +79,37 @@ module RbsInfer::Project
     # parses, `() -> A & B` is a syntax error — and it is the same shape the
     # callback sidecar already stores (`(::Post & ::Post::Validated)`), so a
     # type that reaches a return is usable wherever it lands.
-    def instance_type(path:, module_name:, source:)
+    def instance_type(path:, module_name:, source:, mixin_index: nil)
       return nil if module_name.nil? || module_name.empty?
 
       anchor = module_name.split("::").last
 
       type = @annotators.filter_map do |annotator|
-        annotator.self_type_entries(path: path, module_name: module_name, source: source)
-                 .select { |entry| entry["anchor"] == anchor }
-                 .flat_map { |entry| entry["annotations"] }
-                 .filter_map { |line| line[INSTANCE_ANNOTATION, :type] }
-                 .first
+        entries_from(annotator, path: path, module_name: module_name, source: source, mixin_index: mixin_index)
+          .select { |entry| entry["anchor"] == anchor }
+          .flat_map { |entry| entry["annotations"] }
+          .filter_map { |line| line[INSTANCE_ANNOTATION, :type] }
+          .first
       end.first
 
       "(#{type})" if type
+    end
+
+    # `mixin_index` is passed only to annotators that ask for it, so adding it
+    # to the contract does not break one written against the older three
+    # (felixefelip/rbs_infer#163).
+    def entries_from(annotator, path:, module_name:, source:, mixin_index:)
+      if accepts_mixin_index?(annotator)
+        annotator.self_type_entries(path: path, module_name: module_name, source: source, mixin_index: mixin_index)
+      else
+        annotator.self_type_entries(path: path, module_name: module_name, source: source)
+      end
+    end
+
+    def accepts_mixin_index?(annotator)
+      annotator.method(:self_type_entries).parameters.any? do |kind, name|
+        name == :mixin_index || kind == :keyrest
+      end
     end
   end
 end

--- a/spec/dummy/sig/generated/.steep_contracts.yml
+++ b/spec/dummy/sig/generated/.steep_contracts.yml
@@ -197,21 +197,6 @@ methods:
           kind: self
         method: nickname
     enforced: false
-  Test::Filtrable#filtrable?:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: created_at
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: updated_at
-    enforced: false
   Test::Filtrable#teste:
     requires:
     - kind: not_nil

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -2,12 +2,17 @@
 app/models/concerns/test/filtrable.rb:
   anchor: Filtrable
   annotations:
-  - "# @type self: singleton(Test) & singleton(Test::Filtrable)"
-  - "# @type instance: Test & Test::Filtrable"
+  - "# @type self: singleton(Post) & singleton(Test::Filtrable)"
+  - "# @type instance: Post & Test::Filtrable"
 app/models/coupon/code.rb:
   anchor: Code
   annotations:
   - "# @type instance: Coupon & Coupon::Code"
+app/models/eventable.rb:
+  anchor: Eventable
+  annotations:
+  - "# @type self: singleton(Widget) & singleton(Eventable)"
+  - "# @type instance: Widget & Eventable"
 app/models/post/archiver.rb:
   anchor: Archiver
   annotations:
@@ -62,9 +67,10 @@ app/helpers/application_helper.rb:
 app/helpers/posts_helper.rb:
   anchor: PostsHelper
   annotations:
-  - "# @type instance: ApplicationController & PostsHelper"
+  - "# @type instance: ERBPostsEdit & ERBPostsIndex & ERBPostsNew & ERBPostsShow &
+    PostsHelper"
 app/controllers/concerns/filter_configuration.rb:
   anchor: FilterConfiguration
   annotations:
-  - "# @type self: singleton(ApplicationController) & singleton(FilterConfiguration)"
-  - "# @type instance: ApplicationController & FilterConfiguration"
+  - "# @type self: singleton(PostsController) & singleton(FilterConfiguration)"
+  - "# @type instance: PostsController & FilterConfiguration"

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -4,28 +4,16 @@ app/models/concerns/test/filtrable.rb:
   annotations:
   - "# @type self: singleton(Post) & singleton(Test::Filtrable)"
   - "# @type instance: Post & Test::Filtrable"
-app/models/coupon/code.rb:
-  anchor: Code
-  annotations:
-  - "# @type instance: Coupon & Coupon::Code"
 app/models/eventable.rb:
   anchor: Eventable
   annotations:
   - "# @type self: singleton(Widget) & singleton(Eventable)"
   - "# @type instance: Widget & Eventable"
-app/models/post/archiver.rb:
-  anchor: Archiver
-  annotations:
-  - "# @type instance: Post & Post::Archiver"
 app/models/post/notifiable.rb:
   anchor: Notifiable
   annotations:
   - "# @type self: singleton(Post) & singleton(Post::Notifiable)"
   - "# @type instance: Post & Post::Notifiable"
-app/models/post/tag_digest.rb:
-  anchor: TagDigest
-  annotations:
-  - "# @type instance: Post & Post::TagDigest"
 app/models/post/taggable.rb:
   anchor: Taggable
   annotations:

--- a/spec/dummy/sig/rbs_infer/app/models/concerns/test/filtrable.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/concerns/test/filtrable.rbs
@@ -2,7 +2,7 @@ module Test
   module Filtrable
     extend ActiveSupport::Concern
 
-    def filtrable?: () -> untyped
+    def filtrable?: () -> bool
     def teste: () -> untyped
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/post/taggable.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/post/taggable.rbs
@@ -10,7 +10,7 @@ class Post
     extend ActiveSupport::Concern
 
     def tag_names: () -> Array[untyped]
-    def tag_digest: () -> untyped
+    def tag_digest: () -> Post::TagDigest?
     def tag_with: (untyped name) -> (Tag & Tag::Validated)
     def untag: (untyped name) -> untyped
     def tagged_with?: (untyped name) -> bool

--- a/spec/expectations/models/concerns/test/filtrable.rbs
+++ b/spec/expectations/models/concerns/test/filtrable.rbs
@@ -2,7 +2,7 @@ module Test
   module Filtrable
     extend ActiveSupport::Concern
 
-    def filtrable?: () -> untyped
+    def filtrable?: () -> bool
     def teste: () -> untyped
   end
 end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -1,11 +1,5 @@
-app/models/concerns/test/filtrable.rb:12:27: [error] Type `(::Test & ::Test::Filtrable)` does not have method `updated_at`
-app/models/concerns/test/filtrable.rb:12:4: [error] Type `(::Test & ::Test::Filtrable)` does not have method `created_at`
-app/models/concerns/test/filtrable.rb:16:13: [error] Type `(::Test & ::Test::Filtrable)` does not have method `adddd`
-app/models/concerns/test/filtrable.rb:16:4: [error] Type `(::Test & ::Test::Filtrable)` does not have method `asdasd`
-app/models/concerns/test/filtrable.rb:7:24: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `where`
-app/models/concerns/test/filtrable.rb:7:4: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `scope`
-app/models/concerns/test/filtrable.rb:8:26: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `where`
-app/models/concerns/test/filtrable.rb:8:4: [error] Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `scope`
+app/models/concerns/test/filtrable.rb:16:13: [error] Type `(::Post & ::Test::Filtrable)` does not have method `adddd`
+app/models/concerns/test/filtrable.rb:16:4: [error] Type `(::Post & ::Test::Filtrable)` does not have method `asdasd`
 app/models/example10.rb:27:26: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example14.rb:15:17: [error] Type `(::Example14::User | nil)` does not have method `name`
 app/models/example15.rb:25:25: [error] Type `(::Example15::User | nil)` does not have method `name`

--- a/spec/expectations/steep_contracts.yml
+++ b/spec/expectations/steep_contracts.yml
@@ -197,21 +197,6 @@ methods:
           kind: self
         method: nickname
     enforced: false
-  Test::Filtrable#filtrable?:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: created_at
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: updated_at
-    enforced: false
   Test::Filtrable#teste:
     requires:
     - kind: not_nil

--- a/spec/lib/rbs_infer/extensions/rails/class_methods_implements_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/class_methods_implements_spec.rb
@@ -5,8 +5,14 @@ require "rbs_infer"
 require "rbs_infer/extensions/rails/class_methods_implements"
 
 RSpec.describe RbsInfer::Extensions::Rails::ClassMethodsImplements do
-  def blocks(source, path: "app/models/post/taggable.rb", module_name: "Post::Taggable")
-    described_class.blocks_for(path: path, module_name: module_name, source: source)
+  # A model concern's host is read off the `include` that names it — there is no
+  # convention for one any more (felixefelip/rbs_infer#163), so the index has to
+  # answer or there is no host at all.
+  def blocks(source, path: "app/models/post/taggable.rb", module_name: "Post::Taggable", hosts: ["Post"])
+    described_class.blocks_for(
+      path: path, module_name: module_name, source: source,
+      mixin_index: instance_double(RbsInfer::Project::MixinIndex, hosts_of: hosts)
+    )
   end
 
   it "emits @implements and the includer-singleton self for a `class_methods do` block" do
@@ -31,8 +37,8 @@ RSpec.describe RbsInfer::Extensions::Rails::ClassMethodsImplements do
     )
   end
 
-  it "omits `self` when no including class can be derived (top-level concern)" do
-    result = blocks(<<~RUBY, path: "app/models/concerns/greetable.rb", module_name: "Greetable")
+  it "omits `self` when nobody includes the concern" do
+    result = blocks(<<~RUBY, path: "app/models/concerns/greetable.rb", module_name: "Greetable", hosts: [])
       module Greetable
         extend ActiveSupport::Concern
 
@@ -77,8 +83,11 @@ RSpec.describe RbsInfer::Extensions::Rails::ClassMethodsImplements do
   end
 
   describe ".self_type_entry" do
-    def entry(source, path: "app/models/post/taggable.rb", module_name: "Post::Taggable")
-      described_class.self_type_entry(path: path, module_name: module_name, source: source)
+    def entry(source, path: "app/models/post/taggable.rb", module_name: "Post::Taggable", hosts: ["Post"])
+      described_class.self_type_entry(
+        path: path, module_name: module_name, source: source,
+        mixin_index: instance_double(RbsInfer::Project::MixinIndex, hosts_of: hosts)
+      )
     end
 
     it "anchors the includer-singleton self on the desugared ClassMethods submodule" do
@@ -100,8 +109,8 @@ RSpec.describe RbsInfer::Extensions::Rails::ClassMethodsImplements do
       )
     end
 
-    it "returns nil when no including class can be derived (top-level concern)" do
-      result = entry(<<~RUBY, path: "app/models/concerns/greetable.rb", module_name: "Greetable")
+    it "returns nil when nobody includes the concern" do
+      result = entry(<<~RUBY, path: "app/models/concerns/greetable.rb", module_name: "Greetable", hosts: [])
         module Greetable
           extend ActiveSupport::Concern
 

--- a/spec/lib/rbs_infer/extensions/rails/module_self_type_annotator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/module_self_type_annotator_spec.rb
@@ -65,4 +65,82 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeAnnotator do
       expect(described_class.entry_for(path: "app/models/x.rb", module_name: nil, source: PLAIN_SRC)).to be_nil
     end
   end
+
+  # felixefelip/rbs_infer#163. The conventions above are a guess from a file
+  # path; the `include`s written in the sources are what the code says, so they
+  # answer first and the guess is left for what no source shows.
+  describe "with a mixin index" do
+    def index_answering(hosts)
+      instance_double(RbsInfer::Project::MixinIndex, hosts_of: hosts)
+    end
+
+    it "prefers the written include over the path convention" do
+      # The convention reads the namespace, `Test`, which is not a host at all —
+      # it is the directory the concern happens to sit in.
+      entry = described_class.entry_for(
+        path: "app/models/concerns/test/filtrable.rb",
+        module_name: "Test::Filtrable",
+        source: PLAIN_SRC,
+        mixin_index: index_answering(["Post"])
+      )
+
+      expect(entry["annotations"]).to eq(["# @type instance: Post & Test::Filtrable"])
+    end
+
+    # An intersection, not a union. `self` is one host at a time, so the union
+    # is the truthful type — but Steep raises `Unexpected self_type` on one
+    # (`type_construction.rb#for_new_method`) and the whole method falls to
+    # `untyped`: measured, `PostsHelper`'s four methods all went from `String`
+    # to `untyped`. The intersection resolves against every host's surface,
+    # which is what the callers need, at the cost of accepting a call that only
+    # one of the hosts supports.
+    it "intersects every host when a module is mixed into more than one" do
+      entry = described_class.entry_for(
+        path: "app/helpers/posts_helper.rb",
+        module_name: "PostsHelper",
+        source: PLAIN_SRC,
+        mixin_index: index_answering(%w[ERBPostsIndex ERBPostsShow])
+      )
+
+      expect(entry["annotations"]).to eq(["# @type instance: ERBPostsIndex & ERBPostsShow & PostsHelper"])
+    end
+
+    it "carries the same hosts into the singleton annotation" do
+      entry = described_class.entry_for(
+        path: "app/models/eventable.rb",
+        module_name: "Eventable",
+        source: CONCERN_SRC,
+        mixin_index: index_answering(%w[Card Comment])
+      )
+
+      expect(entry["annotations"]).to eq([
+        "# @type self: singleton(Card) & singleton(Comment) & singleton(Eventable)",
+        "# @type instance: Card & Comment & Eventable"
+      ])
+    end
+
+    # A top-level concern has no namespace to guess from, so before the index it
+    # got no annotation at all.
+    it "answers where the convention had nothing to say" do
+      entry = described_class.entry_for(
+        path: "app/models/trashable.rb",
+        module_name: "Trashable",
+        source: PLAIN_SRC,
+        mixin_index: index_answering(["Card"])
+      )
+
+      expect(entry["annotations"]).to eq(["# @type instance: Card & Trashable"])
+    end
+
+    it "falls back to the convention when nobody includes the module" do
+      entry = described_class.entry_for(
+        path: "app/helpers/posts_helper.rb",
+        module_name: "PostsHelper",
+        source: PLAIN_SRC,
+        mixin_index: index_answering([])
+      )
+
+      expect(entry["annotations"]).to eq(["# @type instance: ApplicationController & PostsHelper"])
+    end
+  end
 end

--- a/spec/lib/rbs_infer/extensions/rails/module_self_type_annotator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/module_self_type_annotator_spec.rb
@@ -5,12 +5,20 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeAnnotator do
   CONCERN_SRC = "module X\n  extend ActiveSupport::Concern\nend\n"
   PLAIN_SRC = "module X\nend\n"
 
+  # A model concern's host comes from the `include` that names it, so these pass
+  # an index (felixefelip/rbs_infer#163). The conventions below cover only what
+  # no source shows.
+  def index_answering(hosts)
+    instance_double(RbsInfer::Project::MixinIndex, hosts_of: hosts)
+  end
+
   describe ".entry_for" do
     it "builds both annotations for a model concern, with the AST-cased name" do
       entry = described_class.entry_for(
         path: "app/models/search/record/sqlite.rb",
         module_name: "Search::Record::SQLite",
-        source: CONCERN_SRC
+        source: CONCERN_SRC,
+        mixin_index: index_answering(["Search::Record"])
       )
 
       expect(entry["anchor"]).to eq("SQLite")
@@ -24,10 +32,21 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeAnnotator do
       entry = described_class.entry_for(
         path: "app/models/post/taggable.rb",
         module_name: "Post::Taggable",
-        source: PLAIN_SRC
+        source: PLAIN_SRC,
+        mixin_index: index_answering(["Post"])
       )
 
       expect(entry["annotations"]).to eq(["# @type instance: Post & Post::Taggable"])
+    end
+
+    # There is no convention for a model concern any more: its host is always
+    # written down, and guessing it from the namespace only ever spoke where the
+    # guess was wrong — `Test::Filtrable` got `Test`, a directory, and the
+    # CLASSES under `app/models/` got a namespace they are not an instance of.
+    it "returns nil for a model concern nobody includes" do
+      expect(
+        described_class.entry_for(path: "app/models/post/taggable.rb", module_name: "Post::Taggable", source: PLAIN_SRC)
+      ).to be_nil
     end
 
     it "uses ApplicationController as the host for helpers" do

--- a/spec/lib/rbs_infer/extensions/rails/module_self_type_generator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/module_self_type_generator_spec.rb
@@ -20,7 +20,10 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeGenerator do
   it "emits the sidecar with the declared (AST) casing, not path camelization" do
     in_app(
       "app/models/search/record/sqlite.rb" =>
-        "module Search::Record::SQLite\n  extend ActiveSupport::Concern\nend\n"
+        "module Search::Record::SQLite\n  extend ActiveSupport::Concern\nend\n",
+      # The host, because the self-type is read off the `include` (#163).
+      "app/models/search/record.rb" =>
+        "class Search::Record\n  include Search::Record::SQLite\nend\n"
     ) do |dir|
       out = described_class.new(app_dir: dir).generate
       table = YAML.safe_load(File.read(out))
@@ -37,6 +40,7 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeGenerator do
   it "covers models, helpers and controller concerns; skips uncovered files" do
     in_app(
       "app/models/post/taggable.rb"            => "module Post::Taggable\nend\n",
+      "app/models/post.rb"                     => "class Post\n  include Post::Taggable\nend\n",
       "app/helpers/posts_helper.rb"            => "module PostsHelper\nend\n",
       "app/controllers/concerns/filterable.rb" => "module Filterable\n  extend ActiveSupport::Concern\nend\n",
       "lib/ignored.rb"                         => "module Ignored\nend\n"
@@ -54,7 +58,7 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeGenerator do
 
   it "adds a `blocks` @implements entry for a concern with `class_methods do`" do
     in_app(
-      "app/models/post/taggable.rb" => <<~RUBY
+      "app/models/post/taggable.rb" => <<~RUBY,
         module Post::Taggable
           extend ActiveSupport::Concern
 
@@ -65,6 +69,7 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeGenerator do
           end
         end
       RUBY
+      "app/models/post.rb" => "class Post\n  include Post::Taggable\nend\n"
     ) do |dir|
       entry = described_class.new(app_dir: dir).build_table.fetch("app/models/post/taggable.rb")
 

--- a/spec/lib/rbs_infer/project/mixin_index_spec.rb
+++ b/spec/lib/rbs_infer/project/mixin_index_spec.rb
@@ -72,4 +72,84 @@ RSpec.describe RbsInfer::Project::MixinIndex do
 
     expect(index.files_reaching("Lonely")).to be_empty
   end
+
+  # felixefelip/rbs_infer#163. What `self` is inside a module, read off the
+  # `include`s that are actually written instead of guessed from a convention.
+  describe "#hosts_of" do
+    it "answers with the class that includes the module" do
+      host = write_file("card.rb", "class Card\n  include Card::Entropic\nend\n")
+      entropic = write_file("card/entropic.rb", "module Card::Entropic\nend\n")
+
+      index = described_class.new([host, entropic])
+
+      expect(index.hosts_of("Card::Entropic")).to contain_exactly("Card")
+    end
+
+    # A module mixed into two classes has two possible `self`s. Naming one would
+    # be a claim the code does not make.
+    it "answers with every host, not the first" do
+      card = write_file("card.rb", "class Card\n  include Eventable\nend\n")
+      comment = write_file("comment.rb", "class Comment\n  include Eventable\nend\n")
+      eventable = write_file("eventable.rb", "module Eventable\nend\n")
+
+      index = described_class.new([card, comment, eventable])
+
+      expect(index.hosts_of("Eventable")).to contain_exactly("Card", "Comment")
+    end
+
+    # Ruby looks a constant up outward through the enclosing namespaces, so the
+    # written name is rarely the FQN.
+    it "resolves a name written relative to the host's namespace" do
+      host = write_file("card.rb", "class Card\n  include Entropic\nend\n")
+      entropic = write_file("card/entropic.rb", "module Card::Entropic\nend\n")
+
+      index = described_class.new([host, entropic])
+
+      expect(index.hosts_of("Card::Entropic")).to contain_exactly("Card")
+    end
+
+    it "resolves a name written absolutely" do
+      host = write_file("card.rb", "class Card\n  include ::Eventable\nend\n")
+      eventable = write_file("eventable.rb", "module Eventable\nend\n")
+
+      index = described_class.new([host, eventable])
+
+      expect(index.hosts_of("::Eventable")).to contain_exactly("Card")
+      expect(index.hosts_of("Eventable")).to contain_exactly("Card")
+    end
+
+    # The short name alone is ambiguous: `ActionController::Base` includes the
+    # `ControllerMethods` of Basic, Digest AND Token.
+    it "does not answer on a short-name collision" do
+      host = write_file("base.rb", <<~RUBY)
+        class ActionController::Base
+          include ActionController::HttpAuthentication::Token::ControllerMethods
+        end
+      RUBY
+      token = write_file("token.rb", "module ActionController::HttpAuthentication::Token::ControllerMethods\nend\n")
+
+      index = described_class.new([host, token])
+
+      expect(index.hosts_of("ActionController::HttpAuthentication::Basic::ControllerMethods")).to be_empty
+      expect(index.hosts_of("ActionController::HttpAuthentication::Token::ControllerMethods"))
+        .to contain_exactly("ActionController::Base")
+    end
+
+    # A class split across files carries the includes of all of them.
+    it "merges the includes of a reopened class" do
+      one = write_file("card.rb", "class Card\n  include Eventable\nend\n")
+      two = write_file("card_extra.rb", "class Card\n  include Searchable\nend\n")
+
+      index = described_class.new([one, two])
+
+      expect(index.hosts_of("Eventable")).to contain_exactly("Card")
+      expect(index.hosts_of("Searchable")).to contain_exactly("Card")
+    end
+
+    it "is empty for a module no one includes" do
+      lonely = write_file("lonely.rb", "module Lonely\nend\n")
+
+      expect(described_class.new([lonely]).hosts_of("Lonely")).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
The self-type of a concern was a guess from its file path:

```ruby
return "ApplicationController" if path.include?(HELPERS_PREFIX)
return nil unless path.include?(MODELS_PREFIX)
parts[0..-2].join("::")        # Card::Entropic → Card
```

Right often enough to be useful, and wrong in ways nothing catches. `Test::Filtrable` sits under `app/models/concerns/test/`, so the convention read the host as `Test` — a directory, not a class. Steep had been reporting six errors against a type nobody has:

```
Type `(::Test & ::Test::Filtrable)` does not have method `created_at`
Type `(singleton(::Test) & singleton(::Test::Filtrable))` does not have method `scope`
```

## The answer was already in the sources

`MixinIndex` parses every `include`/`prepend` in the project — but only to decide which **files** can reach a module's bare calls, keeping the last segment of each name and throwing the rest away.

It now also answers `hosts_of(module_name)`: the classes that include it, by FQN. Matching resolves the written name the way Ruby does, outward through the host's nesting — `include Eventable` inside `class Card` may mean `Card::Eventable` or `::Eventable` — so the short name alone can no longer confuse `Basic::ControllerMethods` with `Token::ControllerMethods`.

Evidence answers first. The conventions stay for what no source shows: a helper is mixed in by Rails itself, and nobody writes that `include` anywhere.

## Every host, intersected

A module mixed into two classes has two possible `self`s, so the truthful type is a **union**. Steep raises on one:

```
RuntimeError: Unexpected self_type: ((::ERBPostsIndex & ::PostsHelper) | (::ERBPostsShow & ::PostsHelper))
  steep/lib/steep/type_construction.rb:344 in `for_new_method'
```

and the method falls to `untyped`. Measured on `PostsHelper`, which four view classes include, holding everything else fixed:

| self type | `post_status_badge` |
|---|---|
| `ApplicationController & PostsHelper` | `-> String` |
| `ERBPostsIndex & PostsHelper` | `-> String` |
| `(ERBPostsIndex & PostsHelper) \| (ERBPostsShow & PostsHelper)` | `-> untyped` |

Each host **alone** resolves, including the view class — it is not that the pseudo-code class is poor, it has `include ActionViewContext`. The union is the blocker, and putting the convention's host back into it does not help.

So the hosts are intersected. It over-permits by construction: a call only one host supports still resolves. That is the same trade the convention was already making silently — asserting `ApplicationController` for a helper that actually runs in a view context — now made in the open, and from evidence.

The union stays available the day `for_new_method` accepts one; nothing else here would have to change.

## Measured

| | |
|---|---|
| `Test::Filtrable#filtrable?` | `untyped` → `bool` |
| steep baseline | **6 errors gone**, none added |
| `.steep_contracts.yml` | a `not_nil` contract on `created_at`/`updated_at` disappears — it existed only because the call did not resolve |
| `FilterConfiguration` | `ApplicationController` → `PostsController`, who actually includes it |
| `Eventable` | no annotation at all → `Widget & Eventable` (a top-level concern has no namespace to guess from) |

## Plumbing

`mixin_index:` joins the annotator contract, passed only to annotators that ask for it, so a plugin written against the older three keyword arguments keeps working.

The YAML sidecar generator builds its own index over `app/**/*.rb` **and** `sig/**/*.rb`, wider than its own ROOTS on purpose — the class that includes a model concern can live anywhere — so `steep check` and the in-process annotation read the same sources and cannot disagree.

One trap disarmed on the way: `entry_for_file` rescues `StandardError`, and an empty table **deletes** the sidecar. A missing require turned that into a silently vanished file, so the index is now built before the loop, where an error is loud.

## Next

This is the machinery. The framework half — emitting `class ActionController::Base; include …::Token::ControllerMethods; end` into the transcribed runtime so the same index answers for it — is the follow-up, and it is what finally gives `Token.authentication_request(self, …)` a real controller (felixefelip/rbs_infer#144).

## Checks

**912 examples, 0 failures.**
