### PR TITLE
fix: key the caller-side expression map by range, so a receiver stops answering for its call

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -608,7 +608,8 @@ module RbsInfer
   # yields an Integer in one branch and a String in another gives its block a
   # union, exactly as the sites say.
   def block_param_type(positions, expression_types)
-    types = positions.filter_map { |line, column| expression_types["#{line}:#{column}"] }.uniq
+    keys = positions.map { |position| RbsInfer::Signatures::SteepBridge.expression_key(*position) }
+    types = keys.filter_map { |key| expression_types[key] }.uniq
     return nil if types.empty?
 
     RbsInfer::Inference::TypeMerger.union_types(types)

--- a/lib/rbs_infer/inference/block_return_collector.rb
+++ b/lib/rbs_infer/inference/block_return_collector.rb
@@ -107,9 +107,7 @@ module RbsInfer::Inference
       last = body.is_a?(Prism::StatementsNode) ? body.body.last : body
       return nil unless last
 
-      # Character column: Steep's map comes from Parser, which counts
-      # characters, while Prism also offers bytes (felixefelip/rbs_infer#142).
-      expression_types["#{last.location.start_line}:#{last.location.start_character_column}"]
+      expression_types[RbsInfer::Signatures::SteepBridge.prism_expression_key(last.location)]
     end
   end
 end

--- a/lib/rbs_infer/inference/class_member_collector/block_signature.rb
+++ b/lib/rbs_infer/inference/class_member_collector/block_signature.rb
@@ -43,8 +43,9 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
     end
 
     # Where the values the body hands to the block sit in the source, one entry
-    # per block parameter: `[[[line, column], …], …]`, columns in CHARACTERS so
-    # a Parser-based lookup lines up (felixefelip/rbs_infer#142).
+    # per block parameter: `[[[start_line, start_column, end_line, end_column], …], …]`,
+    # columns in CHARACTERS so a Parser-based lookup lines up
+    # (felixefelip/rbs_infer#142).
     #
     # Only the positions: the TYPES there are the checker's answer, and the
     # checker belongs to the Analyzer. This object is structural, like the rest
@@ -143,8 +144,15 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
       node.arguments&.arguments || []
     end
 
+    # Both ends of the expression, not just where it starts: the Analyzer looks
+    # these up in a map keyed by the whole range, so that a receiver cannot
+    # answer for the call it receives (felixefelip/rbs_infer#168). Structural
+    # here, like the rest of this object — the KEY is built where the map is.
     def position_of(node)
-      [node.location.start_line, node.location.start_character_column] if node
+      return nil unless node
+
+      loc = node.location
+      [loc.start_line, loc.start_character_column, loc.end_line, loc.end_character_column]
     end
 
     # Anything that asks whether the block is there.

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -856,9 +856,10 @@ module RbsInfer::Inference
     end
 
     def expression_type(node)
-      # Character column, like every other lookup into this map — Parser counts
-      # characters where Prism also offers bytes (felixefelip/rbs_infer#142).
-      type = @expression_types["#{node.location.start_line}:#{node.location.start_character_column}"]
+      # Keyed by the node's whole range: a receiver starts where its call does,
+      # so a start position alone would let `ticket` answer for `ticket.holder`
+      # (felixefelip/rbs_infer#168).
+      type = @expression_types[RbsInfer::Signatures::SteepBridge.prism_expression_key(node.location)]
 
       # `self` is a real RBS type, but it means "the receiver of THIS method" —
       # so carrying it into ANOTHER method's parameter says the argument is a

--- a/lib/rbs_infer/signatures/steep_bridge.rb
+++ b/lib/rbs_infer/signatures/steep_bridge.rb
@@ -619,9 +619,40 @@ module RbsInfer::Signatures
       result
     end
 
