### PR TITLE
test: Example21 — a parameter typed as the receiver of what it was assigned

### DIFF
--- a/spec/dummy/app/models/example21.rb
+++ b/spec/dummy/app/models/example21.rb
@@ -1,0 +1,88 @@
+# A parameter typed as the RECEIVER of the expression assigned to it.
+#
+# The caller-side map that types an argument is keyed by `line:column`
+# (`SteepBridge#all_expression_types`, felixefelip/rbs_infer#155). A receiver
+# starts exactly where its call does — in
+#
+#     Registry.holder = ticket.holder
+#
+# both `ticket` and `ticket.holder` begin at the same column — so the two share
+# one key and whichever `each_typing` yields last takes it.
+#
+# It stays hidden while the call itself has a type, because then either answer
+# is at least about the right expression. It surfaces when the call is
+# `untyped`: here `ticket` is nilable, so Steep types `ticket.holder` as
+# `untyped`, the map drops it, and the receiver is left answering for the whole
+# expression. `holder=` then takes a `Ticket?`, which is the object that HAS a
+# holder rather than the holder.
+#
+# Found in Fizzy, where `Current#identity=` came out as
+#
+#     def identity=: ((Identity | (Session & Session::Validated)?) identity) -> untyped
+#
+# from `self.identity = session.identity`. It does not stop there: `@identity`
+# takes the parameter's type, and `@user` takes it in turn through
+# `self.user = identity.users.find_by(…)` — the same collision, one level on,
+# with the already-polluted `identity` as the receiver. Every `Current.identity`
+# in the app is a `Session` as far as the checker knows.
+#
+# Two shapes that do NOT fix it, both measured: preferring the widest
+# expression at a position, and preferring the narrowest. The key names a
+# position, and a position does not name an expression — `Example10::Sink.last=`
+# and `Current.with` in this same dummy want the INNER answer, for the mirror
+# reason. Only a key that carries the range can tell the two apart.
+class Example21
+  class Holder
+    attr_reader :name
+
+    def initialize(name:)
+      @name = name
+    end
+  end
+
+  class Ticket
+    def holder
+      Holder.new(name: "holder")
+    end
+  end
+
+  class Registry
+    def self.holder=(value)
+      @holder = value
+    end
+
+    def self.holder
+      @holder
+    end
+  end
+
+  # Nilable on purpose: it is what makes the call below `untyped`, and the
+  # receiver the only typed thing left at that position. So `ticket.holder` is
+  # itself a recorded error — the precondition, not the bug.
+  def ticket
+    @ticket
+  end
+
+  def assign(ticket)
+    @ticket = ticket
+  end
+
+  # So the reader above has a type to be nilable OF. Without it `ticket` is
+  # `untyped` and there is nothing for the receiver to answer WITH.
+  def prepare
+    assign(Ticket.new)
+  end
+
+  # The whole fixture. `Registry.holder=` should take a `Holder`; it takes
+  # whatever `ticket` is.
+  def promote
+    Registry.holder = ticket.holder
+  end
+
+  # And where that lands: the registry hands back a `Ticket?`, which has no
+  # `name`. Until the map can tell an expression from a position, this is an
+  # error the real code does not have.
+  def show
+    "Held by #{Registry.holder.name}"
+  end
+end

--- a/spec/dummy/sig/generated/.steep_contracts.yml
+++ b/spec/dummy/sig/generated/.steep_contracts.yml
@@ -124,6 +124,15 @@ methods:
         receiver:
           kind: self
         method: body
+  Example21#promote:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: ticket
+    enforced: false
   Post#author_name:
     requires:
     - kind: not_nil

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -810,6 +810,41 @@ postconditions:
   effects:
     may_write:
     - "@name"
+- class: Example21
+  method: assign
+  unconditional:
+    ivars:
+      "@ticket": "::Example21::Ticket"
+    self: "::Example21 & ::Example21::AfterAssign"
+  effects:
+    may_write:
+    - "@ticket"
+- class: Example21
+  method: prepare
+  effects:
+    may_write:
+    - "@ticket"
+- class: Example21
+  method: ticket
+  effects:
+    returns_ivar: "@ticket"
+- class: Example21::Holder
+  method: initialize
+  effects:
+    may_write:
+    - "@name"
+- class: Example21::Registry
+  method: holder
+  effects:
+    returns_ivar: "@holder"
+- class: Example21::Registry
+  method: holder=
+  unconditional:
+    establishes_consts:
+      holder: "::Example21::Ticket"
+  effects:
+    may_write:
+    - "@holder"
 - class: Example2::Foo
   method: user=
   unconditional:

--- a/spec/dummy/sig/rbs_infer/app/models/example21.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example21.rbs
@@ -1,0 +1,32 @@
+class Example21
+  @ticket: Example21::Ticket?
+
+  def ticket: () -> Example21::Ticket?
+  def assign: (Ticket ticket) -> Example21::Ticket
+  def prepare: () -> Example21::Ticket
+  def promote: () -> Example21::Holder
+  def show: () -> String
+end
+
+class Example21
+  class Holder
+    attr_reader name: String
+
+    def initialize: (name: String) -> void
+  end
+end
+
+class Example21
+  class Ticket
+    def holder: () -> Holder
+  end
+end
+
+class Example21
+  class Registry
+    self.@holder: Example21::Ticket?
+
+    def self.holder=: (Example21::Ticket? value) -> Example21::Ticket?
+    def self.holder: () -> Example21::Ticket?
+  end
+end

