### PR TITLE
fix: give every caller-file walk the mixin graph, so a concern's `self` has a type

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -953,7 +953,7 @@ module RbsInfer
   def find_new_calls
     positional_params = extract_init_positional_params
     target_methods = extract_target_method_params
-    analyzer = RbsInfer::Inference::CallerFileAnalyzer.new(target_class: @target_class, method_type_resolver: method_type_resolver, target_file: @target_file, init_positional_params: positional_params, target_methods: target_methods, steep_bridge: steep_bridge)
+    analyzer = RbsInfer::Inference::CallerFileAnalyzer.new(target_class: @target_class, method_type_resolver: method_type_resolver, target_file: @target_file, init_positional_params: positional_params, target_methods: target_methods, steep_bridge: steep_bridge, mixin_index: mixin_index)
     @source_index.files_referencing(@target_class).flat_map { |file| analyzer.analyze(file) }
   end
 
@@ -1134,7 +1134,7 @@ module RbsInfer
   end
 
   def method_type_resolver
-    @method_type_resolver ||= RbsInfer::Signatures::MethodTypeResolver.new(@source_files, source_index: @source_index, parse_cache: @parse_cache, file_index: @file_index, caller_file_cache: @caller_file_cache, constant_resolver: env_only_constant_resolver)
+    @method_type_resolver ||= RbsInfer::Signatures::MethodTypeResolver.new(@source_files, source_index: @source_index, parse_cache: @parse_cache, file_index: @file_index, caller_file_cache: @caller_file_cache, constant_resolver: env_only_constant_resolver, mixin_index: mixin_index)
   end
 
   def type_merger

--- a/lib/rbs_infer/inference/caller_file_analyzer.rb
+++ b/lib/rbs_infer/inference/caller_file_analyzer.rb
@@ -12,7 +12,7 @@ module RbsInfer::Inference
     # covered by `IntraClassCallAnalyzer`. Omitting it would double-count every same-file
     # self-call — the two paths resolve the receiver differently, so the parameter widens
     # into a union instead of failing loudly (required-threaded-deps).
-    def initialize(target_class:, method_type_resolver:, target_file:, init_positional_params: [], target_methods: {}, steep_bridge: nil, block_methods: Set.new, method_owners: {}, mixin_index: nil)
+    def initialize(target_class:, method_type_resolver:, target_file:, mixin_index:, init_positional_params: [], target_methods: {}, steep_bridge: nil, block_methods: Set.new, method_owners: {})
       @target_class = target_class
       @target_file = target_file
       @method_type_resolver = method_type_resolver
@@ -25,6 +25,13 @@ module RbsInfer::Inference
       @method_owners = method_owners
       # The `include`s written across the sources — what a module's `self` is,
       # for the files scanned as callers (felixefelip/rbs_infer#163).
+      #
+      # Required, not defaulted: without it every module's `self` on this path is
+      # `untyped`, which reads as an answer. One of the Analyzer's two
+      # constructions omitted it, and that is the one deciding `initialize`
+      # parameters — `WidgetAuditor.new(self)` in a concern typed its parameter
+      # `untyped` while the other construction, wired, read the intersection
+      # (felixefelip/rbs_infer#175).
       @mixin_index = mixin_index
       @method_call_usages = Hash.new { |h, k| h[k] = [] }
       @method_block_returns = Hash.new { |h, k| h[k] = [] }
@@ -149,11 +156,9 @@ module RbsInfer::Inference
       # named after: the framework transcription puts several in one file, and
       # the name that stands for it is the outermost wrapper
       # (`ActionController::HttpAuthentication`), which nobody includes.