+    # The key an expression is filed under in `all_expression_types`: its full
+    # RANGE, both ends.
+    #
+    # A position was not enough, because a position does not name an expression.
+    # A receiver starts exactly where its call does, so in
+    #
+    #     Registry.holder = ticket.holder
+    #
+    # `ticket` and `ticket.holder` began at the same column and shared one key.
+    # It stayed hidden while the call had a type of its own — either answer was
+    # at least ABOUT the right expression — and surfaced when the call was
+    # `untyped`: dropped from the map, the receiver was left answering for the
+    # whole expression, and `holder=` took a `Ticket?` (the object that HAS a
+    # holder) instead of a `Holder` (felixefelip/rbs_infer#168).
+    #
+    # Preferring the widest or the narrowest expression at a position does not
+    # decide it either: `Current.with` wants the inner answer and this wants the
+    # outer one. Only the range tells the two apart — so both sides of the map
+    # build their key through here, or they drift apart in silence.
+    def self.expression_key(first_line, first_column, last_line, last_column)
+      "#{first_line}:#{first_column}-#{last_line}:#{last_column}"
+    end
+
+    # The same key for a Prism node — the LOOKUP side of the map. Character
+    # columns, because Parser counts characters where Prism also offers bytes,
+    # and a source with multibyte text has to line up (felixefelip/rbs_infer#142).
+    def self.prism_expression_key(location)
+      expression_key(location.start_line, location.start_character_column,
+                     location.end_line, location.end_character_column)
+    end
+
     # Returns the type of a specific node within the typing result.
     # Useful for resolving argument types in call sites.
-    # Returns { node_id => "Type" } for all typed expressions.
+    # Returns { expression_key => "Type" } for all typed expressions.
     def all_expression_types(source_code)
       typing = type_check(source_code)
       return {} unless typing
@@ -635,7 +666,7 @@ module RbsInfer::Signatures
         type_str = format_type(type)
         next if type_str == "untyped" || type_str == "bot"
 
-        key = "#{loc.first_line}:#{loc.column}"
+        key = self.class.expression_key(loc.first_line, loc.column, loc.last_line, loc.last_column)
         result[key] = type_str
       end
 

--- a/spec/dummy/app/models/example10.rb
+++ b/spec/dummy/app/models/example10.rb
@@ -41,8 +41,13 @@ class Example10
   # then the write. Constant writes never had that treatment — this fixture is
   # the pre-existing half of the same shape.
   #
-  # Note the gap is about which CALLS are visited, not about the write itself:
-  # `Sink.last` is established correctly either way.
+  # Note the gap is about which CALLS are visited, not about the write itself.
+  # What `Sink.last` is established AS does follow from it, though: while `greet`
+  # errors it is `untyped`, so the write says nothing about the type. It read
+  # `Example10::Bar` until felixefelip/rbs_infer#168 — the receiver of the RHS,
+  # which begins at the same column as the RHS itself and so answered for it
+  # while the map was keyed by a position. Closing the gap above is what would
+  # make this a `String`.
   def run
     Example10::Foo.name = 'John Doe'
     Example10::Sink.last = Example10::Bar.new.greet # RHS call NOT walked -> greet errors

--- a/spec/dummy/app/models/example21.rb
+++ b/spec/dummy/app/models/example21.rb
@@ -1,36 +1,38 @@
-# A parameter typed as the RECEIVER of the expression assigned to it.
+# A parameter typed as the RECEIVER of the expression assigned to it — the
+# collision that keying the map by RANGE resolves (felixefelip/rbs_infer#168).
 #
-# The caller-side map that types an argument is keyed by `line:column`
+# The caller-side map that types an argument used to be keyed by `line:column`
 # (`SteepBridge#all_expression_types`, felixefelip/rbs_infer#155). A receiver
 # starts exactly where its call does — in
 #
 #     Registry.holder = ticket.holder
 #
-# both `ticket` and `ticket.holder` begin at the same column — so the two share
-# one key and whichever `each_typing` yields last takes it.
+# both `ticket` and `ticket.holder` begin at the same column — so the two shared
+# one key and whichever `each_typing` yielded last took it.
 #
-# It stays hidden while the call itself has a type, because then either answer
-# is at least about the right expression. It surfaces when the call is
+# It stayed hidden while the call itself had a type, because then either answer
+# was at least about the right expression. It surfaced when the call was
 # `untyped`: here `ticket` is nilable, so Steep types `ticket.holder` as
