### PR TITLE
fix: a block parameter written as a bare `&` is still a block

### DIFF
--- a/lib/rbs_infer/inference/class_member_collector/block_signature.rb
+++ b/lib/rbs_infer/inference/class_member_collector/block_signature.rb
@@ -37,7 +37,7 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
 
     # The RBS fragment, or nil when the method takes no block at all.
     def call
-      return nil unless block_param_name || yields?
+      return nil unless block_param? || yields?
 
       "#{"?" unless required?}{ (#{block_params}) -> untyped }"
     end
@@ -65,7 +65,7 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
     # optional whatever the callee wants, and a direct call has already answered
     # the question with better evidence than a callee's declaration.
     def open_forward?
-      !block_param_name.nil? && use_sites.empty? && forwards_block? && !guards_block?
+      block_param? && use_sites.empty? && forwards_block? && !guards_block?
     end
 
     private
@@ -74,8 +74,25 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
       (yields? || calls_block_param?) && !guards_block?
     end
 
+    # Whether the method declares a block parameter at all — the question that
+    # decides whether a block belongs in the signature.
+    #
+    # It used to be asked as "does it have a NAME", which Ruby 3.1's anonymous
+    # `&` answers no to: `def button_to_copy_to_clipboard(url, &)` takes a block
+    # and forwards it as a bare `&`. The signature came out with no block clause,
+    # and every `<%= button_to_copy_to_clipboard(url) do %>` then read as
+    # `Ruby::UnexpectedBlockGiven` — thirty-two view lines in Fizzy, across the
+    # twelve helpers written that way (felixefelip/rbs_infer#174).
+    def block_param?
+      @params.respond_to?(:block) && !@params.block.nil?
+    end
+
+    # The block's local-variable name, or nil when it is anonymous. Only the
+    # questions that need to FIND the block in the body (`block.call`, `if
+    # block`) go through this — an anonymous block cannot be named, so it can
+    # only be forwarded or asked about with `block_given?`.
     def block_param_name
-      return nil unless @params.respond_to?(:block) && @params.block
+      return nil unless block_param?
 
       @params.block.name&.to_s
     end
@@ -131,12 +148,17 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
       end
     end
 
-    # `foo(&block)` — the block leaving this method for another one.
+    # `foo(&block)` — the block leaving this method for another one. An anonymous
+    # parameter is forwarded as a bare `&`, which Prism spells as the same
+    # `BlockArgumentNode` with no expression.
     def forwards_block?
-      name = block_param_name or return false
+      return false unless block_param?
 
+      name = block_param_name
       walk_body do |node|
-        node.is_a?(Prism::BlockArgumentNode) && reads_block?(node.expression, name)
+        next false unless node.is_a?(Prism::BlockArgumentNode)
+
+        name ? reads_block?(node.expression, name) : node.expression.nil?
       end
     end
 

--- a/lib/rbs_infer/signatures/steep_bridge/block_analyzer.rb
+++ b/lib/rbs_infer/signatures/steep_bridge/block_analyzer.rb
@@ -44,6 +44,12 @@ class RbsInfer::Signatures::SteepBridge
     # `&block_param` — the method's own block on its way out. `&:symbol` is a
     # proc literal built on the spot, not this method's block, so it is not a
     # forward and never reaches the callee lookup.
+    #
+    # The anonymous forward (`other(url, &)`) is the same thing said without a
+    # name, and Parser spells it as a `block_pass` with a nil child rather than
+    # an `lvar` one. Reading only the `lvar` shape left those methods with the
+    # callee's requirement unasked — `?{ (*untyped) }` where the callee makes it
+    # `{ (String) }` (felixefelip/rbs_infer#174).
     def each_forwarded_block(typing, &block)
       walk_forwarded_blocks(typing.source.node, nil, false, &block)
     end
@@ -57,8 +63,10 @@ class RbsInfer::Signatures::SteepBridge
       when :sclass then singleton = true
       when :send, :csend
         forwarded = node.children.any? do |child|
-          child.is_a?(Parser::AST::Node) && child.type == :block_pass &&
-            child.children[0]&.type == :lvar
+          next false unless child.is_a?(Parser::AST::Node) && child.type == :block_pass
+
+          inner = child.children[0]
+          inner.nil? || inner.type == :lvar
         end
         block.call(node, method_key) if forwarded && method_key
       end

--- a/spec/dummy/app/models/example17.rb
+++ b/spec/dummy/app/models/example17.rb
@@ -74,6 +74,24 @@ class Example17
     with_token(&block) if block
   end
 
