### PR TITLE
chore: Example20 closes — the block call two conditionals deep

### DIFF
--- a/spec/dummy/app/models/example18.rb
+++ b/spec/dummy/app/models/example18.rb
@@ -26,12 +26,14 @@
 #   2. `with_token`  — answers with the block or halts, so the fact is gated on
 #      the halt (stage 2b).
 #   3. `from_token`  — the call site: a truthy answer means the block ran and
-#      answered truthy, so what the BLOCK established holds. This is stage 3,
-#      and it is the one that does not exist yet.
+#      answered truthy, so what the BLOCK established holds. This is stage 3.
 #   4. `show`        — dereferences in another method, past the halt check, so
 #      the fact has to survive as an entry fact.
 #
-# Until 3 lands, `show` is a type error. That is the point of the fixture.
+# 3 was the one that did not exist when this was written; felixefelip/steep#125
+# built it and `show` type-checks. The fixture stays as the regression test for
+# all four links at once — a fact crossing a block boundary, gated on a halt,
+# and surviving into another method.
 class Example18
   class User
     attr_reader :name

--- a/spec/dummy/app/models/example19.rb
+++ b/spec/dummy/app/models/example19.rb
@@ -35,7 +35,11 @@
 # `halt` is public for the same reason `render` is: something outside the object
 # calls it.
 #
-# Until #126 lands, `show` is a type error. That is the point of the fixture.
+# felixefelip/steep#126 landed and `show` type-checks: the callee records the
+# calls it makes on each parameter, the caller records where it handed `self`
+# over, and together they prove a halt neither frame states alone. The
+# `__send__` obstacle above was closed separately (#160), by desugaring the
+# dynamic send in the transcription.
 class Example19
   class User
     attr_reader :name

--- a/spec/dummy/app/models/example20.rb
+++ b/spec/dummy/app/models/example20.rb
@@ -36,7 +36,11 @@
 # boundary, `Registry.user` is still written inside the block. If `show` stops
 # being an error, the nesting is the only thing that changed.
 #
-# Until then, `show` is a type error. That is the point of the fixture.
+# It did: felixefelip/steep#132 descends however deep and gates the fact on the
+# alternative's halt rather than refusing it — which is what the paragraph above
+# hoped for, and it needed no new machinery. `show` type-checks, and the last
+# measured difference between this fixture and the method a real app writes is
+# gone (felixefelip/rbs_infer#144).
 class Example20
   class User
     attr_reader :name

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -771,9 +771,21 @@ postconditions:
     may_write:
     - "@name"
 - class: Example20
+  method: authenticate
+  conditional_const_returns:
+    Example20::Registry.user:
+      gate_ivar: "@halted"
+      type: "::Example20::User"
+- class: Example20
   method: fetch_token
   when_true:
     block_truthy: true
+- class: Example20
+  method: from_token
+  conditional_const_returns:
+    Example20::Registry.user:
+      gate_ivar: "@halted"
+      type: "::Example20::User"
 - class: Example20
   method: halt
   unconditional:
@@ -1799,6 +1811,14 @@ method_entry_facts:
   method: user
   consts:
     Example19::Registry.user: "::Example19::User"
+- class: Example20
+  method: show
+  consts:
+    Example20::Registry.user: "::Example20::User"
+- class: Example20::Registry
+  method: user
+  consts:
+    Example20::Registry.user: "::Example20::User"
 - class: Example4
   method: run_foo_name
   consts:

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -2,7 +2,6 @@ app/models/concerns/test/filtrable.rb:16:13: [error] Type `(::Post & ::Test::Fil
 app/models/concerns/test/filtrable.rb:16:4: [error] Type `(::Post & ::Test::Filtrable)` does not have method `asdasd`
 app/models/example14.rb:15:17: [error] Type `(::Example14::User | nil)` does not have method `name`
 app/models/example15.rb:25:25: [error] Type `(::Example15::User | nil)` does not have method `name`
-app/models/example20.rb:67:25: [error] Type `(::Example20::User | nil)` does not have method `name`
 app/models/example21.rb:105:31: [error] Type `(::Example21::Holder | nil)` does not have method `name`
 app/models/example21.rb:96:29: [error] Type `(::Example21::Ticket | nil)` does not have method `holder`
 app/models/example3.rb:122:11: [error] Type `(::Example3::User | nil)` does not have method `name`


### PR DESCRIPTION
Regenerated output of **felixefelip/steep#132**. No source change here — the fixture and its Ruby are unchanged since #166; what moved is what the checker can prove about them.

## The gap it documented

`Example20` is `Example19` with the ONE difference that keeps the real chain open: **where the call carrying the block sits**. Stage 3 reads it as the method's value, unwrapping at most one *one-armed* `if`; an app nests two, and the inner one has an `else`.

Measured against the collector when the fixture was added:

```
[shape] flat   -> [{keys: Set["…#with_token"], consts: {"…Registry.user" => …User}}]
[shape] nested -> []
```

## What now happens

steep#132 descends however deep, and treats an `else` that **halts** as a gate rather than a refusal — either the block ran and answered, or nothing returned at all. The rest of the chain, which Example18 and Example19 already proved, runs to the end:

```
from_token:   conditional_const_returns: {Example20::Registry.user, gate @halted}
authenticate: the same, carried by the `||`
show:         method_entry_facts consts: Example20::Registry.user
```

Baseline 28 → 27 problems. The line it loses is the one the fixture opened (`app/models/example20.rb:67`), and no other line moves. `make rbs_infer` is already at a fixed point — no generated sig changes.

## Where this leaves #144

This was the last **measured** obstacle between the tooling and `Current.identity` in a real app. The framework half is already proven in Fizzy against the transcribed actionpack source rather than a fixture:

```yaml
- class: ActionController::HttpAuthentication::Token
  method: authenticate
  when_true: { block_truthy: true }
- class: …Token::ControllerMethods
  method: authenticate_with_http_token
  when_true: { block_truthy: true }
- class: …Token::ControllerMethods
  method: authenticate_or_request_with_http_token
  conditional_block_truthy: { gate_ivar: "@__rbs_infer__performed" }
```

What was missing was the app's own method — this fixture's shape. With it, `authenticate_by_bearer_token` should carry the halt-gated fact, `require_authentication`'s `||` chain should intersect it with what `resume_session` already establishes, and the controller runtime already emits `require_authentication` + `return if performed?` ahead of every action.

`940 examples, 0 failures`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)