-      module_self_types = defined_names.to_h do |name|
-        [name, RbsInfer::Project::SelfTypeAnnotators.instance_type(
-          path: file, module_name: name, source: source, mixin_index: @mixin_index
-        )]
-      end.compact
+      module_self_types = RbsInfer::Project::SelfTypeAnnotators.instance_types(
+        path: file, module_names: defined_names, source: source, mixin_index: @mixin_index
+      )
 
       visitor = NewCallCollector.new(
         target_class: @target_class,
@@ -220,7 +225,10 @@ module RbsInfer::Inference
         # Pre-converted ERB source has no constant defs of its own → {}.
         constant_arg_resolver: ConstantArgTypeResolver.new(steep_bridge: @steep_bridge, caller_constant_types: {}),
         # ERB-converted source defines no classes → empty; nothing to disambiguate.
-        defined_class_names: NewCallCollector.collect_defined_class_names(result.value)
+        defined_class_names: NewCallCollector.collect_defined_class_names(result.value),
+        # A template declares no module either, so there is no module `self` to
+        # resolve here — the empty map is the answer, not a missing wire.
+        module_self_types: {}
       )
       result.value.accept(visitor)
 

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -28,7 +28,7 @@ module RbsInfer::Inference
       names
     end
 
-    def initialize(target_class:, method_return_types:, local_var_types:, constant_arg_resolver:, defined_class_names:, local_var_read_types: {}, local_var_types_by_method: {}, method_type_resolver: nil, caller_class_name: nil, init_positional_params: [], target_methods: {}, match_bare_calls: false, self_types_by_method: {}, module_self_types: {}, established_ivars_by_method: {}, argument_partitions_by_method: {}, block_methods: Set.new, expression_types: {}, method_owners: {})
+    def initialize(target_class:, method_return_types:, local_var_types:, constant_arg_resolver:, defined_class_names:, local_var_read_types: {}, local_var_types_by_method: {}, method_type_resolver: nil, caller_class_name: nil, init_positional_params: [], target_methods: {}, match_bare_calls: false, self_types_by_method: {}, module_self_types:, established_ivars_by_method: {}, argument_partitions_by_method: {}, block_methods: Set.new, expression_types: {}, method_owners: {})
       @target_class = target_class
       # FQNs of classes/modules defined in the file being scanned; disambiguates
       # a relative receiver from a same-simple-name class elsewhere (see
@@ -68,6 +68,13 @@ module RbsInfer::Inference
       # INSTANCE methods see as `self`, from the self-type annotators. Keyed by
       # module, because one file can declare several and they have different
       # includers (felixefelip/rbs_infer#165).
+      #
+      # Required, not defaulted (required-threaded-deps): a caller that forgets it
+      # gets `untyped` for every `self` inside a concern, which is an answer rather
+      # than a failure. That is exactly what happened to `MethodTypeResolver`'s two
+      # walks over caller files — `Detector.new(self)` in `Card::Stallable` typed
+      # the parameter `untyped` while the caller-file walk beside it, wired with
+      # the same map, read `(Card & Card::Stallable)` (felixefelip/rbs_infer#175).
       @module_self_types = module_self_types
       # `{ "set_post" => { "@post" => "(::Post & ::Post::Validated)" } }` — ivars a
       # self-method proves populated once it has run (postconditions sidecar). Applied

--- a/lib/rbs_infer/project/self_type_annotators.rb
+++ b/lib/rbs_infer/project/self_type_annotators.rb
@@ -95,6 +95,20 @@ module RbsInfer::Project
       "(#{type})" if type
     end
 
+    # `{ "Card::Stallable" => "(Card & Card::Stallable)" }` for the modules a file
+    # declares — what `self` is in each of them, which is what a call site inside a
+    # concern passes when it writes `Detector.new(self)`.
+    #
+    # One place, because two of them ask: the caller-file walk and the resolver's
+    # own walks over the same files. Answering it in only one of them is how
+    # `Card::ActivitySpike::Detector#initialize` came out `untyped` while the
+    # sidecar had the answer all along (felixefelip/rbs_infer#175).
+    def instance_types(path:, module_names:, source:, mixin_index:)
+      module_names.to_h do |name|
+        [name, instance_type(path: path, module_name: name, source: source, mixin_index: mixin_index)]
+      end.compact
+    end
+
     # `mixin_index` is passed only to annotators that ask for it, so adding it
     # to the contract does not break one written against the older three
     # (felixefelip/rbs_infer#163).

