### PR TITLE
fix: union the hosts, and resolve a host that is itself a mixin

### DIFF
--- a/lib/rbs_infer/extensions/rails/class_methods_implements.rb
+++ b/lib/rbs_infer/extensions/rails/class_methods_implements.rb
@@ -62,8 +62,9 @@ module RbsInfer
           # concern cannot end up mixed into different classes.
           hosts = ModuleSelfTypeAnnotator.hosts_for(path, module_name, mixin_index)
           unless hosts.empty?
-            singletons = hosts.map { |host| "singleton(::#{host})" }
-            entry["self"] = (singletons + [class_methods]).join(" & ")
+            entry["self"] = ModuleSelfTypeAnnotator.union(
+              hosts.map { |host| "singleton(::#{host}) & #{class_methods}" }
+            )
           end
           [entry]
         end

--- a/lib/rbs_infer/extensions/rails/module_self_type_annotator.rb
+++ b/lib/rbs_infer/extensions/rails/module_self_type_annotator.rb
@@ -82,11 +82,28 @@ module RbsInfer
         end
 
         def annotations(module_name, hosts, is_concern)
-          instance = "# @type instance: #{(hosts + [module_name]).join(' & ')}"
+          instance = "# @type instance: #{union(hosts.map { |host| "#{host} & #{module_name}" })}"
           return [instance] unless is_concern
 
-          singletons = (hosts + [module_name]).map { |name| "singleton(#{name})" }
-          ["# @type self: #{singletons.join(' & ')}", instance]
+          selves = hosts.map { |host| "singleton(#{host}) & singleton(#{module_name})" }
+          ["# @type self: #{union(selves)}", instance]
+        end
+
+        # Two hosts mean two possible `self`s — one at a time, which is a UNION.
+        # Intersecting them says one object is both, which for two sibling
+        # controllers is a type nothing has: method resolution against it
+        # degrades and the module stops yielding facts at all. Measured on
+        # Fizzy, where `Authentication` lost every postcondition it carried.
+        # felixefelip/steep#130 is what makes a union usable as a self type.
+        #
+        # A single host is written bare, so the common case reads as it always
+        # did and `&` never has to out-bind `|`.
+        def union(parts)
+          if parts.size == 1
+            parts.first
+          else
+            parts.map { |part| "(#{part})" }.join(" | ")
+          end
         end
       end
 

--- a/lib/rbs_infer/project/mixin_index.rb
+++ b/lib/rbs_infer/project/mixin_index.rb
@@ -26,6 +26,7 @@ module RbsInfer::Project
       @included_shorts = {}                            # file → Set[short name]
       @files_defining = Hash.new { |h, k| h[k] = [] }  # short name → [file]
       @includes_by_class = Hash.new { |h, k| h[k] = Set.new } # class FQN → Set[written name]
+      @module_declarations = Set.new                          # FQNs declared as `module`
       build(source_files)
     end
 
@@ -55,12 +56,20 @@ module RbsInfer::Project
     # looks a constant up outward through the enclosing namespaces, so `include
     # Eventable` inside `class Card` may mean `Card::Eventable` or `::Eventable`.
     # Every nesting of the host is a candidate.
-    def hosts_of(module_name)
-      target = unqualified(module_name)
+    def hosts_of(module_name, seen: Set.new)
+      return [] unless seen.add?(unqualified(module_name))
 
-      @includes_by_class.filter_map do |host, written|
-        host if written.any? { |name| resolves_to?(name, host, target) }
-      end.sort
+      direct = @includes_by_class.filter_map do |host, written|
+        host if written.any? { |name| resolves_to?(name, host, module_name) }
+      end
+
+      # A MODULE that includes the target is not a `self` — it is another mixin,
+      # and the real self is whoever includes IT. Fizzy's `Authentication` is
+      # included by `ActiveStorage::Authorize`, a concern; answering `Authorize`
+      # put a module in a position only a class can hold. Resolved through,
+      # `seen`-guarded because two concerns can include each other.
+      direct.flat_map { |host| @module_declarations.include?(host) ? hosts_of(host, seen: seen) : [host] }
+            .uniq.sort
     end
 
     private
