### PR TITLE
test: the const-write RHS is in the flow, so example10's chain types end to end

### DIFF
--- a/spec/dummy/app/models/example10.rb
+++ b/spec/dummy/app/models/example10.rb
@@ -22,34 +22,35 @@ class Example10
   class Bar
     # Reached ONLY from the right-hand side of a constant write in `run`, where
     # `Foo.name` is already established — so a human reading the source sees this
-    # read as non-nil.
+    # read as non-nil, and so does the checker now that the RHS is part of the
+    # flow. This is the method whose return the whole chain below hangs on.
     def greet
-      Example10::Foo.name.upcase # should: "JOHN DOE"; actual: error (const RHS gap)
+      Example10::Foo.name.upcase # "JOHN DOE"
     end
   end
 
-  # CONST-WRITE RHS gap. `method_events` classifies `Const.attr = <rhs>` as a
-  # `:const_write` event and stops there: the RHS is never walked for calls, so
-  # `Bar.new.greet` is invisible to the flow and `greet` never receives the
-  # `Foo.name` fact established one line above.
+  # CONST-WRITE RHS. `method_events` classified `Const.attr = <rhs>` as a
+  # `:const_write` event and stopped there: the RHS was never walked for calls,
+  # so `Bar.new.greet` was invisible to the flow and `greet` never received the
+  # `Foo.name` fact established one line above — `Foo.name.upcase` errored.
   #
   # The RHS runs BEFORE the assignment, so its calls belong to the flow in that
   # order — exactly the reasoning already applied to `@x = <rhs>` when ivar
   # writes were introduced (felixefelip/steep#91). There, classifying the
   # statement as a write initially swallowed the RHS calls and dropped the entry
   # facts of 12 dummy methods; it was fixed by recording the RHS calls first,
-  # then the write. Constant writes never had that treatment — this fixture is
-  # the pre-existing half of the same shape.
+  # then the write. Constant writes got the same treatment in
+  # felixefelip/steep#131, which is what this fixture now pins.
   #
-  # Note the gap is about which CALLS are visited, not about the write itself.
-  # What `Sink.last` is established AS does follow from it, though: while `greet`
-  # errors it is `untyped`, so the write says nothing about the type. It read
-  # `Example10::Bar` until felixefelip/rbs_infer#168 — the receiver of the RHS,
-  # which begins at the same column as the RHS itself and so answered for it
-  # while the map was keyed by a position. Closing the gap above is what would
-  # make this a `String`.
+  # The gap was about which CALLS are visited, not about the write itself — but
+  # what `Sink.last` is established AS followed from it, because an erroring
+  # `greet` is `untyped` and a write of `untyped` says nothing. That slot read
+  # `Example10::Bar` until felixefelip/rbs_infer#168 (the receiver of the RHS,
+  # which begins at the same column as the RHS itself, answering for it while the
+  # map was keyed by a position), then `untyped`, and now `String` — what `greet`
+  # returns, which is what the source said all along.
   def run
     Example10::Foo.name = 'John Doe'
-    Example10::Sink.last = Example10::Bar.new.greet # RHS call NOT walked -> greet errors
+    Example10::Sink.last = Example10::Bar.new.greet
   end
 end

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -277,6 +277,7 @@ postconditions:
   unconditional:
     consts:
       Example10::Foo.name: "::String"
+      Example10::Sink.last: "::String"
 - class: Example10::Foo
   method: name
   effects:
@@ -291,6 +292,20 @@ postconditions:
   effects:
     may_write:
     - "@name"
+- class: Example10::Sink
+  method: last
+  effects:
+    returns_ivar: "@last"
+- class: Example10::Sink
+  method: last=
+  unconditional:
+    ivars:
+      "@last": "::String"
+    establishes_consts:
+      last: "::String"
+  effects:
+    may_write:
+    - "@last"
 - class: Example11::Partial
   method: initialize
   effects:
@@ -1504,10 +1519,6 @@ method_entry_facts:
     Current.user: "(::User & ::User::Validated)"
     Current.viewer_name: "::String"
 - class: ApplicationController
-  method: current_user
-  ivars:
-    "@__rbs_infer__performed": 'true'
-- class: ApplicationController
   method: log_user_author_name
   self_methods:
     current_user: "(::User & ::User::Validated)"
@@ -1695,6 +1706,14 @@ method_entry_facts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
     Current.viewer_name: "::String"
+- class: Example10::Bar
+  method: greet
+  consts:
+    Example10::Foo.name: "::String"
+- class: Example10::Foo
+  method: name
+  consts:
+    Example10::Foo.name: "::String"
 - class: Example12
   method: dispatch_age
   ivars:
@@ -1735,10 +1754,6 @@ method_entry_facts:
     current_user: "::Example13Viewer"
   consts:
     Example13::Registry.user: "::Example13Viewer"
-- class: Example13::Guarded
-  method: current_user
-  self_methods:
-    current_user: "::Example13Viewer"
 - class: Example13::Registry
   method: user
   consts:

--- a/spec/dummy/sig/rbs_infer/app/models/example10.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example10.rbs
@@ -1,5 +1,5 @@
 class Example10
-  def run: () -> untyped
+  def run: () -> String
 end
 
 class Example10
