### PR TITLE
perf: resolve a mixin's hosts by lookup, not by scanning the graph per question

### DIFF
--- a/lib/rbs_infer/project/mixin_index.rb
+++ b/lib/rbs_infer/project/mixin_index.rb
@@ -27,6 +27,8 @@ module RbsInfer::Project
       @files_defining = Hash.new { |h, k| h[k] = [] }  # short name → [file]
       @includes_by_class = Hash.new { |h, k| h[k] = Set.new } # class FQN → Set[written name]
       @module_declarations = Set.new                          # FQNs declared as `module`
+      @hosts_by_target = {}                                   # target FQN → [host FQN]
+      @hosts_of_cache = {}                                    # target FQN → resolved hosts
       build(source_files)
     end
 
@@ -55,27 +57,35 @@ module RbsInfer::Project
     # Matching has to resolve the written name, which is rarely the FQN: Ruby
     # looks a constant up outward through the enclosing namespaces, so `include
     # Eventable` inside `class Card` may mean `Card::Eventable` or `::Eventable`.
-    # Every nesting of the host is a candidate.
-    def hosts_of(module_name, seen: Set.new)
-      return [] unless seen.add?(unqualified(module_name))
-
-      direct = @includes_by_class.filter_map do |host, written|
-        host if written.any? { |name| resolves_to?(name, host, module_name) }
-      end
-
-      # A MODULE that includes the target is not a `self` — it is another mixin,
-      # and the real self is whoever includes IT. Fizzy's `Authentication` is
-      # included by `ActiveStorage::Authorize`, a concern; answering `Authorize`
-      # put a module in a position only a class can hold. Resolved through,
-      # `seen`-guarded because two concerns can include each other.
-      direct.flat_map { |host| @module_declarations.include?(host) ? hosts_of(host, seen: seen) : [host] }
-            .uniq.sort
+    # Every nesting of the host is a candidate — which is what `@hosts_by_target`
+    # has already enumerated, so the answer is a lookup rather than a scan.
+    def hosts_of(module_name)
+      @hosts_of_cache[unqualified(module_name)] ||= resolve_hosts(module_name, Set.new)
     end
 
     private
 
     EMPTY = Set.new.freeze
     private_constant :EMPTY
+
+    EMPTY_ARRAY = [].freeze
+    private_constant :EMPTY_ARRAY
+
+    # `seen` is recursion state, threaded rather than exposed: only the outermost
+    # call is memoized, so a cached entry is always the complete answer.
+    def resolve_hosts(module_name, seen)
+      target = unqualified(module_name)
+      return [] unless seen.add?(target)
+
+      # A MODULE that includes the target is not a `self` — it is another mixin,
+      # and the real self is whoever includes IT. Fizzy's `Authentication` is
+      # included by `ActiveStorage::Authorize`, a concern; answering `Authorize`
+      # put a module in a position only a class can hold. Resolved through,
+      # `seen`-guarded because two concerns can include each other.
+      @hosts_by_target.fetch(target, EMPTY_ARRAY)
+                      .flat_map { |host| @module_declarations.include?(host) ? resolve_hosts(host, seen) : [host] }
+                      .uniq.sort
+    end
 
     # Files whose class/module includes `short`.
     def host_files(short)
@@ -122,15 +132,34 @@ module RbsInfer::Project
         end
         @included_shorts[file] = inherited unless inherited.empty?
       end
+
+      index_hosts_by_target
     end
 
-    # Whether `written`, as it appears inside `host`, names `target`.
-    def resolves_to?(written, host, target)
-      name = unqualified(written)
-      target = unqualified(target)
-      return true if name == target
-
-      nestings(host).any? { |prefix| "#{prefix}::#{name}" == target }
+    # The reverse of `@includes_by_class`, built once.
+    #
+    # `include Eventable` written inside `class Card` names exactly one of a
+    # fixed, enumerable set: the name as written, or that name under any of the
+    # host's nestings. Nothing about that set depends on what is later asked, so
+    # deriving it per query — scanning every class and re-splitting every name to
+    # ask "does this one resolve to the target?" — recomputes at every call what
+    # one pass over the graph settles for good. Enumerating it here turns
+    # `hosts_of` into a hash lookup, and (measured on Fizzy) takes the mixin
+    # resolution from ~36% of a run's wall time, plus the GC churn of the strings
+    # it allocated, down to noise.
+    def index_hosts_by_target
+      @includes_by_class.each do |host, written|
+        prefixes = nestings(host)
+        written.each do |name|
+          short = unqualified(name)
+          candidates = prefixes.map { |prefix| "#{prefix}::#{short}" }
+          candidates.unshift(short)
+          candidates.each do |target|
+            hosts = (@hosts_by_target[target] ||= [])
+            hosts << host unless hosts.include?(host)
+          end
+        end
+      end
     end
 
     # `"A::B::C"` → `["A", "A::B", "A::B::C"]`, the namespaces a constant

--- a/spec/lib/rbs_infer/project/mixin_index_spec.rb
+++ b/spec/lib/rbs_infer/project/mixin_index_spec.rb
@@ -186,5 +186,35 @@ RSpec.describe RbsInfer::Project::MixinIndex do
 
       expect(described_class.new([lonely]).hosts_of("Lonely")).to be_empty
     end
