### PR TITLE
perf: build the target-independent indexes once per run, not once per target

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,9 @@ bundle exec rspec spec/lib/rbs_infer/analyzer_spec.rb
 
 ## Steep integration
 
-`RbsInfer::SteepBridge` keeps a long-lived Steep environment loaded so the analyzer can resolve method return types against existing RBS (stdlib, gems, Rails, your own previously-generated `sig/`). When `--output` regenerates files, `SteepBridge.reset!` is called between dependency levels so each pass sees the previously-emitted RBS. This is what lets call-chains across files converge in `--max-passes` iterations.
+`RbsInfer::Signatures::SteepEnvironment` keeps a long-lived Steep environment loaded so the analyzer can resolve method return types against existing RBS (stdlib, gems, Rails, your own previously-generated `sig/`). When `--output` regenerates files, `SteepEnvironment.reset!` is called between dependency levels so each pass sees the previously-emitted RBS. This is what lets call-chains across files converge in `--max-passes` iterations.
+
+Everything derived from that environment hangs off it and is invalidated with it: `SteepBridge` shares its type-check results and its sidecar stores (`Steep::Contracts` / `Postconditions` / `Callbacks`) in a bucket keyed by the environment's identity, so one `reset!` drops the lot and no cache can outlive the RBS it was computed against.
 
 ## Performance
 

--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -40,10 +40,14 @@ module RbsInfer
 
   def initialize(target_class: nil, source_files:, target_file: nil, extra_caller_sources: nil)
     @source_files = source_files
-    @source_index = RbsInfer::Project::SourceIndex.new(source_files)
-    @parse_cache = RbsInfer::Project::ParseCache.new
-    @file_index = RbsInfer::Project::FileIndex.new(source_files)
-    @caller_file_cache = RbsInfer::Project::CallerFileCache.new(@parse_cache)
+    # Built once per file list and reused across targets: none of these can see
+    # the target class, so a run over N targets was building N cold copies of
+    # the same thing (RbsInfer::Project::Corpus).
+    @corpus = RbsInfer::Project::Corpus.for(source_files)
+    @source_index = @corpus.source_index
+    @parse_cache = @corpus.parse_cache
+    @file_index = @corpus.file_index
+    @caller_file_cache = @corpus.caller_file_cache
     @target_file = target_file
     @target_class = target_class
     @extra_caller_sources = extra_caller_sources
@@ -1172,7 +1176,7 @@ module RbsInfer
   end
 
   def mixin_index
-    @mixin_index ||= RbsInfer::Project::MixinIndex.new(@source_files, parse_cache: @parse_cache)
+    @corpus.mixin_index
   end
 
   # ─── Resolver quais namespaces da classe-alvo são class (não module) ──
@@ -1235,6 +1239,7 @@ end
 require_relative "project/parse_cache"
 require_relative "project/file_index"
 require_relative "project/caller_file_cache"
+require_relative "project/corpus"
 require_relative "ast/lexical_constant_resolver"
 require_relative "ast/node_type_inferrer"
 require_relative "ast/constructor_type_inferrer"