@@ -95,6 +104,7 @@ module RbsInfer::Project
         end
 
         written = include_written_names(entry.result.value)
+        @module_declarations << class_name if extractor.is_module
         @files_defining[class_name.split("::").last] << file
         @included_shorts[file] = written.map { |name| name.split("::").last }.to_set
         # Merged rather than assigned: a class reopened across files carries the
@@ -117,6 +127,7 @@ module RbsInfer::Project
     # Whether `written`, as it appears inside `host`, names `target`.
     def resolves_to?(written, host, target)
       name = unqualified(written)
+      target = unqualified(target)
       return true if name == target
 
       nestings(host).any? { |prefix| "#{prefix}::#{name}" == target }

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -14,8 +14,8 @@ app/helpers/posts_helper.rb:
   modules:
   - anchor: PostsHelper
     annotations:
-    - "# @type instance: ERBPostsEdit & ERBPostsIndex & ERBPostsNew & ERBPostsShow
-      & PostsHelper"
+    - "# @type instance: (ERBPostsEdit & PostsHelper) | (ERBPostsIndex & PostsHelper)
+      | (ERBPostsNew & PostsHelper) | (ERBPostsShow & PostsHelper)"
 app/models/concerns/test/filtrable.rb:
   modules:
   - anchor: Filtrable
@@ -84,8 +84,3 @@ sig/generated/steep_current_runtime/current.rb:
   - anchor: GeneratedAttributeMethods
     annotations:
     - "# @type instance: Current & Current::GeneratedAttributeMethods"
-sig/generated/steep_devise_runtime/devise_scoped_helpers.rb:
-  modules:
-  - anchor: DeviseScopedHelpers
-    annotations:
-    - "# @type instance: DeviseScopedHelpers & DeviseScopedHelpers"

--- a/spec/lib/rbs_infer/extensions/rails/module_self_type_annotator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/module_self_type_annotator_spec.rb
@@ -106,14 +106,12 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeAnnotator do
       expect(entry["annotations"]).to eq(["# @type instance: Post & Test::Filtrable"])
     end
 
-    # An intersection, not a union. `self` is one host at a time, so the union
-    # is the truthful type — but Steep raises `Unexpected self_type` on one
-    # (`type_construction.rb#for_new_method`) and the whole method falls to
-    # `untyped`: measured, `PostsHelper`'s four methods all went from `String`
-    # to `untyped`. The intersection resolves against every host's surface,
-    # which is what the callers need, at the cost of accepting a call that only
-    # one of the hosts supports.
-    it "intersects every host when a module is mixed into more than one" do
+    # A union, because `self` is one host at a time. Intersecting them says an
+    # object is both, and for two sibling controllers that is a type nothing
+    # has — measured on Fizzy, where it cost `Authentication` every
+    # postcondition it carried. felixefelip/steep#130 is what makes a union
+    # usable here.
+    it "unions every host when a module is mixed into more than one" do
       entry = described_class.entry_for(
         path: "app/helpers/posts_helper.rb",
         module_name: "PostsHelper",
@@ -121,7 +119,8 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeAnnotator do
         mixin_index: index_answering(%w[ERBPostsIndex ERBPostsShow])
       )
 
-      expect(entry["annotations"]).to eq(["# @type instance: ERBPostsIndex & ERBPostsShow & PostsHelper"])
+      expect(entry["annotations"])
+        .to eq(["# @type instance: (ERBPostsIndex & PostsHelper) | (ERBPostsShow & PostsHelper)"])
     end
 
     it "carries the same hosts into the singleton annotation" do
@@ -133,8 +132,8 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeAnnotator do
       )
 
       expect(entry["annotations"]).to eq([
-        "# @type self: singleton(Card) & singleton(Comment) & singleton(Eventable)",
-        "# @type instance: Card & Comment & Eventable"
+        "# @type self: (singleton(Card) & singleton(Eventable)) | (singleton(Comment) & singleton(Eventable))",
+        "# @type instance: (Card & Eventable) | (Comment & Eventable)"
       ])
     end
 