--- a/lib/rbs_infer/signatures/method_type_resolver.rb
+++ b/lib/rbs_infer/signatures/method_type_resolver.rb
@@ -15,10 +15,18 @@ module RbsInfer::Signatures
     # Required, not defaulted: a caller that forgets it silently degrades those
     # types to untyped. Callers without a project SteepBridge can still pass an
     # env-only ConstantArgTypeResolver (the RBS env is process-global).
-    def initialize(source_files, constant_resolver:, source_index: nil, parse_cache: nil, file_index: nil, caller_file_cache: nil)
+    # mixin_index: required (felixefelip/rbs_infer#175). It is what says who
+    # includes a module, and therefore what `self` is inside one — so a call site
+    # in a concern (`Detector.new(self)`) has a type to pass. A caller that
+    # forgets it does not fail: `self` resolves to `untyped` on this path, the
+    # parameter it feeds goes untyped with it, and the class's contracts stop
+    # being inferrable. Passed in rather than built here, because building one is
+    # a full sweep of the project's files and the Analyzer already has it.
+    def initialize(source_files, constant_resolver:, mixin_index:, source_index: nil, parse_cache: nil, file_index: nil, caller_file_cache: nil)
       @source_files = source_files
       @source_index = source_index
       @constant_resolver = constant_resolver
+      @mixin_index = mixin_index
       @parse_cache = parse_cache || RbsInfer::Project::ParseCache.new
       @file_index = file_index || RbsInfer::Project::FileIndex.new(source_files)
       @caller_file_cache = caller_file_cache || RbsInfer::Project::CallerFileCache.new(@parse_cache)
@@ -171,6 +179,16 @@ module RbsInfer::Signatures
 
     private
 
+    # What `self` is in each module the scanned file declares, so a call site
+    # inside a concern passes the host's type rather than nothing. Both walks
+    # below scan caller files exactly as the Analyzer's own walk does, and this
+    # is the piece they were missing (felixefelip/rbs_infer#175).
+    def module_self_types_for(file, entry, defined_names)
+      RbsInfer::Project::SelfTypeAnnotators.instance_types(
+        path: file, module_names: defined_names, source: entry.source, mixin_index: @mixin_index
+      )
+    end
+
     def build_init_param_types(class_name)
       @building_init_params ||= Set.new
       return {} if @building_init_params.include?(class_name)
@@ -212,6 +230,7 @@ module RbsInfer::Signatures
         end
 
         local_var_types = {}
+        defined_names = RbsInfer::Inference::NewCallCollector.collect_defined_class_names(entry.result.value)
         visitor = RbsInfer::Inference::NewCallCollector.new(
           target_class: class_name,
           method_return_types: mrt,
@@ -221,7 +240,8 @@ module RbsInfer::Signatures
           # Env-aware resolver so constant call-site args resolve to their value
           # type via the loaded RBS env, not a bare name (#46, #56).
           constant_arg_resolver: @constant_resolver,
-          defined_class_names: RbsInfer::Inference::NewCallCollector.collect_defined_class_names(entry.result.value)
+          defined_class_names: defined_names,
+          module_self_types: module_self_types_for(file, entry, defined_names)
         )
         entry.result.value.accept(visitor)
         all_usages.concat(visitor.usages)
@@ -426,6 +446,7 @@ module RbsInfer::Signatures
         end
 
         local_var_types = {}
+        defined_names = RbsInfer::Inference::NewCallCollector.collect_defined_class_names(entry.result.value)
         visitor = RbsInfer::Inference::NewCallCollector.new(
           target_class: class_name,
           method_return_types: method_return_types,
@@ -435,7 +456,8 @@ module RbsInfer::Signatures
           # Env-aware resolver so constant call-site args resolve to their value
           # type via the loaded RBS env, not a bare name (#46, #56).
           constant_arg_resolver: @constant_resolver,
-          defined_class_names: RbsInfer::Inference::NewCallCollector.collect_defined_class_names(entry.result.value)
+          defined_class_names: defined_names,
+          module_self_types: module_self_types_for(file, entry, defined_names)
         )
         entry.result.value.accept(visitor)
 