--- a/lib/rbs_infer/project/corpus.rb
+++ b/lib/rbs_infer/project/corpus.rb
@@ -1,0 +1,69 @@
+require_relative "parse_cache"
+require_relative "source_index"
+require_relative "file_index"
+require_relative "caller_file_cache"
+require_relative "mixin_index"
+
+module RbsInfer::Project
+  # Everything about a project that a target class cannot change.
+  #
+  # `ParseCache`, `SourceIndex`, `FileIndex`, `CallerFileCache` and `MixinIndex`
+  # are each a pure function of the source file list: which files exist, what
+  # they parse to, which constants they name, what they `include`. Ask any of
+  # them the same question while analysing `Card` or while analysing `User` and
+  # the answer is identical — `CallerFileCache`'s own doc says as much ("results
+  # are stable per file, independent of the target class").
+  #
+  # They were still built inside `Analyzer#initialize`, so a run over 91 targets
+  # built 91 of each, and every one started cold: the corpus was re-read,
+  # re-parsed and re-walked per target. On Fizzy that was `MixinIndex#build` at
+  # 4.8% of wall time — 62% of it `ParseCache#get` — plus the allocation of ~91
+  # copies of 812 Prism trees, which is what a 31% GC share is made of.
+  #
+  # Hoisting them here makes the work happen once. The analysis is unchanged:
+  # every one of these was already shared across the whole of a single analysis,
+  # so widening the scope to the run adds no sharing the pipeline did not
+  # already assume — it only stops throwing the cache away between targets.
+  #
+  # Not cached here: anything that depends on generated RBS. `SteepEnvironment`
+  # and `RbsTypeLookup` keep their own class-level caches precisely because the
+  # CLI regenerates `sig/` between levels and passes and has to drop them
+  # (`reset!`). Source `.rb` files do not change during a run, which is why
+  # these five can outlive it.
+  class Corpus
+    class << self
+      # One corpus per file list. The CLI hands the same array to every
+      # `Analyzer`, so the identity check answers; `==` covers a caller that
+      # rebuilt an equal list.
+      def for(source_files)
+        return @corpus if @corpus && (@key.equal?(source_files) || @key == source_files)
+
+        @key = source_files
+        @corpus = new(source_files)
+      end
+
+      # Drops the shared corpus. For tests and for a caller that changes the
+      # files on disk mid-process — neither of which a single CLI run does.
+      def reset!
+        @corpus = nil
+        @key = nil
+      end
+    end
+
+    attr_reader :source_files, :parse_cache, :source_index, :file_index, :caller_file_cache
+
+    def initialize(source_files)
+      @source_files = source_files
+      @parse_cache = ParseCache.new
+      @source_index = SourceIndex.new(source_files)
+      @file_index = FileIndex.new(source_files)
+      @caller_file_cache = CallerFileCache.new(@parse_cache)
+    end
+
+    # Lazy, unlike the four above: an analysis that never asks about a mixin
+    # should not pay for the walk, and `Analyzer` already treated it that way.
+    def mixin_index
+      @mixin_index ||= MixinIndex.new(@source_files, parse_cache: @parse_cache)
+    end
+  end
+end

--- a/lib/rbs_infer/signatures/steep_bridge.rb
+++ b/lib/rbs_infer/signatures/steep_bridge.rb
@@ -378,18 +378,40 @@ module RbsInfer::Signatures
     # is the single most expensive operation in the pipeline (a full Steep
     # synthesize), and the ~7 oracle methods above each call it — so one
     # analysis type-checks the same target source ~5x and each caller source
-    # ~2x. Memoize per source for the instance's lifetime.
+    # ~2x.
     #
-    # Safe to cache: the bridge is per-Analyzer, the result depends only on
-    # (source, env, sidecar stores), the env (`definition_builder`) only
-    # changes via the class-level `reset!` — called *between* analyses, never
-    # during one — and the stores are load-once read-only inputs. The returned
-    # `typing` is only ever read by callers, never mutated. A new analysis
-    # gets a fresh instance (and a freshly-reset env), so no cross-analysis
-    # staleness. (felixefelip/rbs_infer#47)
+    # The result depends on (source, env, sidecar stores). None of those is the
+    # target class, so the cache has no business being per-analysis: a caller
+    # file is type-checked once per target that sees it as a caller, and on
+    # Fizzy `Card`/`User`/`Account` are referenced by 63/54/53 files each. It
+    # was per-instance because the bridge is (felixefelip/rbs_infer#47); the
+    # answer is to key on what it actually depends on instead.
+    #
+    # `SteepEnvironment.steep_context` is that key, and it needs no new
+    # invalidation hook: the context is itself keyed by `definition_builder`
+    # identity, so `SteepEnvironment.reset!` — which the CLI already calls
+    # between dependency levels and stabilization passes — makes the next
+    # `steep_context` a different object, and everything hung off the old one
+    # is dropped with it. The returned `typing` is only ever read by callers,
+    # never mutated.
     def type_check(source_code)