-# `untyped`, the map drops it, and the receiver is left answering for the whole
-# expression. `holder=` then takes a `Ticket?`, which is the object that HAS a
-# holder rather than the holder.
+# `untyped`, the map dropped it, and the receiver was left answering for the
+# whole expression. `holder=` then took a `Ticket?`, which is the object that
+# HAS a holder rather than the holder.
 #
 # Found in Fizzy, where `Current#identity=` came out as
 #
 #     def identity=: ((Identity | (Session & Session::Validated)?) identity) -> untyped
 #
-# from `self.identity = session.identity`. It does not stop there: `@identity`
-# takes the parameter's type, and `@user` takes it in turn through
+# from `self.identity = session.identity`. It did not stop there: `@identity`
+# took the parameter's type, and `@user` took it in turn through
 # `self.user = identity.users.find_by(…)` — the same collision, one level on,
 # with the already-polluted `identity` as the receiver. Every `Current.identity`
-# in the app is a `Session` as far as the checker knows.
+# in the app was a `Session` as far as the checker knew.
 #
 # Two shapes that do NOT fix it, both measured: preferring the widest
-# expression at a position, and preferring the narrowest. The key names a
+# expression at a position, and preferring the narrowest. The key named a
 # position, and a position does not name an expression — `Example10::Sink.last=`
 # and `Current.with` in this same dummy want the INNER answer, for the mirror
-# reason. Only a key that carries the range can tell the two apart.
+# reason. Only a key that carries the range tells the two apart, which is what
+# the map is keyed by now.
 class Example21
   class Holder
     attr_reader :name
@@ -73,15 +75,23 @@ class Example21
     assign(Ticket.new)
   end
 
-  # The whole fixture. `Registry.holder=` should take a `Holder`; it takes
-  # whatever `ticket` is.
+  # The whole fixture. `Registry.holder=` used to take whatever `ticket` is; it
+  # now takes `untyped`, which is what the assigned expression really has — the
+  # call below is itself the error the baseline records, so the checker types it
+  # with nothing rather than with the receiver.
+  #
+  # `Holder` is what a human reads here, and reaching it is a separate step: the
+  # structural chain asks the caller class's method map for `ticket` and gets
+  # `untyped`, where `MethodTypeResolver#resolve` answers `Example21::Ticket?`
+  # for the same question — and `resolve("Example21::Ticket?", "holder")` is
+  # already `Example21::Holder`.
   def promote
     Registry.holder = ticket.holder
   end
 
-  # And where that lands: the registry hands back a `Ticket?`, which has no
-  # `name`. Until the map can tell an expression from a position, this is an
-  # error the real code does not have.
+  # And where that lands: the registry used to hand back a `Ticket?`, which has
+  # no `name` — an error the real code does not have. It hands back what was
+  # actually assigned now, so this line is clean.
   def show
     "Held by #{Registry.holder.name}"
   end

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -291,20 +291,6 @@ postconditions:
   effects:
     may_write:
     - "@name"
-- class: Example10::Sink
-  method: last
-  effects:
-    returns_ivar: "@last"
-- class: Example10::Sink
-  method: last=
-  unconditional:
-    ivars:
-      "@last": "::Example10::Bar"
-    establishes_consts:
-      last: "::Example10::Bar"
-  effects:
-    may_write:
-    - "@last"
 - class: Example11::Partial
   method: initialize
   effects:
@@ -833,18 +819,6 @@ postconditions:
   effects:
     may_write:
     - "@name"
-- class: Example21::Registry
-  method: holder
-  effects:
-    returns_ivar: "@holder"
-- class: Example21::Registry
-  method: holder=
-  unconditional:
-    establishes_consts:
-      holder: "::Example21::Ticket"
-  effects:
-    may_write:
-    - "@holder"
 - class: Example2::Foo
   method: user=
   unconditional:

