### PR TITLE
test: Example20 — the block call two conditionals deep, with a halting else

### DIFF
--- a/spec/dummy/app/models/example20.rb
+++ b/spec/dummy/app/models/example20.rb
@@ -1,0 +1,140 @@
+# Example19, with the ONE change that is left between here and the real chain:
+# WHERE the call carrying the block sits.
+#
+# Example19 closes because the block call is the method's value, and the rule
+# that turns "the block established X" into a fact about the method that passed
+# it reads exactly that (`collect_block_call_establishments`):
+#
+#     value = returned_value(body)
+#     return [] unless value&.type == :block
+#
+# `returned_value` unwraps one `if`, and only a one-armed one. Fizzy nests two,
+# and the inner one has an `else`:
+#
+#     def authenticate_by_bearer_token
+#       if request.authorization.to_s.include?("Bearer")
+#         if bearer_token_authenticatable_request?
+#           authenticate_or_request_with_http_token do |token|
+#             Current.identity = identity if identity = Identity.find_by_...
+#           end
+#         else
+#           request_http_token_authentication          # halts
+#         end
+#       end
+#     end
+#
+# Refusing an `else` is right in general — with one, the block may never run, so
+# the fact does not hold unconditionally. But this `else` HALTS, which is what
+# makes the fact sound on every exit that returns: either the block ran and
+# answered, or nothing returned at all. That is the shape felixefelip/steep#121
+# already models for a constant WRITE — a clause whose alternative halts — so
+# the fact should come out halt-gated and compose with what exists, rather than
+# needing new machinery.
+#
+# Everything else is Example19's, deliberately: the halt still lands on an
+# argument (proven by felixefelip/steep#127), the block still crosses the object
+# boundary, `Registry.user` is still written inside the block. If `show` stops
+# being an error, the nesting is the only thing that changed.
+#
+# Until then, `show` is a type error. That is the point of the fixture.
+class Example20
+  class User
+    attr_reader :name
+
+    def initialize(name:)
+      @name = name
+    end
+  end
+
+  class Registry
+    def self.user
+      @user
+    end
+
+    def self.user=(value)
+      @user = value
+    end
+  end
+
+  module Responder
+    def self.deny(host, message)
+      host.record(message)
+      host.halt
+    end
+  end
+
+  def show
+    "Hi, #{Registry.user.name.upcase}!"
+  end
+
+  def call
+    authenticate
+
+    return if @halted
+
+    show
+  end
+
+  # Public because `Responder.deny` calls it from outside.
+  def halt
+    @halted = true
+  end
+
+  def record(message)
+    @message = message
+  end
+
+  private
+
+  def authenticate
+    from_token || refuse
+  end
+
+  # The one difference from Example19. The block call is two conditionals deep,
+  # and the inner alternative is the halt.
+  def from_token
+    if bearer_request?
+      if json_request?
+        with_token do |token|
+          if user = lookup(token)
+            Registry.user = user
+          end
+        end
+      else
+        refuse
+      end
+    end
+  end
+
+  def with_token(&block)
+    fetch_token(&block) || refuse
+  end
+
+  def fetch_token(&block)
+    token = token_value
+
+    unless token.empty?
+      block.call(token)
+    end
+  end
+
+  def refuse
+    Responder.deny(self, "denied")
+  end
+
+  def lookup(token)
+    User.new(name: "token") if token.start_with?("t")
+  end
+
+  def bearer_request?
+    token_value.start_with?("t")
+  end
+
+  def json_request?
+    ENV.fetch("EXAMPLE20_FORMAT", "json") == "json"
+  end
+
+  def token_value
+    ENV.fetch("EXAMPLE20_TOKEN", "")
+  end
+end

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -769,6 +769,47 @@ postconditions:
   effects:
     may_write:
     - "@name"
+- class: Example20
+  method: fetch_token
+  when_true:
+    block_truthy: true
+- class: Example20
+  method: halt
+  unconditional:
+    ivars:
+      "@halted": 'true'
+    self: "::Example20 & ::Example20::AfterHalt"
+  effects:
+    may_write:
+    - "@halted"
+- class: Example20
+  method: record
+  effects:
+    may_write:
+    - "@message"
+- class: Example20
+  method: with_token
+  conditional_block_truthy:
+    gate_ivar: "@halted"
+- class: Example20::Registry
+  method: user
+  effects:
+    returns_ivar: "@user"
+- class: Example20::Registry
+  method: user=
+  unconditional:
+    ivars:
+      "@user": "::Example20::User"
+    establishes_consts:
+      user: "::Example20::User"
+  effects:
+    may_write:
+    - "@user"
+- class: Example20::User
+  method: initialize
+  effects:
+    may_write:
+    - "@name"
 - class: Example2::Foo
   method: user=
   unconditional:

--- a/spec/dummy/sig/rbs_infer/app/models/example20.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example20.rbs
@@ -1,0 +1,42 @@
+class Example20
+  @halted: true?
+  @message: String?
+
+  module Responder
+    def self.deny: (Example20 host, String message) -> bool
+  end
+
+  def show: () -> String
+  def call: () -> String?
+  def halt: () -> bool
+  def record: (String? message) -> String?
+
+  private
+
+  def authenticate: () -> (Example20::User | bool)
+  def from_token: () -> (Example20::User | bool | nil)
+  def with_token: () { (String) -> Example20::User? } -> (Example20::User | bool)
+  def fetch_token: () { (String) -> Example20::User? } -> Example20::User?
+  def refuse: () -> bool
+  def lookup: (String token) -> Example20::User?
+  def bearer_request?: () -> bool
+  def json_request?: () -> bool
+  def token_value: () -> String
+end
+
+class Example20
+  class User
+    attr_reader name: String
+
+    def initialize: (name: String) -> void
+  end
+end
+
+class Example20
+  class Registry
+    self.@user: Example20::User?
+
+    def self.user: () -> Example20::User?
+    def self.user=: (Example20::User value) -> Example20::User
+  end
+end