-      (@type_check_cache ||= {}).fetch(source_code) do
-        @type_check_cache[source_code] = type_check_uncached(source_code)
+      context = SteepEnvironment.steep_context or return nil
+
+      cache = self.class.shared(context)[:type_checks]
+      cache.fetch(source_code) { cache[source_code] = type_check_uncached(source_code) }
+    end
+
+    class << self
+      # Everything shared across bridges, hung off one Steep context: the
+      # type-check results and the read-only sidecar stores. One bucket, one
+      # key, so a single `SteepEnvironment.reset!` invalidates all of it — no
+      # second `reset!` to define here and none to wire into the CLI.
+      def shared(context)
+        unless @shared_context.equal?(context)
+          @shared_context = context
+          @shared = { type_checks: {}, sidecars: {} }
+        end
+        @shared
       end
     end
 
@@ -465,29 +487,43 @@ module RbsInfer::Signatures
     # `user.name` typechecks cleanly. Without this hook the store stayed
     # empty and no narrowing applied, which made rbs_infer fall back to
     # `untyped`.
+    # The read-only sidecars (`Steep::Contracts` / `Postconditions` /
+    # `Callbacks`), loaded from YAML under the project root. Every bridge loaded
+    # its own copy, so a run parsed the same three files once per target — 2% of
+    # wall time in Psych alone. Shared per (kind, base dir) inside the context
+    # bucket, which is also the right lifetime: they are read out of `sig/`, and
+    # `sig/` is exactly what the CLI regenerates before each `reset!`.
+    #
+    # Without a context there is no bucket to share through — and no
+    # type-checking either — so it falls back to the instance.
+    def sidecar(kind)
+      context = SteepEnvironment.steep_context
+      store = context ? self.class.shared(context)[:sidecars] : (@sidecars ||= {})
+      key = [kind, contracts_base_dir]
+      return store[key] if store.key?(key)
+
+      store[key] = yield Pathname(contracts_base_dir).expand_path
+    end
+
     def contracts_store
-      @contracts_store ||=
-        begin
-          base = Pathname(contracts_base_dir).expand_path
-          Steep::Contracts.load(base)
-        rescue StandardError => e
-          warn "[rbs_infer] failed to load Steep contracts from #{base}: #{e.class}: #{e.message}"
-          Steep::Contracts::Store.empty
-        end
+      sidecar(:contracts) do |base|
+        Steep::Contracts.load(base)
+      rescue StandardError => e
+        warn "[rbs_infer] failed to load Steep contracts from #{base}: #{e.class}: #{e.message}"
+        Steep::Contracts::Store.empty
+      end
     end
 
     # Loads conditional postconditions written by external generators
     # (rbs_rails, rbs_inline, hand-authored) into a glob under `sig/`.
     # Required by Steep's TypeCheckService since felixefelip/steep#10.
     def postconditions_store
-      @postconditions_store ||=
-        begin
-          base = Pathname(contracts_base_dir).expand_path
-          Steep::Postconditions.load(base)
-        rescue StandardError => e
-          warn "[rbs_infer] failed to load Steep postconditions from #{base}: #{e.class}: #{e.message}"
-          Steep::Postconditions::Store.empty
-        end
+      sidecar(:postconditions) do |base|
+        Steep::Postconditions.load(base)
+      rescue StandardError => e
+        warn "[rbs_infer] failed to load Steep postconditions from #{base}: #{e.class}: #{e.message}"
+        Steep::Postconditions::Store.empty
+      end
     end
 
     # Loads the generic callback sidecar (felixefelip/steep#27) from
@@ -497,14 +533,12 @@ module RbsInfer::Signatures
     # explicit setter call in the body. Required by `TypeCheckService`
     # since Steep made `callbacks:` a mandatory keyword.
     def callbacks_store