--- a/spec/dummy/sig/rbs_infer/app/jobs/profile_formatter_job.rbs
+++ b/spec/dummy/sig/rbs_infer/app/jobs/profile_formatter_job.rbs
@@ -1,3 +1,3 @@
 class ProfileFormatterJob < ApplicationJob
-  def perform: () -> ProfileFormatter?
+  def perform: () -> untyped
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example10.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example10.rbs
@@ -1,5 +1,5 @@
 class Example10
-  def run: () -> Example10::Bar
+  def run: () -> untyped
 end
 
 class Example10
@@ -13,10 +13,8 @@ end
 
 class Example10
   class Sink
-    self.@last: Example10::Bar?
-
-    def self.last: () -> Example10::Bar?
-    def self.last=: (Example10::Bar value) -> Example10::Bar
+    def self.last: () -> untyped
+    def self.last=: (untyped value) -> untyped
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example21.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example21.rbs
@@ -24,9 +24,7 @@ end
 
 class Example21
   class Registry
-    self.@holder: Example21::Ticket?
-
-    def self.holder=: (Example21::Ticket? value) -> Example21::Ticket?
-    def self.holder: () -> Example21::Ticket?
+    def self.holder=: (untyped value) -> untyped
+    def self.holder: () -> untyped
   end
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs
@@ -33,5 +33,5 @@ class Current
   def self.viewer_name=: (String? value) -> String?
   def self.__rbs_infer_instance: () -> Current
   def self.set: (?user: ((User & User::Validated) | User)?, ?author_name: String?, ?account: (Account & Account::Validated)?, ?viewer_name: String?) ?{ () -> untyped } -> untyped
-  def self.with: (?user: (User & User::Validated)?, ?author_name: String?, ?account: (Account & Account::Validated)?, ?viewer_name: String?) ?{ () -> ProfileFormatter } -> ProfileFormatter?
+  def self.with: (?user: (User & User::Validated)?, ?author_name: String?, ?account: (Account & Account::Validated)?, ?viewer_name: String?) ?{ () -> untyped } -> untyped
 end

--- a/spec/expectations/jobs/profile_formatter_job.rbs
+++ b/spec/expectations/jobs/profile_formatter_job.rbs
@@ -1,3 +1,3 @@
 class ProfileFormatterJob < ApplicationJob
-  def perform: () -> ProfileFormatter?
+  def perform: () -> untyped
 end

--- a/spec/expectations/models/example10.rbs
+++ b/spec/expectations/models/example10.rbs
@@ -1,5 +1,5 @@
 class Example10
-  def run: () -> Example10::Bar
+  def run: () -> untyped
 end
 
 class Example10
@@ -13,10 +13,8 @@ end
 
 class Example10
   class Sink
-    self.@last: Example10::Bar?
-
-    def self.last: () -> Example10::Bar?
-    def self.last=: (Example10::Bar value) -> Example10::Bar
+    def self.last: () -> untyped
+    def self.last=: (untyped value) -> untyped
   end
 end
 

--- a/spec/expectations/models/example21.rbs
+++ b/spec/expectations/models/example21.rbs
@@ -24,9 +24,7 @@ end
 
 class Example21
   class Registry
-    self.@holder: Example21::Ticket?
-
-    def self.holder=: (Example21::Ticket? value) -> Example21::Ticket?
-    def self.holder: () -> Example21::Ticket?
+    def self.holder=: (untyped value) -> untyped
+    def self.holder: () -> untyped
   end
 end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -4,8 +4,7 @@ app/models/example10.rb:27:26: [error] Type `(::String | nil)` does not have met
 app/models/example14.rb:15:17: [error] Type `(::Example14::User | nil)` does not have method `name`
 app/models/example15.rb:25:25: [error] Type `(::Example15::User | nil)` does not have method `name`
 app/models/example20.rb:67:25: [error] Type `(::Example20::User | nil)` does not have method `name`
-app/models/example21.rb:79:29: [error] Type `(::Example21::Ticket | nil)` does not have method `holder`
-app/models/example21.rb:86:31: [error] Type `(::Example21::Ticket | nil)` does not have method `name`
+app/models/example21.rb:89:29: [error] Type `(::Example21::Ticket | nil)` does not have method `holder`
 app/models/example3.rb:122:11: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:63:13: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:64:26: [error] Type `(::Example3::User | nil)` does not have method `name`