--- a/spec/dummy/app/models/widget/closeable.rb
+++ b/spec/dummy/app/models/widget/closeable.rb
@@ -14,4 +14,11 @@ module Widget::Closeable
   def reopen
     track_event(:reopened) if was_just_published?
   end
+
+  # felixefelip/rbs_infer#175: `self` inside a concern, handed to a constructor.
+  # `WidgetAuditor#initialize` should take `(Widget & Widget::Closeable)` — the
+  # includer, which only the mixin graph knows.
+  def audit
+    WidgetAuditor.new(self).audit
+  end
 end

--- a/spec/dummy/app/services/widget_auditor.rb
+++ b/spec/dummy/app/services/widget_auditor.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# A plain class whose ONLY call site is inside a concern, constructed with
+# `self` — `WidgetAuditor.new(self)` in `Widget::Closeable`.
+#
+# What `self` is there is not in the file: it is whoever includes the module,
+# which the mixin graph knows (`Widget`) and the self-type annotators state as
+# `(Widget & Widget::Closeable)`. The caller-file walk was wired with that map;
+# `MethodTypeResolver`'s two walks over the same files were not, and those are
+# the ones that decide an `initialize` parameter — so this parameter came out
+# `untyped`, and `@widget`/`attr_reader widget` with it.
+#
+# Found in Fizzy as `Card::ActivitySpike::Detector.new(self)` inside
+# `Card::Stallable` (and `Account::Seeder.new(self, …)` inside
+# `Account::Seedeable`). The cost is not only the parameter: with it untyped,
+# Steep infers no precondition for any method of the class, and 256 lines of
+# `.steep_contracts.yml` — every `Detector#*` and `Seeder#*` entry — disappeared
+# (felixefelip/rbs_infer#175).
+class WidgetAuditor
+  attr_reader :widget
+
+  def initialize(widget)
+    @widget = widget
+  end
+
+  # Reads a method the HOST has, not the concern: it only resolves while the
+  # parameter carries the intersection.
+  def audit
+    widget.published?
+  end
+end

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -1503,6 +1503,11 @@ postconditions:
     may_write:
     - "@posts"
     - "@user"
+- class: WidgetAuditor
+  method: initialize
+  effects:
+    may_write:
+    - "@widget"
 method_entry_facts:
 - class: Account
   method: label

--- a/spec/dummy/sig/rbs_infer/app/models/widget/closeable.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/widget/closeable.rbs
@@ -4,5 +4,6 @@ class Widget
 
     def close: () -> { action: (Symbol | String), particulars: untyped }
     def reopen: () -> ({ action: Symbol | String, particulars: untyped } | nil)
+    def audit: () -> bool
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/services/widget_auditor.rbs
+++ b/spec/dummy/sig/rbs_infer/app/services/widget_auditor.rbs
@@ -1,0 +1,6 @@
+class WidgetAuditor
+  attr_reader widget: (Widget & Widget::Closeable)
+
+  def initialize: ((Widget & Widget::Closeable) widget) -> void
+  def audit: () -> bool
+end

--- a/spec/expectations/services/widget_auditor.rbs
+++ b/spec/expectations/services/widget_auditor.rbs
@@ -1,0 +1,6 @@
+class WidgetAuditor
+  attr_reader widget: (Widget & Widget::Closeable)
+
+  def initialize: ((Widget & Widget::Closeable) widget) -> void
+  def audit: () -> bool
+end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -887,6 +887,15 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     assert_snapshot("services/profile_formatter", target_class: "ProfileFormatter", target_file: "app/services/profile_formatter.rb")
   end
 