--- a/spec/expectations/models/example21.rbs
+++ b/spec/expectations/models/example21.rbs
@@ -1,0 +1,32 @@
+class Example21
+  @ticket: Example21::Ticket?
+
+  def ticket: () -> Example21::Ticket?
+  def assign: (Ticket ticket) -> Example21::Ticket
+  def prepare: () -> Example21::Ticket
+  def promote: () -> Example21::Holder
+  def show: () -> String
+end
+
+class Example21
+  class Holder
+    attr_reader name: String
+
+    def initialize: (name: String) -> void
+  end
+end
+
+class Example21
+  class Ticket
+    def holder: () -> Holder
+  end
+end
+
+class Example21
+  class Registry
+    self.@holder: Example21::Ticket?
+
+    def self.holder=: (Example21::Ticket? value) -> Example21::Ticket?
+    def self.holder: () -> Example21::Ticket?
+  end
+end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -4,6 +4,8 @@ app/models/example10.rb:27:26: [error] Type `(::String | nil)` does not have met
 app/models/example14.rb:15:17: [error] Type `(::Example14::User | nil)` does not have method `name`
 app/models/example15.rb:25:25: [error] Type `(::Example15::User | nil)` does not have method `name`
 app/models/example20.rb:67:25: [error] Type `(::Example20::User | nil)` does not have method `name`
+app/models/example21.rb:79:29: [error] Type `(::Example21::Ticket | nil)` does not have method `holder`
+app/models/example21.rb:86:31: [error] Type `(::Example21::Ticket | nil)` does not have method `name`
 app/models/example3.rb:122:11: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:63:13: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:64:26: [error] Type `(::Example3::User | nil)` does not have method `name`

--- a/spec/expectations/steep_contracts.yml
+++ b/spec/expectations/steep_contracts.yml
@@ -124,6 +124,15 @@ methods:
         receiver:
           kind: self
         method: body
+  Example21#promote:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: ticket
+    enforced: false
   Post#author_name:
     requires:
     - kind: not_nil

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -464,6 +464,28 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
   # snapshot pins is that everything else still holds: the block keeps its
   # required, `String`-shaped signature, so a reader can tell the nesting is
   # what fails.
+  # felixefelip/rbs_infer#168. A parameter typed as the RECEIVER of the
+  # expression assigned to it: `Registry.holder = ticket.holder` types
+  # `holder=` as taking a `Ticket?`, because the caller-side map is keyed by
+  # `line:column` and a receiver starts where its call does. Fizzy's
+  # `Current#identity=` is the same shape, and from there `Current.identity` is
+  # a `Session` for the whole app.
+  it "example21" do
+    name = "models/example21"
+    rbs = RbsInfer::Analyzer.new(
+      target_file: "app/models/example21.rb",
+      source_files: source_files
+    ).generate_rbs
+
+    if ENV["UPDATE_EXPECTATIONS"]
+      path = expectations_dir.join("#{name}.rbs")
+      path.dirname.mkpath
+      path.write(rbs)
+    end
+
+    expect(rbs.chomp).to eq(expected_rbs(name).chomp)
+  end
+
   it "example20" do
     name = "models/example20"
     rbs = RbsInfer::Analyzer.new(


### PR DESCRIPTION
The target for the `Current#identity=` pollution found in the Fizzy run, reduced to a fixture.

The caller-side map that types an argument is keyed by `line:column` (`SteepBridge#all_expression_types`, #155). A receiver starts exactly where its call does, so in

```ruby
Registry.holder = ticket.holder
```

`ticket` and `ticket.holder` share one key, and whichever `each_typing` yields last takes it.

It stays hidden while the call has a type of its own — either answer is at least about the right expression. It surfaces when the call is **untyped**: `ticket` is nilable here, so Steep types `ticket.holder` as `untyped`, the map drops it, and the receiver is left answering for the whole expression.

The snapshot states it in two adjacent lines:

```rbs
def promote: () -> Example21::Holder            # the expression IS a Holder
def self.holder=: (Example21::Ticket? value)    # the parameter took the receiver
```

## Where it was found

Fizzy's `Current#identity=`, from `self.identity = session.identity`:

```rbs
def identity=: ((Identity | (Session & Session::Validated)?) identity) -> untyped
```

And it does not stop at one method. `@identity` takes the parameter's type, then `@user` takes it in turn through `self.user = identity.users.find_by(…)` — the same collision one level on, with the already-polluted `identity` as the receiver. Every `Current.identity` in the app is a `Session` as far as the checker knows.

Bisected to `fdbb170` (#155).

## Two fixes that do not work

Both measured against this dummy:

- **Widest expression wins** — fixes Fizzy, breaks `Example10::Sink.last=` (`(Bar value) -> Bar` → `untyped`) and `Current.with` (`?{ () -> ProfileFormatter }` → `untyped`), which want the *inner* answer.
- **Narrowest wins** — the present behaviour, i.e. the bug.

A position does not name an expression, and no tie-break repairs an ambiguous key. The fix is a key that carries the **range**, with callers passing the node's start *and* end — they hold the node, so they hold both.

## Recorded targets

```
example21.rb:79  Type `(::Example21::Ticket | nil)` does not have method `holder`   # the precondition
example21.rb:86  Type `(::Example21::Ticket | nil)` does not have method `name`     # the bug
```

The first is intentional: a nilable receiver is what makes the call untyped, and the comment in the fixture says so.

## Checks

**920 examples, 0 failures.**