+
+    # The answer is memoized and the cycle guard is now threaded through the
+    # recursion rather than rebuilt per call, so a second question must not see
+    # the first one's `seen` set — which would silently answer empty.
+    it "answers the same on repeat, and after resolving through a neighbour" do
+      app = write_file("application_controller.rb", "class ApplicationController\n  include Authorize\nend\n")
+      authorize = write_file("authorize.rb", "module Authorize\n  include Authentication\nend\n")
+      auth = write_file("authentication.rb", "module Authentication\nend\n")
+
+      index = described_class.new([app, authorize, auth])
+
+      expect(index.hosts_of("Authentication")).to contain_exactly("ApplicationController")
+      # Asked again, and asked about the module the first answer resolved through.
+      expect(index.hosts_of("Authentication")).to contain_exactly("ApplicationController")
+      expect(index.hosts_of("Authorize")).to contain_exactly("ApplicationController")
+      expect(index.hosts_of("Authentication")).to contain_exactly("ApplicationController")
+    end
+
+    # A cycle is `seen`-guarded per question. The guard must not outlive it: the
+    # empty answer for `A` says nothing about `B`.
+    it "keeps a cycle's guard local to the question" do
+      a = write_file("a.rb", "module A\n  include B\nend\n")
+      b = write_file("b.rb", "module B\n  include A\nend\n")
+      host = write_file("widget.rb", "class Widget\n  include B\nend\n")
+
+      index = described_class.new([a, b, host])
+
+      expect(index.hosts_of("A")).to contain_exactly("Widget")
+      expect(index.hosts_of("B")).to contain_exactly("Widget")
+    end
   end
 end


### PR DESCRIPTION
Closes nothing — opened off the profile in felixefelip/rbs_infer#47's wake, after `rbs_infer sig/generated/steep_ar_runtime/ --output` on Fizzy took ~6-9 min for 91 targets.

## What the profiler said

Sampled with stackprof (wall, 1ms). The suspect everyone reaches for — the Steep type-check, which `steep_bridge.rb` itself calls "the single most expensive operation in the pipeline" — was **11.6%**. Building the indices was **2.3%**. The cost was in *querying* the mixin graph:

| frame | % wall |
|---|---|
| `MethodTypeResolver#build_init_param_types` | 48.0% |
| → `module_self_types_for` → `ModuleSelfTypeAnnotator.hosts_for` → **`MixinIndex#hosts_of`** | **35.9%** |
| **GC** (marking 18.4% + sweeping 16.1%) | **34.5%** |
| `SteepBridge#local_var_types_per_method` (all of Steep) | 11.6% |
| `MixinIndex#build` + `SourceIndex#initialize` | 2.3% |

Self-time inside that 35.9% is almost entirely string churn — `nestings` 5.3%, `resolves_to?` 3.2%, `hosts_of` 2.3%, `unqualified` 1.5%, plus `String#sub` 5.4%, `String#split` 2.8%, `Array#join` 2.3% — which is also what fed the 34.5% in GC.

## Why it was slow

`hosts_of` answered "which classes include this module" by walking every class in `@includes_by_class` and, per written `include`, re-deriving whether that name — read inside that host — resolves to the target: `unqualified` (a `sub`), then `nestings` (a `split` plus one `join` per segment).

None of that derivation depends on the question being asked, so every call rebuilt the same strings. #175 then put the walk on *every* caller-file scan — once per candidate file per target class — and on Fizzy `Card`/`User`/`Account` alone are referenced by 63/54/53 files each.

## The change

The set of FQNs a written `include` can name is fixed and enumerable: the name as written, or that name under any of the host's nestings. That is exactly what `resolves_to?` tested, term for term — so it belongs in the index, not in the query.

One pass at build time inverts the graph into `target FQN -> [host]`. `hosts_of` becomes a hash lookup plus the existing resolve-through-a-module recursion, whose outermost answer is memoized. `seen` stops being a public kwarg — it was recursion state, and since only the outer call is cached, a cached entry is always the complete answer.

## Measured

Same command, same corpus (91 targets, ~812 files), uninstrumented, on this machine:

| | `main` | this branch |
|---|---|---|
| wall | 6:20.28 | **2:18.16** |
| user | 377.33s | **134.57s** |
| max RSS | 796 MB | 874 MB |

**2.75× faster.** RSS goes up ~78 MB — that is the reverse index, and it is the trade being made.

(The 8:28 / 5 GB figure from the profiling run was the profiler: `raw: true` buffers every sample's stack.)

## Correctness

- Full suite green: **942 examples, 0 failures**.
- Two new specs cover what the refactor newly puts at risk — the memoized answer and a `seen` set that is now threaded rather than rebuilt per call, so one question's cycle guard must not leak into the next.
- Regenerating Fizzy's 91 `.rbs` on this branch leaves its `git status` untouched: **byte-identical output**.

## Not in this PR

- `files_reaching`/`host_files` scan `@included_shorts` per query — the same shape of problem, but it never showed in the profile, so it stays until something measures it.
- `SourceIndex`/`MixinIndex` are still rebuilt per `Analyzer` (91× per pass). Cheap to build (2.3%), but sharing them would let this cache survive across targets — a follow-up worth measuring after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