+  # felixefelip/rbs_infer#175. Constructed only from inside a concern, with
+  # `self` — so the parameter is whoever includes the module, which needs the
+  # mixin graph. Two of the paths that walk caller files were not given it and
+  # answered `untyped`, and those are the ones that decide an `initialize`
+  # parameter. Fizzy's `Card::ActivitySpike::Detector.new(self)` is this shape.
+  it "WidgetAuditor takes the includer's type from a concern's `self`" do
+    assert_snapshot("services/widget_auditor", target_class: "WidgetAuditor", target_file: "app/services/widget_auditor.rb")
+  end
+
   it "ApplicationJob base class matches expected RBS" do
     assert_snapshot("jobs/application_job", target_class: "ApplicationJob", target_file: "app/jobs/application_job.rb")
   end

--- a/spec/lib/rbs_infer/inference/caller_file_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/inference/caller_file_analyzer_spec.rb
@@ -2,15 +2,17 @@ require "spec_helper"
 require "rbs_infer"
 
 RSpec.describe RbsInfer::Inference::CallerFileAnalyzer do
-  # Test-only default for the required `target_file` (which gates bare-call matching
-  # for a class reopened across files). These examples exercise a private string
-  # helper and never reach that path, so any path serves — the production API stays
-  # strict so a forgotten wiring fails loudly instead of widening types.
+  # Test-only defaults for the required `target_file` (which gates bare-call matching
+  # for a class reopened across files) and `mixin_index` (what a module's `self` is).
+  # These examples exercise a private string helper and never reach either path, so
+  # anything serves — the production API stays strict so a forgotten wiring fails
+  # loudly instead of typing every concern's `self` untyped.
   let(:analyzer) do
     described_class.new(
       target_class: "Foo",
       method_type_resolver: nil,
-      target_file: "app/models/foo.rb"
+      target_file: "app/models/foo.rb",
+      mixin_index: RbsInfer::Project::MixinIndex.new([])
     )
   end
 

--- a/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
@@ -28,9 +28,17 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
     found
   end
 
+  # Test-only builder. `module_self_types:` is REQUIRED in production (a caller
+  # that forgets it types every `self` inside a concern `untyped` — see
+  # docs/engineering/required-threaded-deps.md), and hardly an example here is
+  # about that map; the ones that are pass their own.
+  def build_collector(**kwargs)
+    described_class.new(module_self_types: {}, **kwargs)
+  end
+
   def collect_usages(source, target_class:, method_return_types: {}, local_var_types: {})
     result = Prism.parse(source)