@@ -13,13 +13,15 @@ end
 
 class Example10
   class Sink
-    def self.last: () -> untyped
-    def self.last=: (untyped value) -> untyped
+    self.@last: String?
+
+    def self.last: () -> String?
+    def self.last=: (String value) -> String
   end
 end
 
 class Example10
   class Bar
-    def greet: () -> untyped
+    def greet: () -> String
   end
 end

--- a/spec/expectations/models/example10.rbs
+++ b/spec/expectations/models/example10.rbs
@@ -1,5 +1,5 @@
 class Example10
-  def run: () -> untyped
+  def run: () -> String
 end
 
 class Example10
@@ -13,13 +13,15 @@ end
 
 class Example10
   class Sink
-    def self.last: () -> untyped
-    def self.last=: (untyped value) -> untyped
+    self.@last: String?
+
+    def self.last: () -> String?
+    def self.last=: (String value) -> String
   end
 end
 
 class Example10
   class Bar
-    def greet: () -> untyped
+    def greet: () -> String
   end
 end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -1,6 +1,5 @@
 app/models/concerns/test/filtrable.rb:16:13: [error] Type `(::Post & ::Test::Filtrable)` does not have method `adddd`
 app/models/concerns/test/filtrable.rb:16:4: [error] Type `(::Post & ::Test::Filtrable)` does not have method `asdasd`
-app/models/example10.rb:27:26: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example14.rb:15:17: [error] Type `(::Example14::User | nil)` does not have method `name`
 app/models/example15.rb:25:25: [error] Type `(::Example15::User | nil)` does not have method `name`
 app/models/example20.rb:67:25: [error] Type `(::Example20::User | nil)` does not have method `name`

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -375,9 +375,11 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     expect(rbs.chomp).to eq(expected_rbs(name).chomp)
   end
 
-  # CONST-WRITE RHS. `Const.attr = <rhs>` classifies as a write and the RHS is
-  # walked for calls first, so a callee reached only from there — `Bar.new.greet`
-  # — still receives the facts established above it.
+  # CONST-WRITE RHS (felixefelip/steep#131). `Const.attr = <rhs>` classifies as a
+  # write and the RHS is walked for calls first, so a callee reached only from
+  # there — `Bar.new.greet` — still receives the facts established above it. What
+  # the snapshot pins is the whole chain that follows: `greet` types as `String`
+  # rather than erroring, so the write carries a `String` and `run` returns one.
   it "example10" do
     name = "models/example10"
     rbs = RbsInfer::Analyzer.new(


### PR DESCRIPTION
Pairs with **felixefelip/steep#131** — merge that first, this PR carries what it moves in the dummy.

## The `untyped` in example10 was never rbs_infer's

`Example10::Bar#greet` is reached only from the right-hand side of

```ruby
Example10::Sink.last = Example10::Bar.new.greet
```

and `MethodEntryInferrer#body_events` classified that statement as a `:const_write` and stopped there. So `greet` appeared in no event of the flow, never saw `Example10::Foo.name` established one line above, and its body errored:

```
app/models/example10.rb:27:26: [error] Type `(::String | nil)` does not have method `upcase`
```

An erroring body is `untyped`, and a write of `untyped` says nothing — which is how the whole chain below it went untyped in #169.

## With the RHS in the flow

```diff
 class Example10
-  def run: () -> untyped
+  def run: () -> String
 class Example10::Sink
-  def self.last: () -> untyped
-  def self.last=: (untyped value) -> untyped
+  self.@last: String?
+  def self.last: () -> String?
+  def self.last=: (String value) -> String
 class Example10::Bar
-  def greet: () -> untyped
+  def greet: () -> String
```

Note this is not a return to the pre-#169 reading. That was `Example10::Bar` — the **receiver** of the RHS, which the position-keyed map let answer for the whole expression. `String` is what `greet` actually returns.

## Baseline

Loses `app/models/example10.rb:27:26`, gains nothing: **29 → 28 entries**.

## The sidecar moves in both directions, from the same cause

It gains what the write now proves — `Example10::Sink.last: ::String`, and `Example10::Bar#greet`'s entry seeing `Example10::Foo.name: ::String`.

It also loses two entry-fact records, both for `current_user`: `ApplicationController`'s `@__rbs_infer__performed` and `Example13::Guarded`'s self-method. An entry fact is the intersection over every flow that reaches the method, and both now have one more flow to intersect with — the RHS of `Current.user = current_user` (`application_controller.rb:24`, `dashboard_controller.rb:46`) and `Registry.user = current_user` (`example13.rb:93`), call sites the checker was blind to. Strictly more correct, and nothing in the dummy depended on them: no error appears.

## Regeneration order, for the record

The dummy needs `steep check` **before** `make rbs_infer`: the entry facts live in `.steep_postconditions.yml`, and rbs_infer's bridge reads that file rather than recomputing the flow. Run the other way round the new types never appear. Looped to a fixed point (sidecar stable, `make rbs_infer` idempotent) before regenerating expectations and the baseline.

## Tests

`927 examples, 0 failures`. The fixture comments in `example10.rb` and the snapshot's own comment now describe the closed gap instead of the pending one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