--- a/spec/expectations/steep_current_runtime/current.rbs
+++ b/spec/expectations/steep_current_runtime/current.rbs
@@ -33,5 +33,5 @@ class Current
   def self.viewer_name=: (String? value) -> String?
   def self.__rbs_infer_instance: () -> Current
   def self.set: (?user: ((User & User::Validated) | User)?, ?author_name: String?, ?account: (Account & Account::Validated)?, ?viewer_name: String?) ?{ () -> untyped } -> untyped
-  def self.with: (?user: (User & User::Validated)?, ?author_name: String?, ?account: (Account & Account::Validated)?, ?viewer_name: String?) ?{ () -> ProfileFormatter } -> ProfileFormatter?
+  def self.with: (?user: (User & User::Validated)?, ?author_name: String?, ?account: (Account & Account::Validated)?, ?viewer_name: String?) ?{ () -> untyped } -> untyped
 end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -465,11 +465,12 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
   # required, `String`-shaped signature, so a reader can tell the nesting is
   # what fails.
   # felixefelip/rbs_infer#168. A parameter typed as the RECEIVER of the
-  # expression assigned to it: `Registry.holder = ticket.holder` types
-  # `holder=` as taking a `Ticket?`, because the caller-side map is keyed by
-  # `line:column` and a receiver starts where its call does. Fizzy's
-  # `Current#identity=` is the same shape, and from there `Current.identity` is
-  # a `Session` for the whole app.
+  # expression assigned to it: `Registry.holder = ticket.holder` typed `holder=`
+  # as taking a `Ticket?`, because the caller-side map was keyed by `line:column`
+  # and a receiver starts where its call does. Fizzy's `Current#identity=` is the
+  # same shape, and from there `Current.identity` was a `Session` for the whole
+  # app. Keyed by the whole range, the parameter takes what the expression really
+  # has — `untyped`, the call itself being the error the baseline records.
   it "example21" do
     name = "models/example21"
     rbs = RbsInfer::Analyzer.new(

--- a/spec/lib/rbs_infer/inference/block_return_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/block_return_collector_spec.rb
@@ -2,9 +2,10 @@ require "spec_helper"
 require "rbs_infer"
 
 RSpec.describe RbsInfer::Inference::BlockReturnCollector do
-  # Steep's map is keyed `"line:column"`; the fixtures below state it directly so
-  # the collector's own job — finding the block's last statement and looking it
-  # up — is what gets tested, not the bridge.
+  # Steep's map is keyed by an expression's whole RANGE
+  # (`"start_line:start_column-end_line:end_column"`, #168); the fixtures below
+  # state it directly so the collector's own job — finding the block's last
+  # statement and looking it up — is what gets tested, not the bridge.
   def collect(source, methods:, expression_types:, receiver_check: nil)
     collector = described_class.new(
       methods: Set.new(methods), expression_types: expression_types, receiver_check: receiver_check
@@ -22,7 +23,7 @@ RSpec.describe RbsInfer::Inference::BlockReturnCollector do
       end
     RUBY
 
-    expect(collect(source, methods: ["with_token"], expression_types: { "3:4" => "User?" }))
+    expect(collect(source, methods: ["with_token"], expression_types: { "3:4-3:17" => "User?" }))
       .to eq("with_token" => ["User?"])
   end
 
@@ -34,7 +35,7 @@ RSpec.describe RbsInfer::Inference::BlockReturnCollector do
       end
     RUBY
 
-    expect(collect(source, methods: ["wrap"], expression_types: { "2:9" => "Integer", "3:9" => "String" }))
+    expect(collect(source, methods: ["wrap"], expression_types: { "2:9-2:10" => "Integer", "3:9-3:12" => "String" }))
       .to eq("wrap" => ["Integer", "String"])
   end
 
@@ -43,13 +44,13 @@ RSpec.describe RbsInfer::Inference::BlockReturnCollector do
   it "ignores a call on a receiver when no check is supplied" do
     source = "def go; other.wrap { 1 }; end"
 
-    expect(collect(source, methods: ["wrap"], expression_types: { "1:21" => "Integer" })).to be_empty
+    expect(collect(source, methods: ["wrap"], expression_types: { "1:21-1:22" => "Integer" })).to be_empty
   end
 
   it "asks the supplied check about a receiver" do
     source = "def go; other.wrap { 1 }; end"
 
-    expect(collect(source, methods: ["wrap"], expression_types: { "1:21" => "Integer" }, receiver_check: ->(_node) { true }))
+    expect(collect(source, methods: ["wrap"], expression_types: { "1:21-1:22" => "Integer" }, receiver_check: ->(_node) { true }))
       .to eq("wrap" => ["Integer"])
   end
 

--- a/spec/lib/rbs_infer/inference/class_member_collector/block_signature_spec.rb
+++ b/spec/lib/rbs_infer/inference/class_member_collector/block_signature_spec.rb
@@ -71,8 +71,8 @@ RSpec.describe RbsInfer::Inference::ClassMemberCollector::BlockSignature do
   end
 
   # The types at those sites are the checker's answer, so this only records
-  # where to look — line and CHARACTER column, which is what a Parser-based
-  # lookup is keyed by.
+  # where to look — BOTH ends of the expression, in lines and CHARACTER columns,
+  # which is what a Parser-based lookup is keyed by (#168).
   describe "#arg_positions" do
     def positions_for(source)
       def_node = Prism.parse(source).value.statements.body.first
@@ -80,11 +80,11 @@ RSpec.describe RbsInfer::Inference::ClassMemberCollector::BlockSignature do
     end
 
     it "points at each argument the body passes to the block" do
-      expect(positions_for("def m(&block)\n  block.call(x, y)\nend")).to eq([[[2, 13]], [[2, 16]]])
+      expect(positions_for("def m(&block)\n  block.call(x, y)\nend")).to eq([[[2, 13, 2, 14]], [[2, 16, 2, 17]]])
     end
 
     it "collects every site for the same parameter, so they can be unioned" do
-      expect(positions_for("def m\n  yield 1\n  yield 2\nend")).to eq([[[2, 8], [3, 8]]])
+      expect(positions_for("def m\n  yield 1\n  yield 2\nend")).to eq([[[2, 8, 2, 9], [3, 8, 3, 9]]])
     end
 
     it "has nothing to say when the arity itself is unknown" do

--- a/spec/lib/rbs_infer/signatures/steep_bridge_spec.rb
+++ b/spec/lib/rbs_infer/signatures/steep_bridge_spec.rb
@@ -1170,7 +1170,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
   end
 
   describe "#all_expression_types" do
-    it "maps line:column to type for all typed expressions" do
+    it "maps every typed expression to its type" do
       code = <<~RUBY
         class Foo
           def bar
@@ -1184,6 +1184,27 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
       # The lvasgn for x is on line 3
       typed_values = result.values
       expect(typed_values).to include("(Comment & Comment::Validated)")
+    end
+
+    # felixefelip/rbs_infer#168. A receiver starts exactly where its call does,
+    # so three expressions here begin at 3:4 and only the range tells them
+    # apart. Keyed by the start alone they collapsed into one entry, and the
+    # answer the caller-side inference read was whichever `each_typing` yielded
+    # last — the receiver, whenever the call itself was `untyped`.
+    it "keys an expression by its whole range, so a receiver cannot answer for its call" do
+      code = <<~RUBY
+        class Foo
+          def bar
+            Comment.find(1).body
+          end
+        end
+      RUBY
+
+      result = bridge.all_expression_types(code)
+
+      expect(result["3:4-3:11"]).to eq("singleton(Comment)")
+      expect(result["3:4-3:19"]).to eq("(Comment & Comment::Validated)")
+      expect(result["3:4-3:24"]).to eq("String")
     end
 
     it "returns empty hash for unparseable code" do


### PR DESCRIPTION
Fixes the bug recorded by Example21 (#168).

## The bug

`SteepBridge#all_expression_types` (#155) filed every typed expression under `line:column`. A receiver starts exactly where its call does, so in

```ruby
Registry.holder = ticket.holder
```

`ticket` and `ticket.holder` shared one key, and whichever `each_typing` yielded last took it:

```
79:22
    79:22-79:28  :send  Example21::Ticket?   "ticket"
    79:22-79:35  :send  untyped              "ticket.holder"
```

It stayed hidden while the call had a type of its own — either answer was at least *about* the right expression. It surfaced when the call was `untyped`: the map drops those, so the receiver was left answering for the whole expression and `holder=` took a `Ticket?`, the object that HAS a holder rather than the holder. Found in Fizzy as `Current#identity=` taking a `Session`, from where every `Current.identity` in the app was a `Session` as far as the checker knew.

## The fix

The key carries both ends of the expression. A position does not name an expression, and neither widest-at-a-position nor narrowest decides it — `Current.with` wants the inner answer where this wants the outer.

Both sides build the key through one place, `SteepBridge.expression_key` / `.prism_expression_key`, so the producer and the three lookups can't drift apart:

- `NewCallCollector#expression_type` — the call-site argument fallback
- `BlockReturnCollector.block_return_type`
- `Analyzer#block_param_type`, with `BlockSignature#arg_positions` now recording both ends

## Measured

Over the whole dummy (`app/`, `sig/`, `lib/`), restricted to the shapes those lookups actually consult (call arguments, a block's last statement, `yield`/`.call` arguments):

| | |
|---|---|
| answers unchanged | 510 |
| answers changed | 0 |
| answers dropped | 74 |

Every dropped answer is a receiver or a hash key answering for something larger: `ticket.holder`→`Ticket?`, `Example10::Bar.new.greet`→`Bar`, `ProfileFormatter.new(…).call`→`ProfileFormatter`, `controller.request`→the controller's type, and 65 keyword hashes that answered `Symbol`/`:if`. Prism and Parser agree on end columns — the 510 exact matches are the proof.

## What it costs

An expression the checker genuinely cannot type now says so, instead of borrowing its receiver's type. Four places in the dummy show it:

```diff
 class Example21::Registry
-  def self.holder=: (Example21::Ticket? value) -> Example21::Ticket?
-  def self.holder: () -> Example21::Ticket?
+  def self.holder=: (untyped value) -> untyped
+  def self.holder: () -> untyped
 class Example10::Sink
-  def self.last=: (Example10::Bar value) -> Example10::Bar
+  def self.last=: (untyped value) -> untyped
 class Current
-  def self.with: (…) ?{ () -> ProfileFormatter } -> ProfileFormatter?
+  def self.with: (…) ?{ () -> untyped } -> untyped
 class ProfileFormatterJob
-  def perform: () -> ProfileFormatter?
+  def perform: () -> untyped
```

Each was "typed" from a receiver: `Bar.new.greet` is untyped while `greet` errors under the const-RHS gap the example10 fixture documents, and `ProfileFormatter#call` is untyped by the gap its own fixture notes (`# o retorno deveria ser String?`).

Example21's recorded target is met — the baseline loses

```
app/models/example21.rb:86:31: [error] Type `(::Example21::Ticket | nil)` does not have method `name`
```

and keeps the precondition on the assignment itself. 28 baseline entries, none new.

## Follow-up, not in this PR

Reaching `Holder` rather than `untyped` for `Registry.holder=` is a separate step: the structural chain asks the caller class's method map for `ticket` and gets `untyped`, while `MethodTypeResolver#resolve` answers `Example21::Ticket?` for the same question — and `resolve("Example21::Ticket?", "holder")` is already `Example21::Holder`. So `resolve_all` being weaker than `resolve` is what stands between the two, and it is worth its own issue.

## Tests

`921 examples, 0 failures`, including a new bridge spec pinning three expressions that share a start column (`Comment.find(1).body`) to three separate answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