+  # The same forward, with Ruby 3.1's ANONYMOUS block parameter. `&` declares a
+  # block and has no name, so a rule that asks for the name concluded the method
+  # takes none and left the block out of the signature entirely — after which
+  # every `forward_anonymous { … }` is `Ruby::UnexpectedBlockGiven`. Found in
+  # Fizzy, where twelve helpers are written this way
+  # (`def button_to_copy_to_clipboard(url, &)`) and thirty-two view lines failed
+  # on it (felixefelip/rbs_infer#174).
+  def forward_anonymous(&)
+    with_token(&)
+  end
+
+  # A guard needs no name either — `block_given?` asks the question for both
+  # spellings — so this stays optional where the one above is settled by the
+  # callee.
+  def forward_anonymous_guarded(&)
+    with_token(&) if block_given?
+  end
+
   def name
     "example"
   end

--- a/spec/dummy/sig/rbs_infer/app/models/example17.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example17.rbs
@@ -7,6 +7,8 @@ class Example17
   def forward_required: () { (String) -> untyped } -> String
   def forward_optional: () ?{ (*untyped) -> untyped } -> untyped
   def forward_guarded: () ?{ (*untyped) -> untyped } -> String?
+  def forward_anonymous: () { (String) -> untyped } -> String
+  def forward_anonymous_guarded: () ?{ (*untyped) -> untyped } -> String?
   def name: () -> String
   def run: () -> String
 end

--- a/spec/expectations/models/example17.rbs
+++ b/spec/expectations/models/example17.rbs
@@ -7,6 +7,8 @@ class Example17
   def forward_required: () { (String) -> untyped } -> String
   def forward_optional: () ?{ (*untyped) -> untyped } -> untyped
   def forward_guarded: () ?{ (*untyped) -> untyped } -> String?
+  def forward_anonymous: () { (String) -> untyped } -> String
+  def forward_anonymous_guarded: () ?{ (*untyped) -> untyped } -> String?
   def name: () -> String
   def run: () -> String
 end

--- a/spec/lib/rbs_infer/inference/class_member_collector/block_signature_spec.rb
+++ b/spec/lib/rbs_infer/inference/class_member_collector/block_signature_spec.rb
@@ -48,6 +48,39 @@ RSpec.describe RbsInfer::Inference::ClassMemberCollector::BlockSignature do
     end
   end
 
+  # felixefelip/rbs_infer#174. Ruby 3.1's `&` is a block parameter with no NAME,
+  # so asking for the name to decide whether there IS a block answered no, and
+  # the signature came out with no block clause at all. Every call site passing
+  # one then reads as `Ruby::UnexpectedBlockGiven`.
+  describe "anonymous block parameter" do
+    it "declares the block a method takes as a bare `&`" do
+      expect(signature_for("def m(url, &); other(url, &); end")).to eq("?{ (*untyped) -> untyped }")
+    end
+
+    it "counts the bare `&` as a forward, so the callee can settle it" do
+      def_node = Prism.parse("def m(url, &); other(url, &); end").value.statements.body.first
+      signature = described_class.new(def_node.parameters, body: def_node.body)
+
+      expect(signature.open_forward?).to be(true)
+    end
+
+    it "still reads a guard, which no name is needed for" do
+      def_node = Prism.parse("def m(&); other(&) if block_given?; end").value.statements.body.first
+      signature = described_class.new(def_node.parameters, body: def_node.body)
+
+      expect(signature.call).to eq("?{ (*untyped) -> untyped }")
+      expect(signature.open_forward?).to be(false)
+    end
+
+    it "is required when the body yields, anonymous parameter or not" do
+      expect(signature_for("def m(&); yield 1; end")).to eq("{ (untyped) -> untyped }")
+    end
+
+    it "keeps saying nothing about a method with no block at all" do
+      expect(signature_for("def m(url); other(url); end")).to be_nil
+    end
+  end
+
   describe "arity" do
     it "takes the arity from the use site" do
       expect(signature_for("def m(&block); block.call(1, 2); end")).to eq("{ (untyped, untyped) -> untyped }")

