### PR TITLE
chore: drop the three concern `-> self` errors from the steep baseline

### DIFF
--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -16,9 +16,6 @@ app/models/example4.rb:40:23: [error] Type `(::String | nil)` does not have meth
 app/models/example7.rb:31:28: [error] Type `(::Integer | nil)` does not have method `abs`
 app/models/example7.rb:34:27: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/post/notifiable.rb:28:24: [error] Type `(::User | nil)` does not have method `full_name`
-app/models/user/recoverable.rb:10:6: [error] Cannot allow method body have type `::User` because declared as type `self`
-app/models/user/recoverable.rb:14:6: [error] Cannot allow method body have type `::User` because declared as type `self`
-app/models/user/recoverable.rb:18:6: [error] Cannot allow method body have type `::User` because declared as type `self`
 app/services/comment/create.rb:3:12: [error] Cannot find compatible overloading of method `find` of type `singleton(::Comment)`
 app/services/email_notifier.rb:13:15: [error] Type `(::User | nil)` does not have method `email`
 app/services/profile_formatter.rb:31:4: [error] `format_nickname` requires `self.nickname` to be non-nil here


### PR DESCRIPTION
Paired with **felixefelip/steep#133** — merge that first.

## What moved

`spec/dummy/app/models/user/recoverable.rb` is the dummy's copy of the pattern that PR fixes: a concern method forwarding an inherited `update!: (*untyped) -> self`.

```ruby
module User::Recoverable
  extend ActiveSupport::Concern

  def deactivate!
    update!(active: false)
  end
  # ...same for reactivate! / toggle_active!
end
```

The module self-type annotation makes the checked self an intersection (`User & User::Recoverable`). `Interface::Builder#self_shape` had no intersection arm, so it fell through to `raw_shape`, which substituted `self` with the member hosting the method — `update!` returned `::User`, which then couldn't satisfy the method's own `-> self`:

```
app/models/user/recoverable.rb:10:6: [error] Cannot allow method body have type `::User` because declared as type `self`
app/models/user/recoverable.rb:14:6: [error] ...
app/models/user/recoverable.rb:18:6: [error] ...
```

## Verification

`make steep` on the dummy, same tree, steep#133 toggled:

| | diagnostics |
|---|---|
| without the fix | 27 |
| with the fix | 24 |

`diff` between the two runs is **exactly** those three lines — nothing else in the dummy moves, no new errors. The 24 remaining are the previous set unchanged.

The pre-refresh baseline also matched the unfixed run exactly, so the refresh is a pure deletion of three lines.

`bundle exec rspec spec/integration/steep_dummy_spec.rb` → 2 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)