-    visitor = described_class.new(
+    visitor = build_collector(
       target_class: target_class,
       method_return_types: method_return_types,
       local_var_types: local_var_types,
@@ -61,7 +69,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
     RUBY
 
     result = Prism.parse(source)
-    visitor = described_class.new(
+    visitor = build_collector(
       target_class: "Foo",
       method_return_types: {},
       local_var_types: { "session" => "Session" },
@@ -86,7 +94,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
     RUBY
 
     result = Prism.parse(source)
-    visitor = described_class.new(
+    visitor = build_collector(
       target_class: "Foo",
       method_return_types: {},
       local_var_types: { "session" => "Session?" },
@@ -155,10 +163,10 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
 
     with_temp_files(files) do |dir, paths|
       Dir.chdir(dir) do
-        resolver = RbsInfer::Signatures::MethodTypeResolver.new(paths, constant_resolver: fake_constant_resolver)
+        resolver = RbsInfer::Signatures::MethodTypeResolver.new(paths, constant_resolver: fake_constant_resolver, mixin_index: RbsInfer::Project::MixinIndex.new(paths))
         source = File.read(paths.last)
         result = Prism.parse(source)
-        visitor = described_class.new(
+        visitor = build_collector(
           target_class: "Target",
           method_return_types: {},
           local_var_types: {},
@@ -213,7 +221,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
     def collect_with_self(source, target_class:, caller_class_name:, init_positional_params:,
                           self_types_by_method: {}, module_self_types: {})
       result = Prism.parse(source)
-      visitor = described_class.new(
+      visitor = build_collector(
         target_class: target_class,
         method_return_types: {},
         local_var_types: {},
@@ -331,7 +339,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
       # No enclosing class node and no caller_class_name.
       source = "Target.new(self)"
       result = Prism.parse(source)
-      visitor = described_class.new(
+      visitor = build_collector(
         target_class: "Target",
         method_return_types: {},
         local_var_types: {},
@@ -475,7 +483,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
     it "matches a target call whose receiver resolves to an intersection type" do
       source = "caderneta.qtde_por_vacina(v)"
       result = Prism.parse(source)
-      visitor = described_class.new(
+      visitor = build_collector(
         target_class: "Caderneta",
         method_return_types: { "caderneta" => "Caderneta & Caderneta::Validated", "v" => "Vacina" },
         local_var_types: {},
@@ -500,7 +508,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
       it "matches a target call whose receiver resolves to a #{shape} type" do
         source = "caderneta.qtde_por_vacina(v)"
         result = Prism.parse(source)
-        visitor = described_class.new(
+        visitor = build_collector(
           target_class: "Caderneta",
           method_return_types: { "caderneta" => receiver_type, "v" => "Vacina" },
           local_var_types: {},
@@ -517,7 +525,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
     it "still refuses a receiver that is not the target" do
       source = "vacina.qtde_por_vacina(v)"
       result = Prism.parse(source)
-      visitor = described_class.new(
+      visitor = build_collector(
         target_class: "Caderneta",
         method_return_types: { "vacina" => "(Vacina & Vacina::Validated)?", "v" => "Vacina" },
         local_var_types: {},
@@ -535,7 +543,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
     it "does not match a singleton receiver against the instance target" do
       source = "klass.qtde_por_vacina(v)"
       result = Prism.parse(source)
-      visitor = described_class.new(
+      visitor = build_collector(
         target_class: "Caderneta",
         method_return_types: { "klass" => "singleton(Caderneta)", "v" => "Vacina" },
         local_var_types: {},
@@ -586,10 +594,10 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
 
       with_temp_files(files) do |dir, paths|
         Dir.chdir(dir) do
-          resolver = RbsInfer::Signatures::MethodTypeResolver.new(paths, constant_resolver: fake_constant_resolver)
+          resolver = RbsInfer::Signatures::MethodTypeResolver.new(paths, constant_resolver: fake_constant_resolver, mixin_index: RbsInfer::Project::MixinIndex.new(paths))
           source = File.read(File.join(dir, "caller.rb"))
           result = Prism.parse(source)
-          visitor = described_class.new(
+          visitor = build_collector(
             target_class: "Thing",
             method_return_types: {},
             local_var_types: {},
@@ -613,7 +621,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
   describe "external attr-setter call-sites (rbs_infer#71)" do
     def collect_method_usages(source, target_class:, target_methods:, local_var_types: {})
       result = Prism.parse(source)
-      visitor = described_class.new(
+      visitor = build_collector(
         target_class: target_class,
         method_return_types: {},
         local_var_types: local_var_types,
@@ -661,7 +669,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
   describe "same-simple-name classes are not conflated (cross-class leak)" do
     def collect_method_usages(source, target_class:, target_methods:, local_var_types: {})
       result = Prism.parse(source)
-      visitor = described_class.new(
+      visitor = build_collector(
         target_class: target_class,
         method_return_types: {},
         local_var_types: local_var_types,
@@ -716,7 +724,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
   describe "ivars established by a self-call (postconditions sidecar)" do
     def collect_with_established(source, target_class:, established:)
       result = Prism.parse(source)
-      visitor = described_class.new(
+      visitor = build_collector(
         target_class: target_class,
         method_return_types: {},
         local_var_types: {},
@@ -821,7 +829,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
   describe "ivars from an argument partition" do
     def collect_with_partitions(source, target_class:, partitions:)
       result = Prism.parse(source)
-      visitor = described_class.new(
+      visitor = build_collector(
         target_class: target_class,
         method_return_types: {},
         local_var_types: {},
@@ -917,7 +925,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
   describe "a keyword hash that collapses to a positional argument" do
     def collect_calls(source, target_class:, target_methods:)
       result = Prism.parse(source)
-      visitor = described_class.new(
+      visitor = build_collector(
         target_class: target_class,
         method_return_types: {},
         local_var_types: {},

--- a/spec/lib/rbs_infer/signatures/method_type_resolver_spec.rb
+++ b/spec/lib/rbs_infer/signatures/method_type_resolver_spec.rb
@@ -7,6 +7,19 @@ require_relative "../../../support/temp_file_helpers"
 RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
   include TempFileHelpers
 
+  # Test-only builder. `mixin_index:` is REQUIRED in production — it is what says
+  # who includes a module, so a call site inside a concern has a `self` to pass,
+  # and a caller that forgets it degrades silently (see
+  # docs/engineering/required-threaded-deps.md). Here it is built from the same
+  # files the resolver gets, which is what the Analyzer does too.
+  def build_resolver(source_files, **kwargs)
+    described_class.new(
+      source_files,
+      mixin_index: RbsInfer::Project::MixinIndex.new(source_files),
+      **kwargs
+    )
+  end
+
   it "resolve tipo de método anotado com #:" do
     files = {
       "foo.rb" => <<~RUBY
@@ -20,7 +33,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     }
 
     with_temp_files(files) do |dir, paths|
-      resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
+      resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
       expect(resolver.resolve("Foo", "name")).to eq("String")
     end
   end
@@ -35,7 +48,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     }
 
     with_temp_files(files) do |dir, paths|
-      resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
+      resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
       expect(resolver.resolve("Foo", "count")).to eq("Integer")
     end
   end
@@ -54,7 +67,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     }
 
     with_temp_files(files) do |dir, paths|
-      resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
+      resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
       expect(resolver.resolve("Foo", "repo")).to eq("DefaultRepo")
     end
   end
@@ -79,7 +92,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     }
 
     with_temp_files(files) do |dir, paths|
-      resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
+      resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
       expect(resolver.resolve("MyApp::Foo", "widget")).to eq("Widget")
     end
   end
@@ -111,7 +124,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     RUBY
 
     with_temp_files("my_app/entity.rb" => entity_src, "my_app/service.rb" => service_src) do |dir, paths|
-      resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
+      resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
       expect(resolver.resolve("MyApp::Entity", "nome")).to eq("String")
     end
   end
@@ -143,7 +156,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     RUBY
 
     with_temp_files("my_app/entity.rb" => entity_src, "my_app/caller.rb" => caller_src) do |dir, paths|
-      resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
+      resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
       expect(resolver.resolve("MyApp::Entity", "email")).to eq("Wrapper")
       expect(resolver.resolve_init_param_types("MyApp::Entity")["email"]).to eq("String")
     end
@@ -176,7 +189,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     }
 
     with_temp_files(files) do |dir, paths|
-      resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
+      resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
       expect(resolver.resolve("Model & Model::Validated", "file")).to eq("Uploader")
       expect(resolver.resolve("(Model & Model::Validated)", "file")).to eq("Uploader")
     end
@@ -206,7 +219,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     }
 
     with_temp_files(files) do |dir, paths|
-      resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
+      resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
       expect(resolver.resolve("(LeftClass & RightClass)", "shared")).to eq("Symbol")
     end
   end
@@ -239,7 +252,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
 
     it "resolves a bare constant against the enclosing namespace" do
       with_temp_files(namespaced_service) do |dir, paths|
-        resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
+        resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
         expect(resolver.qualify_constant("Archiver", enclosing: "Post")).to eq("Post::Archiver")
       end
     end
@@ -267,7 +280,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
       )
 
       with_temp_files(files) do |dir, paths|
-        resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
+        resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
 
         expect(resolver.qualify_constant("Archiver", enclosing: "Post")).to eq("Post::Archiver")
         expect(resolver.qualify_constant("Archiver", enclosing: "Comment")).to eq("Archiver")
@@ -283,7 +296,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
 
     it "keeps a constant that is not the enclosing namespace's" do
       with_temp_files(namespaced_service) do |dir, paths|
-        resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
+        resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
         expect(resolver.qualify_constant("Post", enclosing: "Post")).to eq("Post")
       end
     end
@@ -292,7 +305,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     # flow through untouched, so the resolvers that CAN see it still get a chance.
     it "returns the written name when no candidate is known" do
       with_temp_files(namespaced_service) do |dir, paths|
-        resolver = described_class.new(paths, constant_resolver: fake_constant_resolver)
+        resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
         expect(resolver.qualify_constant("Time", enclosing: "Post")).to eq("Time")
       end
     end
@@ -329,7 +342,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
         end
       RBS
 
-      resolver = described_class.new([source], constant_resolver: fake_constant_resolver)
+      resolver = build_resolver([source], constant_resolver: fake_constant_resolver)
 
       expect(resolver.resolve_all("Example")).to include("ticket" => "Ticket?")
       # The single-method path already answered this; the two agreeing is the point.
@@ -347,7 +360,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
       RUBY
       write("sig/example.rbs", "class Example\n  def ticket: () -> Ticket?\nend\n")
 
-      resolver = described_class.new([source], constant_resolver: fake_constant_resolver)
+      resolver = build_resolver([source], constant_resolver: fake_constant_resolver)
 
       expect(resolver.resolve_all("Example")).to include("ticket" => "String")
     end


### PR DESCRIPTION
Second of the two losses found by regenerating Fizzy (the first is #174). Independent of it.

## The symptom

```diff
 class Card::ActivitySpike::Detector
-  def initialize: (Card::Stallable card) -> void
-  attr_reader card: Card::Stallable
+  def initialize: (untyped card) -> void
+  attr_reader card: untyped
```

The only call site is `Card::ActivitySpike::Detector.new(self)` inside the concern `Card::Stallable`, and the self-type annotators answer `(Card & Card::Stallable)` for that file — one of the walks over caller files was already asking them.

## The cause: three un-threaded wires, all defaulted

The map reaches `NewCallCollector` as `module_self_types:`. Three of its four construction sites were not passing it:

| site | had the map? |
|---|---|
| `CallerFileAnalyzer` (analyzer.rb:975 path) | yes |
| `MethodTypeResolver#build_init_param_types` | no |
| `MethodTypeResolver#infer_attrs_from_call_sites` | no |
| `CallerFileAnalyzer` built at analyzer.rb:956 — no `mixin_index:` at all | no |

The ones without it are the paths that decide an `initialize` parameter, so the wired one never got to answer. Every kwarg involved was **defaulted** (`module_self_types: {}`, `mixin_index: nil`), which is exactly how three missing wires read as "this concern's `self` is untyped" instead of failing — `docs/engineering/required-threaded-deps.md`.

Traced rather than guessed:

```
[new] msts={}  from=caller_file_analyzer.rb:156 …
[new] msts={"Widget::Closeable" => "(Widget & Widget::Closeable)"} from=method_type_resolver.rb:234 …
```

## The fix

- `module_self_types:` and `mixin_index:` become **required**.
- `MethodTypeResolver` takes the Analyzer's `mixin_index` rather than building one: building it is a full sweep of the project's sources, and in `--output` mode the resolver is constructed once per file.
- `SelfTypeAnnotators.instance_types` holds the question in one place, now that two callers ask it.

## What the gap cost, measured on Fizzy

Beyond the four declarations: with an untyped parameter Steep infers no precondition for any method of those classes, so **256 lines of `.steep_contracts.yml`** — every `Card::ActivitySpike::Detector#*` and `Account::Seeder#*` entry — disappeared from the regeneration.

## Fixture

`WidgetAuditor`, a plain class whose only call site is `WidgetAuditor.new(self)` inside `Widget::Closeable`:

```rbs
class WidgetAuditor
  attr_reader widget: (Widget & Widget::Closeable)

  def initialize: ((Widget & Widget::Closeable) widget) -> void
  def audit: () -> bool
end
```

`audit` reads `published?`, which the **host** has and the concern does not — it only resolves while the parameter carries the intersection. The dummy's postconditions sidecar gains the class too.

## Tests

`932 examples, 0 failures`; dummy steep baseline unchanged at 28 problems. Three spec files that build these objects get a test-only builder each, so the production signatures stay strict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