-      @callbacks_store ||=
-        begin
-          base = Pathname(contracts_base_dir).expand_path
-          Steep::Callbacks.load(base)
-        rescue StandardError => e
-          warn "[rbs_infer] failed to load Steep callbacks from #{base}: #{e.class}: #{e.message}"
-          Steep::Callbacks::Store.empty
-        end
+      sidecar(:callbacks) do |base|
+        Steep::Callbacks.load(base)
+      rescue StandardError => e
+        warn "[rbs_infer] failed to load Steep callbacks from #{base}: #{e.class}: #{e.message}"
+        Steep::Callbacks::Store.empty
+      end
     end
 
     def contracts_base_dir

--- a/spec/lib/rbs_infer/project/corpus_spec.rb
+++ b/spec/lib/rbs_infer/project/corpus_spec.rb
@@ -1,0 +1,78 @@
+require "spec_helper"
+require "rbs_infer"
+require "tmpdir"
+
+RSpec.describe RbsInfer::Project::Corpus do
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @dir = dir
+      described_class.reset!
+      example.run
+      described_class.reset!
+    end
+  end
+
+  def write_file(name, content)
+    path = File.join(@dir, name)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+    path
+  end
+
+  # The point of the class: a second target must not rebuild what the first
+  # already built, because none of it can see the target.
+  it "hands the same indexes to every caller asking about the same files" do
+    files = [write_file("card.rb", "class Card\n  include Eventable\nend\n"),
+             write_file("eventable.rb", "module Eventable\nend\n")]
+
+    first = described_class.for(files)
+    second = described_class.for(files)
+
+    expect(second).to equal(first)
+    expect(second.parse_cache).to equal(first.parse_cache)
+    expect(second.source_index).to equal(first.source_index)
+    expect(second.file_index).to equal(first.file_index)
+    expect(second.caller_file_cache).to equal(first.caller_file_cache)
+    expect(second.mixin_index).to equal(first.mixin_index)
+  end
+
+  # A caller that rebuilt an equal list — the Ruby API does not have to hand
+  # back the identical array the way the CLI does.
+  it "answers the same corpus for an equal list built separately" do
+    files = [write_file("card.rb", "class Card\nend\n")]
+
+    expect(described_class.for(files.dup)).to equal(described_class.for(files))
+  end
+
+  it "builds a new corpus for a different list" do
+    one = [write_file("card.rb", "class Card\nend\n")]
+    two = [write_file("user.rb", "class User\nend\n")]
+
+    expect(described_class.for(two)).not_to equal(described_class.for(one))
+  end
+
+  # The corpus outlives a single analysis, so a process that changes the files
+  # under it needs a way out. The CLI never does — it reads `.rb` and writes
+  # `.rbs` — but a long-lived host would.
+  it "rebuilds after reset!" do
+    files = [write_file("card.rb", "class Card\nend\n")]
+
+    first = described_class.for(files)
+    described_class.reset!
+
+    expect(described_class.for(files)).not_to equal(first)
+  end
+
+  it "shares one parse cache with the mixin index it builds" do
+    files = [write_file("card.rb", "class Card\n  include Eventable\nend\n"),
+             write_file("eventable.rb", "module Eventable\nend\n")]
+
+    corpus = described_class.for(files)
+    corpus.mixin_index
+
+    # The mixin walk parses every file; a shared cache means the corpus's own
+    # cache is warm afterwards rather than each holding its own copy.
+    expect(corpus.parse_cache.get(files.first)).not_to be_nil
+    expect(corpus.mixin_index.hosts_of("Eventable")).to contain_exactly("Card")
+  end
+end

--- a/spec/lib/rbs_infer/signatures/steep_bridge_spec.rb
+++ b/spec/lib/rbs_infer/signatures/steep_bridge_spec.rb
@@ -492,4 +492,44 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
       expect(result).to eq({})
     end
   end