--- a/spec/expectations/models/example20.rbs
+++ b/spec/expectations/models/example20.rbs
@@ -1,0 +1,42 @@
+class Example20
+  @halted: true?
+  @message: String?
+
+  module Responder
+    def self.deny: (Example20 host, String message) -> bool
+  end
+
+  def show: () -> String
+  def call: () -> String?
+  def halt: () -> bool
+  def record: (String? message) -> String?
+
+  private
+
+  def authenticate: () -> (Example20::User | bool)
+  def from_token: () -> (Example20::User | bool | nil)
+  def with_token: () { (String) -> Example20::User? } -> (Example20::User | bool)
+  def fetch_token: () { (String) -> Example20::User? } -> Example20::User?
+  def refuse: () -> bool
+  def lookup: (String token) -> Example20::User?
+  def bearer_request?: () -> bool
+  def json_request?: () -> bool
+  def token_value: () -> String
+end
+
+class Example20
+  class User
+    attr_reader name: String
+
+    def initialize: (name: String) -> void
+  end
+end
+
+class Example20
+  class Registry
+    self.@user: Example20::User?
+
+    def self.user: () -> Example20::User?
+    def self.user=: (Example20::User value) -> Example20::User
+  end
+end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -3,6 +3,7 @@ app/models/concerns/test/filtrable.rb:16:4: [error] Type `(::Post & ::Test::Filt
 app/models/example10.rb:27:26: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example14.rb:15:17: [error] Type `(::Example14::User | nil)` does not have method `name`
 app/models/example15.rb:25:25: [error] Type `(::Example15::User | nil)` does not have method `name`
+app/models/example20.rb:67:25: [error] Type `(::Example20::User | nil)` does not have method `name`
 app/models/example3.rb:122:11: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:63:13: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:64:26: [error] Type `(::Example3::User | nil)` does not have method `name`

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -456,6 +456,30 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     expect(rbs.chomp).to eq(expected_rbs(name).chomp)
   end
 
+  # Example19 with the one thing left between here and the real chain: the call
+  # carrying the block sits two conditionals deep, and the inner alternative is
+  # the halt — Fizzy's `authenticate_by_bearer_token`. The rule that turns "the
+  # block established X" into a fact about the method reads the method's VALUE
+  # and unwraps a single one-armed `if`, so it sees nothing here. What the
+  # snapshot pins is that everything else still holds: the block keeps its
+  # required, `String`-shaped signature, so a reader can tell the nesting is
+  # what fails.
+  it "example20" do
+    name = "models/example20"
+    rbs = RbsInfer::Analyzer.new(
+      target_file: "app/models/example20.rb",
+      source_files: source_files
+    ).generate_rbs
+
+    if ENV["UPDATE_EXPECTATIONS"]
+      path = expectations_dir.join("#{name}.rbs")
+      path.dirname.mkpath
+      path.write(rbs)
+    end
+
+    expect(rbs.chomp).to eq(expected_rbs(name).chomp)
+  end
+
   # Blocks, whose signature is decided by the body rather than the parameter
   # list: required or not (#147), the parameter types read off the sites that
   # use it (#148), and — for a body that only forwards — the callee's own


### PR DESCRIPTION
The target for the last piece of #144, written down before the rule that has to satisfy it.

Example19 closes because the block call is the method's **value**, which is exactly what the rule reads:

```ruby
value = returned_value(body)
return [] unless value&.type == :block
```

`returned_value` unwraps one `if`, and only a one-armed one. Fizzy nests two, and the inner one has an `else`:

```ruby
def authenticate_by_bearer_token
  if request.authorization.to_s.include?("Bearer")
    if bearer_token_authenticatable_request?
      authenticate_or_request_with_http_token do |token|
        Current.identity = identity if identity = Identity.find_by_permissable_access_token(token, …)
      end
    else
      request_http_token_authentication          # halts
    end
  end
end
```

Refusing an `else` is right **in general**: with one, the block may never run, so the fact does not hold unconditionally. But this `else` halts, so the fact holds on every exit that returns — either the block ran and answered, or nothing returned at all. That is the shape felixefelip/steep#121 already models for a constant **write** (a clause whose alternative halts), which suggests the fact comes out halt-gated and composes with what exists rather than needing new machinery.

## One change from Example19, and nothing else

Same halt landing on an argument (proven by felixefelip/steep#127), same block crossing the object boundary, same constant written inside it. Only `from_token` moved:

```ruby
def from_token
  if bearer_request?
    if json_request?
      with_token do |token|
        Registry.user = user if user = lookup(token)
      end
    else
      refuse
    end
  end
end
```

If `show` stops being an error, the nesting is the only thing that changed.

## The recorded target

```
app/models/example20.rb:67:25: [error] Type `(::Example20::User | nil)` does not have method `name`
```

One error, in the baseline, where Example19's used to be before #127 landed.

## Measured on the way

The nesting does **not** weaken the block signature: `with_token` keeps `{ (String) -> Example20::User? }`, byte-identical to Example19's. The first generation showed `?{ (*untyped) -> nil }` — which looked like a second defect — only because no RBS for the fixture existed yet to read back (#156). A second pass fixes it, and the flat and nested shapes agree.

So the fixture isolates exactly one thing, which is what a fixture is for.

## Checks

**916 examples, 0 failures.**