--- a/spec/lib/rbs_infer/signatures/steep_bridge/block_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/signatures/steep_bridge/block_analyzer_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+require "rbs_infer"
+
+RSpec.describe RbsInfer::Signatures::SteepBridge::BlockAnalyzer, :dummy_app do
+  subject(:bridge) { RbsInfer::Signatures::SteepBridge.new }
+
+  # A method that only hands its block to someone else says nothing about it on
+  # its own, so the CALLEE's declaration is the evidence (felixefelip/rbs_infer#149).
+  describe "#forwarded_block_requirements" do
+    it "takes the requirement from the callee of a named forward" do
+      code = <<~RUBY
+        class Foo
+          def named(&block)
+            Example17.new.with_token(&block)
+          end
+        end
+      RUBY
+
+      expect(bridge.forwarded_block_requirements(code)["named"])
+        .to eq(required: true, params: ["String"])
+    end
+
+    # felixefelip/rbs_infer#174. The anonymous forward is the same statement
+    # without a name, and Parser spells it as a `block_pass` whose child is nil
+    # rather than an `lvar`. Reading only the `lvar` shape left the callee
+    # unasked, so the method kept `?{ (*untyped) }` where the named spelling of
+    # the very same body gets `{ (String) }`.
+    it "reads an anonymous forward the same way" do
+      code = <<~RUBY
+        class Foo
+          def anonymous(&)
+            Example17.new.with_token(&)
+          end
+        end
+      RUBY
+
+      expect(bridge.forwarded_block_requirements(code)["anonymous"])
+        .to eq(required: true, params: ["String"])
+    end
+
+    # `&:symbol` builds a proc on the spot; it is not this method's block, so it
+    # is not a forward and the callee has no say over a block this method never
+    # declared.
+    it "does not read `&:symbol` as a forward" do
+      code = <<~RUBY
+        class Foo
+          def symbol_proc(items)
+            items.map(&:to_s)
+          end
+        end
+      RUBY
+
+      expect(bridge.forwarded_block_requirements(code)).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Found by regenerating Fizzy: twelve helpers there are written with Ruby 3.1's anonymous block parameter, and all twelve came out with no block in their signature.

```ruby
def button_to_copy_to_clipboard(url, &)    # => (untyped url) -> untyped
def button_to_copy_to_clipboard(url, &b)   # => (untyped url) ?{ … } -> untyped
```

Every call site passing a block then fails:

```
app/views/layouts/shared/_time_zone.html.erb:2:64: [error] The method cannot be called with a block
│ Diagnostic ID: Ruby::UnexpectedBlockGiven
└   <%= auto_submit_form_with url: my_timezone_path, method: :put do %>
```

**32 such errors in Fizzy**, across `access_menu_tag`, `auto_submit_form_with`, `bridged_form_with`, `button_to_copy_to_clipboard`, `messages_tag`, `notification_tag`, `pagination_frame_tag`, `day_timeline_pagination_frame_tag`, `link_to_webhooks`, `with_account`, `without_account`, `set_current_timezone`.

## Cause

`BlockSignature#call` returned nil when `block_param_name` was nil, and `&` is a block parameter with **no name**. Before #147 the rule was "there is a `&block` parameter → `?{ (untyped) -> untyped }`", which covered the anonymous spelling by accident.

## Fix

Existence and name become separate questions:

- `block_param?` — does the method declare a block at all. Decides whether a block clause is emitted, and whether the forward is open (#149).
- `block_param_name` — stays, for the questions that must *find* the block in the body (`block.call`, `if block`). An anonymous block can't be the subject of those; it can only be forwarded, or asked about with `block_given?`, which needs no name and already worked.

Forwarding needed the same split on both sides:

| | named | anonymous |
|---|---|---|
| Prism (`BlockSignature#forwards_block?`) | `BlockArgumentNode` wrapping an `lvar` read | `BlockArgumentNode` with **no expression** |
| Parser (`BlockAnalyzer#walk_forwarded_blocks`) | `block_pass` with an `lvar` child | `block_pass` with a **nil** child |

Without the second half the callee's requirement was never asked for, so the method kept `?{ (*untyped) }` where the named spelling of the same body gets `{ (String) }`. `&:symbol` stays excluded — a proc built on the spot is not this method's block.

## Fixture

example17 (the block-parameter fixture) gains the two shapes, and the anonymous forward now reads exactly like the named one beside it:

```diff
 def forward_required: () { (String) -> untyped } -> String
 def forward_optional: () ?{ (*untyped) -> untyped } -> untyped
 def forward_guarded: () ?{ (*untyped) -> untyped } -> String?
+def forward_anonymous: () { (String) -> untyped } -> String
+def forward_anonymous_guarded: () ?{ (*untyped) -> untyped } -> String?
```

## Tests

`939 examples, 0 failures`. Unit specs for both halves: five on `BlockSignature` (declared, forward is open, guard still read without a name, `yield` still required, a method with no block still says nothing) and a new `BlockAnalyzer` spec pinning that the named and anonymous forwards get the same answer from the callee, and that `&:symbol` is not a forward. Dummy steep check unchanged at 28 problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