--- a/spec/lib/rbs_infer/project/mixin_index_spec.rb
+++ b/spec/lib/rbs_infer/project/mixin_index_spec.rb
@@ -146,6 +146,41 @@ RSpec.describe RbsInfer::Project::MixinIndex do
       expect(index.hosts_of("Searchable")).to contain_exactly("Card")
     end
 
+    # felixefelip/rbs_infer#167. A MODULE that includes the target is another
+    # mixin, not a `self`: the real self is whoever includes IT. Fizzy's
+    # `Authentication` is included by a concern, and answering that concern put
+    # a module where only a class can stand.
+    it "resolves through a module that re-mixes the target" do
+      host = write_file("application_controller.rb", "class ApplicationController\n  include Authorize\nend\n")
+      authorize = write_file("authorize.rb", "module Authorize\n  include Authentication\nend\n")
+      auth = write_file("authentication.rb", "module Authentication\nend\n")
+
+      index = described_class.new([host, authorize, auth])
+
+      expect(index.hosts_of("Authentication")).to contain_exactly("ApplicationController")
+    end
+
+    it "keeps the class hosts alongside a re-mixed one" do
+      app = write_file("application_controller.rb", "class ApplicationController\n  include Authentication\nend\n")
+      other = write_file("passkeys_controller.rb", "class PasskeysController\n  include Authentication\nend\n")
+      authorize = write_file("authorize.rb", "module Authorize\n  include Authentication\nend\n")
+      auth = write_file("authentication.rb", "module Authentication\nend\n")
+
+      index = described_class.new([app, other, authorize, auth])
+
+      # `Authorize` resolves to nothing here — nobody includes it — and drops
+      # out rather than standing in for a class.
+      expect(index.hosts_of("Authentication")).to contain_exactly("ApplicationController", "PasskeysController")
+    end
+
+    # Two concerns including each other must not recurse forever.
+    it "survives a cycle" do
+      a = write_file("a.rb", "module A\n  include B\nend\n")
+      b = write_file("b.rb", "module B\n  include A\nend\n")
+
+      expect(described_class.new([a, b]).hosts_of("A")).to be_empty
+    end
+
     it "is empty for a module no one includes" do
       lonely = write_file("lonely.rb", "module Lonely\nend\n")
 


### PR DESCRIPTION
#163 intersected every host because a union crashed Steep. Your Fizzy run measured that trade, and the intersection is the worse half of it.

`Authentication` is included by three things:

```
app/controllers/application_controller.rb            class
app/controllers/my/passkey_challenges_controller.rb  class, a sibling
lib/rails_ext/active_storage_authorization.rb        inside module ActiveStorage::Authorize
```

which produced

```rbs
# @type instance: ActiveStorage::Authorize & ApplicationController & My::PasskeyChallengesController & Authentication
```

No object is both controllers. Resolution against that type degrades, the concern stops yielding facts, and:

| | before | after |
|---|---|---|
| `Authentication#resume_session` | `when_true: {Current.identity: ::Identity}` | **gone** |
| `.steep_postconditions.yml` | ~12,500 lines | ~1,400 |

The one fact the whole `Current.identity` chain rests on was among the casualties.

## Two fixes, both needed

**Union, not intersection.** `self` is one host at a time. felixefelip/steep#130 makes a union usable — `for_new_method` used to raise on one and leave the method `untyped` with no diagnostic.

**A module that includes the target is not a `self`.** It is another mixin; the real self is whoever includes *it*. Resolved through, and `seen`-guarded, because two concerns can include each other. A module host nobody includes now drops out instead of standing in for a class.

That also deletes a nonsense entry the dummy was carrying:

```yaml
- "# @type instance: DeviseScopedHelpers & DeviseScopedHelpers"
```

## In the dummy

```rbs
- "# @type instance: ERBPostsEdit & ERBPostsIndex & ERBPostsNew & ERBPostsShow & PostsHelper"
+ "# @type instance: (ERBPostsEdit & PostsHelper) | (ERBPostsIndex & PostsHelper) | (ERBPostsNew & PostsHelper) | (ERBPostsShow & PostsHelper)"
```

**Depends on felixefelip/steep#130.**

## Checks

**919 examples, 0 failures.** Steep's dummy baseline unchanged.