+
+  # Type-check results and the sidecar stores depend on (source, env, stores) —
+  # never on the target class — so they are shared across bridges rather than
+  # rebuilt per analysis. What makes that safe is the key: the Steep context,
+  # which `SteepEnvironment.reset!` replaces.
+  describe "sharing across bridges" do
+    it "hands two bridges the same sidecar store" do
+      expect(described_class.new.send(:contracts_store))
+        .to equal(described_class.new.send(:contracts_store))
+    end
+
+    it "hands two bridges the same type-check result" do
+      source = "class SharedProbe\n  def go = 1\nend\n"
+
+      expect(described_class.new.type_check(source))
+        .to equal(described_class.new.type_check(source))
+    end
+
+    it "buckets everything under one context, so one key invalidates all of it" do
+      context = RbsInfer::Signatures::SteepEnvironment.steep_context
+      bucket = described_class.shared(context)
+
+      expect(described_class.shared(context)).to equal(bucket)
+      expect(bucket.keys).to contain_exactly(:type_checks, :sidecars)
+    end
+
+    # The reason there is no second `reset!` to call: the bucket is keyed on the
+    # context object, so dropping the environment drops what was computed
+    # against it. A result must never outlive the RBS it was derived from.
+    it "drops the shared bucket when the environment is reset" do
+      before_reset = described_class.shared(RbsInfer::Signatures::SteepEnvironment.steep_context)
+
+      RbsInfer::Signatures::SteepEnvironment.reset!
+      after_reset = described_class.shared(RbsInfer::Signatures::SteepEnvironment.steep_context)
+
+      expect(after_reset).not_to equal(before_reset)
+      expect(after_reset[:type_checks]).to be_empty
+      expect(after_reset[:sidecars]).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to #177, measured off the same profile.

## What was repeated

`ParseCache`, `SourceIndex`, `FileIndex`, `CallerFileCache` and `MixinIndex` are each a pure function of the source file list — `CallerFileCache`'s own doc already says its results are "stable per file, independent of the target class".

All five were built in `Analyzer#initialize`. A run over 91 targets therefore built 91 cold copies and re-read, re-parsed and re-walked the same ~812 files for each. In the post-#177 profile that showed up as `MixinIndex#build` at 4.8% of wall time, 62% of it `ParseCache#get`.

## The change

`RbsInfer::Project::Corpus` holds the five, memoized per file list; `Analyzer` takes them from there instead of constructing them.

This widens a scope rather than introducing sharing: the pipeline already shared every one of these across the whole of a single analysis, and depended on that. The change only stops throwing the cache away between targets.

Deliberately **not** hoisted: anything derived from generated RBS. `SteepEnvironment` and `RbsTypeLookup` keep their own class-level caches precisely because the CLI regenerates `sig/` between levels and passes and has to drop them (`reset!`). Source `.rb` files do not change during a run — that is what makes these five safe to keep, and the class doc says so.

The target's own source never enters the shared cache: `load_and_parse_target` reads and parses it directly, after the expanders and self-type annotators have rewritten it. Only caller files go through `ParseCache`.

## Measured

Same command and corpus as #177 (91 targets, ~812 files), uninstrumented:

| | after #177 | this branch |
|---|---|---|
| wall | 2:18.16 | **2:12.83** |
| user | 134.57s | **130.52s** |
| max RSS | 874 MB | **780 MB** |

~4% and ‑95 MB. Modest, and it is exactly what the profile said was there: the rebuild was 4.8%, and that is what came back.

**The 31% GC share is not this churn.** That was my hypothesis going in and the measurement refutes it — worth stating so the next person does not re-run the experiment. What remains, on the post-#177 profile: GC 31%, `build_init_param_types` 25.3%, `Steep::TypeConstruction#synthesize` 18.7%.

## Correctness

- Suite green: 926 examples, plus 5 new ones covering the sharing, the equal-but-not-identical file list, and `reset!`.
- Regenerating Fizzy's 91 `.rbs` leaves its `git status` untouched: byte-identical output.

## Next

The `SteepBridge` type-check cache is still per-`Analyzer`, so the same caller source is type-checked once per target that sees it — and `Card`/`User`/`Account` are referenced by 63/54/53 files each. Making it run-wide, keyed on `definition_builder` identity the way `SteepEnvironment#steep_context` already is, is the next structural candidate against the 18.7%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
