### PR TITLE
fix: type ivars assigned by a single multiple assignment

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -474,13 +474,13 @@ module RbsInfer
       param_names = def_param_names(defn)
       next if param_names.empty?
 
-      self.class.find_all_nodes(defn) { |n| n.is_a?(Prism::InstanceVariableWriteNode) }.each do |write|
-        next unless write.value.is_a?(Prism::LocalVariableReadNode)
+      ivar_writes_with_values(defn).each do |ivar_name, value|
+        next unless value.is_a?(Prism::LocalVariableReadNode)
 
-        param_name = write.value.name.to_s
+        param_name = value.name.to_s
         next unless param_names.include?(param_name)
 
-        ivar_type = ivar_types[write.name.to_s.sub(/\A@/, "")]
+        ivar_type = ivar_types[ivar_name]
         next if ivar_type.nil? || ivar_type == "untyped"
 
         params = (method_param_types[defn.name.to_s] ||= {})
@@ -493,6 +493,21 @@ module RbsInfer
         elsif ivar_type == RbsInfer::Signatures::RbsParserUtil.nilablize(current)
           params[param_name] = ivar_type
         end
+      end
+    end
+  end
+
+  # `[["ivar_name", value_node], ...]` for every ivar assignment in `defn`,
+  # covering both `@x = v` and the multiple-assignment form `@x, @y = v, w`
+  # (felixefelip/rbs_infer#183).
+  def ivar_writes_with_values(defn)
+    self.class.find_all_nodes(defn) do |n|
+      n.is_a?(Prism::InstanceVariableWriteNode) || n.is_a?(Prism::MultiWriteNode)
+    end.flat_map do |node|
+      if node.is_a?(Prism::InstanceVariableWriteNode)
+        [[node.name.to_s.sub(/\A@/, ""), node.value]]
+      else
+        RbsInfer::AST::MultiWriteDecomposer.ivar_name_pairs(node)
       end
     end
   end
@@ -1241,6 +1256,7 @@ require_relative "project/file_index"
 require_relative "project/caller_file_cache"
 require_relative "project/corpus"
 require_relative "ast/lexical_constant_resolver"
+require_relative "ast/multi_write_decomposer"
 require_relative "ast/node_type_inferrer"
 require_relative "ast/constructor_type_inferrer"
 require_relative "inference/known_return_types_builder"

--- a/lib/rbs_infer/ast/multi_write_decomposer.rb
+++ b/lib/rbs_infer/ast/multi_write_decomposer.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module RbsInfer::AST
+  # `@a, @b = x, y` assigns exactly what `@a = x; @b = y` assigns, but Prism
+  # gives it a different shape: one `MultiWriteNode` whose targets are
+  # `InstanceVariableTargetNode`s (no `.value` of their own). Every visitor
+  # keyed on `InstanceVariableWriteNode` therefore misses it, and the ivar is
+  # left `untyped` even though the param it came from is fully typed
+  # (felixefelip/rbs_infer#183).
+  #
+  # This is the one place that decides how a multiple assignment pairs up, so
+  # the consumers keep their own semantics and only gain the shape.
+  #
+  # The pairing is deliberately narrow: it fires only when the values are an
+  # array literal, the arities match, and neither side splats. Those are the
+  # cases where the target/value correspondence is positional and certain.
+  # Everything else is left alone:
+  #
+  #   @a, @b = pair          # one value destructured at runtime
+  #   @a, *@rest = 1, 2, 3   # a splat redistributes the elements
+  #   @a, (@b, @c) = 1, [2, 3]
+  #
+  # Guessing there would be worse than the honest `untyped` those already get.
+  module MultiWriteDecomposer
+    module_function
+
+    # `[[InstanceVariableTargetNode, value_node], ...]` for the ivar targets of
+    # a multiple assignment, or `[]` when the node isn't one or the pairing
+    # isn't decidable. Non-ivar targets (locals, constants, `self.x =`) are
+    # dropped — callers here only ever ask about ivars.
+    def ivar_pairs(node)
+      return [] unless node.is_a?(Prism::MultiWriteNode)
+      # A splat on either side redistributes the values; positions stop lining up.
+      return [] if node.rest
+      return [] unless node.rights.empty?
+
+      value = node.value
+      return [] unless value.is_a?(Prism::ArrayNode)
+
+      elements = value.elements
+      return [] if elements.any? { |element| element.is_a?(Prism::SplatNode) }
+      return [] unless node.lefts.size == elements.size
+
+      node.lefts.zip(elements).select { |target, _| target.is_a?(Prism::InstanceVariableTargetNode) }
+    end
+
+    # Same pairing, as `[["name_without_at", value_node], ...]` — the form most
+    # consumers want, since they all strip the leading `@`.
+    def ivar_name_pairs(node)
+      ivar_pairs(node).map { |target, value| [target.name.to_s.sub(/\A@/, ""), value] }
+    end
+
+    # Every ivar name a multiple assignment writes, regardless of whether the
+    # values can be paired up. Definite-initialization only asks "was `@x`
+    # assigned here?", which is answerable for `@a, *@rest = whatever` too.
+    def ivar_target_names(node)
+      return [] unless node.is_a?(Prism::MultiWriteNode)
+
+      targets = node.lefts + [node.rest].compact + node.rights
+      targets.filter_map do |target|
+        target = target.expression if target.is_a?(Prism::SplatNode)
+        target.name.to_s.sub(/\A@/, "") if target.is_a?(Prism::InstanceVariableTargetNode)
+      end
+    end
+  end
+end

--- a/lib/rbs_infer/inference/class_body_attr_analyzer.rb
+++ b/lib/rbs_infer/inference/class_body_attr_analyzer.rb
@@ -77,11 +77,16 @@ module RbsInfer::Inference
     end
 
     def visit_instance_variable_write_node(node)
+      record_ivar_write(node.name.to_s.sub(/\A@/, ""), node.value) if @in_method && in_target_class?
+      super
+    end
+
+    # `@a, @b = x, y` writes the same attrs the one-per-line form does
+    # (felixefelip/rbs_infer#183).
+    def visit_multi_write_node(node)
       if @in_method && in_target_class?
-        name = node.name.to_s.sub(/\A@/, "")
-        if @attr_names.include?(name) && !@attr_types[name]
-          type = infer_type_from_node(node.value)
-          @attr_types[name] = type if type
+        RbsInfer::AST::MultiWriteDecomposer.ivar_name_pairs(node).each do |name, value|
+          record_ivar_write(name, value)
         end
       end
       super
@@ -93,6 +98,13 @@ module RbsInfer::Inference
     # concat: arg é um array, elementos estão dentro
 
     private
+
+    def record_ivar_write(name, value)
+      return unless @attr_names.include?(name) && !@attr_types[name]
+
+      type = infer_type_from_node(value)
+      @attr_types[name] = type if type
+    end
 
     # Pushes the class/module name (`Foo`, `Foo::Bar` for a compact path)
     # while visiting its body, so `in_target_class?` can tell whether the

--- a/lib/rbs_infer/inference/initialize_body_analyzer.rb
+++ b/lib/rbs_infer/inference/initialize_body_analyzer.rb
@@ -52,6 +52,17 @@ module RbsInfer::Inference
       super
     end
 
+    # `@user, @filter = user, filter` assigns the same params the one-per-line
+    # form does; Prism just shapes it as one node (felixefelip/rbs_infer#183).
+    def visit_multi_write_node(node)
+      if @in_initialize
+        RbsInfer::AST::MultiWriteDecomposer.ivar_name_pairs(node).each do |attr_name, value|
+          @self_assignments[attr_name] ||= resolve_assignment_value(value)
+        end
+      end
+      super
+    end
+
     private
 
     def extract_param_names(params)

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -340,15 +340,22 @@ module RbsInfer::Inference
     end
 
     def collect_class_ivar_types(class_node)
+      # Both `@x = Foo.new` and `@x, @y = Foo.new, Bar.new`
+      # (felixefelip/rbs_infer#183).
       ivar_writes = RbsInfer::Analyzer.find_all_nodes(class_node) do |n|
-        n.is_a?(Prism::InstanceVariableWriteNode) && n.value.is_a?(Prism::CallNode)
+        (n.is_a?(Prism::InstanceVariableWriteNode) && n.value.is_a?(Prism::CallNode)) ||
+          n.is_a?(Prism::MultiWriteNode)
+      end.flat_map do |n|
+        if n.is_a?(Prism::InstanceVariableWriteNode)
+          [[n.name.to_s.sub(/\A@/, ""), n.value]]
+        else
+          RbsInfer::AST::MultiWriteDecomposer.ivar_name_pairs(n).select { |_, value| value.is_a?(Prism::CallNode) }
+        end
       end
 
-      ivar_writes.each do |ivar|
-        var_name = ivar.name.to_s.sub(/\A@/, "")
+      ivar_writes.each do |var_name, call|
         next if @local_var_types[var_name]
 
-        call = ivar.value
         if call.name == :new && call.receiver
           class_name = RbsInfer::Analyzer.extract_constant_path(call.receiver)
           @local_var_types[var_name] = class_name if class_name
@@ -537,20 +544,28 @@ module RbsInfer::Inference
             end
           end
         elsif stmt.is_a?(Prism::InstanceVariableWriteNode)
-          var_name = stmt.name.to_s.sub(/\A@/, "")
-          if stmt.value.is_a?(Prism::CallNode)
-            if stmt.value.name == :new && stmt.value.receiver
-              class_name = RbsInfer::Analyzer.extract_constant_path(stmt.value.receiver)
-              @local_var_types[var_name] = class_name if class_name
-            elsif @method_type_resolver
-              class_name = RbsInfer::Analyzer.extract_constant_path(stmt.value.receiver)
-              if class_name
-                resolved = @method_type_resolver.resolve_class_method(class_name, stmt.value.name.to_s)
-                @local_var_types[var_name] = resolved.delete_suffix("?") if resolved && resolved != "untyped"
-              end
-            end
+          record_ivar_call_type(stmt.name.to_s.sub(/\A@/, ""), stmt.value)
+        elsif stmt.is_a?(Prism::MultiWriteNode)
+          # `@a, @b = Foo.new, Bar.new` (felixefelip/rbs_infer#183).
+          RbsInfer::AST::MultiWriteDecomposer.ivar_name_pairs(stmt).each do |var_name, value|
+            record_ivar_call_type(var_name, value)
           end
         end
+      end
+    end
+
+    def record_ivar_call_type(var_name, value)
+      return unless value.is_a?(Prism::CallNode)
+
+      if value.name == :new && value.receiver
+        class_name = RbsInfer::Analyzer.extract_constant_path(value.receiver)
+        @local_var_types[var_name] = class_name if class_name
+      elsif @method_type_resolver
+        class_name = RbsInfer::Analyzer.extract_constant_path(value.receiver)
+        return unless class_name
+
+        resolved = @method_type_resolver.resolve_class_method(class_name, value.name.to_s)
+        @local_var_types[var_name] = resolved.delete_suffix("?") if resolved && resolved != "untyped"
       end
     end
 

--- a/lib/rbs_infer/inference/return_type_resolver.rb
+++ b/lib/rbs_infer/inference/return_type_resolver.rb
@@ -434,6 +434,15 @@ module RbsInfer::Inference
           result << name
         end
         node.compact_child_nodes.each { |c| collect_body_level_ivar_writes(c, known_return_types, type_sets, attr_names, result) }
+      when Prism::MultiWriteNode
+        RbsInfer::AST::MultiWriteDecomposer.ivar_name_pairs(node).each do |name, value|
+          next if attr_names.include?(name)
+
+          inferred = basic_value_type(value, known_return_types)
+          type_sets[name].add(inferred) if inferred
+          result << name
+        end
+        node.compact_child_nodes.each { |c| collect_body_level_ivar_writes(c, known_return_types, type_sets, attr_names, result) }
       else
         node.compact_child_nodes.each { |c| collect_body_level_ivar_writes(c, known_return_types, type_sets, attr_names, result) }
       end
@@ -542,6 +551,17 @@ module RbsInfer::Inference
             type_sets[name].add(inferred) if inferred
           end
         end
+
+        # `@a, @b = x, y` — same contribution as the one-per-line form
+        # (felixefelip/rbs_infer#183).
+        RbsInfer::AST::MultiWriteDecomposer.ivar_name_pairs(current).each do |name, value|
+          next if attr_names.include?(name)
+
+          inferred = basic_value_type(value, known_return_types)
+          inferred = param_types[value.name.to_s] if inferred.nil? && value.is_a?(Prism::LocalVariableReadNode)
+          type_sets[name].add(inferred) if inferred
+        end
+
         queue.concat(current.compact_child_nodes)
       end
     end
@@ -566,6 +586,13 @@ module RbsInfer::Inference
       when Prism::InstanceVariableWriteNode
         if in_init || in_class_body
           result << node.name.to_s.sub(/\A@/, "")
+        end
+        walk_prism_init_targets(node.value, in_init: in_init, in_class_body: in_class_body, result: result) if node.value
+      when Prism::MultiWriteNode
+        # `@a, @b = x, y` initializes both, whatever the values look like — so
+        # this uses every ivar target, not just the pairable ones.
+        if in_init || in_class_body
+          result.merge(RbsInfer::AST::MultiWriteDecomposer.ivar_target_names(node))
         end
         walk_prism_init_targets(node.value, in_init: in_init, in_class_body: in_class_body, result: result) if node.value
       when Prism::CallNode

--- a/lib/rbs_infer/signatures/steep_bridge/ivar_write_analyzer.rb
+++ b/lib/rbs_infer/signatures/steep_bridge/ivar_write_analyzer.rb
@@ -44,13 +44,14 @@ class RbsInfer::Signatures::SteepBridge
       # `each_typing` enumerates the whole file, so we filter it by node
       # identity against the set of writes that belong to `target_class`.
       in_scope = collect_scoped_write_node_ids(source_node, attr_writer_to_ivar, target_class)
+      masgn_values = collect_masgn_target_values(source_node)
 
       typing.each_typing do |node, type|
         next unless in_scope.include?(node.object_id)
 
         case node.type
         when :ivasgn, :or_asgn, :and_asgn
-          parts = ivar_write_name_and_rhs(node)
+          parts = ivar_write_name_and_rhs(node, masgn_values: masgn_values)
           next unless parts
 
           var_name, rhs = parts
@@ -121,6 +122,7 @@ class RbsInfer::Signatures::SteepBridge
         current_method: nil,
         namespace: [],
         target_class: target_class,
+        masgn_values: collect_masgn_target_values(source_node),
         result: per_method_sets
       )
 
@@ -357,7 +359,7 @@ class RbsInfer::Signatures::SteepBridge
     # filter logic of `ivar_write_types` for both `:ivasgn` and
     # attr_writer-style `:send`.
     def collect_ivar_writes_per_method(node, typing:, attr_writer_to_ivar:, current_method:, namespace:, target_class:,
-                                       result:)
+                                       masgn_values:, result:)
       return unless node.is_a?(::Parser::AST::Node)
 
       case node.type
@@ -368,6 +370,7 @@ class RbsInfer::Signatures::SteepBridge
                                              current_method: nil,
                                              namespace: RbsInfer::Signatures::SteepBridge::LexicalScope.push_namespace(namespace, node),
                                              target_class: target_class,
+                                             masgn_values: masgn_values,
                                              result: result) if body
       when :sclass
         # `class << self` — same lexical class, singleton scope; keep the
@@ -378,6 +381,7 @@ class RbsInfer::Signatures::SteepBridge
                                              current_method: nil,
                                              namespace: namespace,
                                              target_class: target_class,
+                                             masgn_values: masgn_values,
                                              result: result) if body
       when :def
         method_name = node.children[0].to_s
@@ -387,12 +391,13 @@ class RbsInfer::Signatures::SteepBridge
                                              current_method: method_name,
                                              namespace: namespace,
                                              target_class: target_class,
+                                             masgn_values: masgn_values,
                                              result: result) if body
       when :defs
         # Singleton `def self.X` — class-instance variable scope, not
         # relevant for the per-action narrowing this method serves.
       when :ivasgn, :or_asgn, :and_asgn
-        parts = ivar_write_name_and_rhs(node)
+        parts = ivar_write_name_and_rhs(node, masgn_values: masgn_values)
         rhs = parts&.last
         if current_method && parts && RbsInfer::Signatures::SteepBridge::LexicalScope.class_scope_match?(namespace,
                                                                                                          target_class)
@@ -417,6 +422,7 @@ class RbsInfer::Signatures::SteepBridge
                                             current_method: current_method,
                                             namespace: namespace,
                                             target_class: target_class,
+                                            masgn_values: masgn_values,
                                             result: result) if rhs
       when :send
         receiver, method_name, *args = node.children
@@ -436,6 +442,7 @@ class RbsInfer::Signatures::SteepBridge
                                             current_method: current_method,
                                             namespace: namespace,
                                             target_class: target_class,
+                                            masgn_values: masgn_values,
                                             result: result)
         end
       when :begin
@@ -445,6 +452,7 @@ class RbsInfer::Signatures::SteepBridge
                                             current_method: current_method,
                                             namespace: namespace,
                                             target_class: target_class,
+                                            masgn_values: masgn_values,
                                             result: result)
         end
       else
@@ -454,6 +462,7 @@ class RbsInfer::Signatures::SteepBridge
                                             current_method: current_method,
                                             namespace: namespace,
                                             target_class: target_class,
+                                            masgn_values: masgn_values,
                                             result: result)
         end
       end
@@ -488,15 +497,53 @@ class RbsInfer::Signatures::SteepBridge
     # callers type them exactly like a plain write; `:op_asgn` (`+=`, `<<=`) is
     # deliberately excluded, since there the result type is the operator's, not
     # the RHS's.
-    def ivar_write_name_and_rhs(node)
+    # `masgn_values` required, not defaulted: a caller that forgets it doesn't
+    # break, it silently stops typing every multiple assignment — the
+    # silent-wrong case in docs/engineering/required-threaded-deps.md.
+    def ivar_write_name_and_rhs(node, masgn_values:)
       case node.type
       when :ivasgn
         name, rhs = node.children
+        # A multiple-assignment target is an argument-less `:ivasgn`; its value
+        # is the element of the RHS array that lands in it
+        # (felixefelip/rbs_infer#183).
+        rhs ||= masgn_values[node.object_id]
         [name.to_s.sub(/\A@/, ""), rhs] if rhs
       when :or_asgn, :and_asgn
         lhs, rhs = node.children
         [lhs.children[0].to_s.sub(/\A@/, ""), rhs] if lhs.type == :ivasgn && rhs
       end
+    end
+
+    # `{ target_ivasgn_node_id => value_node }` for every `@a, @b = x, y` in
+    # the tree. Handing back the RHS *element* (rather than reading the
+    # target's own typing) keeps `intrinsic_type_of` in play: a masgn target
+    # is subject to the same declared-ivar hint widening that
+    # `intrinsic_type_of` exists to undo, so pairing here makes the multiple
+    # assignment type exactly like the one-per-line form it stands for.
+    #
+    # Pairs only when the correspondence is positional and certain — same rule
+    # as the Prism-side `AST::MultiWriteDecomposer`.
+    def collect_masgn_target_values(node, result: {})
+      return result unless node.is_a?(::Parser::AST::Node)
+
+      if node.type == :masgn
+        mlhs, rhs = node.children
+        if mlhs.respond_to?(:type) && mlhs.type == :mlhs && rhs.respond_to?(:type) && rhs.type == :array
+          targets = mlhs.children
+          values = rhs.children
+          if targets.size == values.size &&
+             targets.none? { |t| t.respond_to?(:type) && t.type == :splat } &&
+             values.none? { |v| v.respond_to?(:type) && v.type == :splat }
+            targets.zip(values).each do |target, value|
+              result[target.object_id] = value if target.respond_to?(:type) && target.type == :ivasgn
+            end
+          end
+        end
+      end
+
+      node.children.each { |c| collect_masgn_target_values(c, result: result) }
+      result
     end
   end
 end

--- a/spec/dummy/app/controllers/posts_controller.rb
+++ b/spec/dummy/app/controllers/posts_controller.rb
@@ -43,6 +43,9 @@ class PostsController < ApplicationController
   def publish
     # Assignment call-site that types `Current.user` (rbs_infer#19)
     Current.user = @post.user
+    # Call-site that types the one-line `@user, @post, @expanded = ...` in
+    # PostFiltering#initialize (rbs_infer#183)
+    PostFiltering.new(@post.user, @post, expanded: true)
     publisher = PostPublisher.new(@post)
     if publisher.call
       redirect_to @post, notice: "Post published."

--- a/spec/dummy/app/services/post_filtering.rb
+++ b/spec/dummy/app/services/post_filtering.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# felixefelip/rbs_infer#183 — `initialize` assigns its ivars on one line.
+#
+# Prism shapes `@a, @b = a, b` as a single `MultiWriteNode` whose targets are
+# `InstanceVariableTargetNode`s, so every visitor keyed on
+# `InstanceVariableWriteNode` used to miss it: the params were typed from the
+# call-site as usual, but the attrs came out `untyped` (and, once the ivar link
+# was restored, `T?` until the definite-initialization rule learned the shape
+# too). Fizzy's `User::Filtering` is this class.
+class PostFiltering
+  attr_reader :user, :post, :expanded
+
+  def initialize(user, post, expanded: false)
+    @user, @post, @expanded = user, post, expanded
+  end
+
+  def expanded?
+    @expanded
+  end
+
+  def title
+    post.title
+  end
+
+  # `user` is nilable because the call-site passes `@post.user` — nothing to do
+  # with the multiple assignment, which is what this fixture is about.
+  def author_name
+    user&.name
+  end
+end

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -1079,6 +1079,17 @@ postconditions:
   effects:
     may_write:
     - "@post"
+- class: PostFiltering
+  method: expanded?
+  effects:
+    returns_ivar: "@expanded"
+- class: PostFiltering
+  method: initialize
+  effects:
+    may_write:
+    - "@expanded"
+    - "@post"
+    - "@user"
 - class: PostPublisher
   method: initialize
   effects:

--- a/spec/dummy/sig/rbs_infer/app/services/post_filtering.rbs
+++ b/spec/dummy/sig/rbs_infer/app/services/post_filtering.rbs
@@ -1,0 +1,10 @@
+class PostFiltering
+  attr_reader user: User?
+  attr_reader post: Post
+  attr_reader expanded: bool
+
+  def initialize: (User? user, Post post, ?expanded: bool) -> void
+  def expanded?: () -> bool
+  def title: () -> String?
+  def author_name: () -> String?
+end

--- a/spec/expectations/services/post_filtering.rbs
+++ b/spec/expectations/services/post_filtering.rbs
@@ -1,0 +1,10 @@
+class PostFiltering
+  attr_reader user: User?
+  attr_reader post: Post
+  attr_reader expanded: bool
+
+  def initialize: (User? user, Post post, ?expanded: bool) -> void
+  def expanded?: () -> bool
+  def title: () -> String?
+  def author_name: () -> String?
+end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -902,6 +902,15 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     assert_snapshot("services/widget_auditor", target_class: "WidgetAuditor", target_file: "app/services/widget_auditor.rb")
   end
 
+  # felixefelip/rbs_infer#183. `initialize` assigns every ivar on one line
+  # (`@user, @post, @expanded = user, post, expanded`), which Prism shapes as a
+  # `MultiWriteNode` — the ivar → param link, and the definite-initialization
+  # rule behind it, both have to read that shape or the attrs come out
+  # `untyped`/`T?` while the params are fully typed. Fizzy's `User::Filtering`.
+  it "PostFiltering types attrs assigned by a single multiple assignment" do
+    assert_snapshot("services/post_filtering", target_class: "PostFiltering", target_file: "app/services/post_filtering.rb")
+  end
+
   it "ApplicationJob base class matches expected RBS" do
     assert_snapshot("jobs/application_job", target_class: "ApplicationJob", target_file: "app/jobs/application_job.rb")
   end

--- a/spec/lib/rbs_infer/ast/multi_write_decomposer_spec.rb
+++ b/spec/lib/rbs_infer/ast/multi_write_decomposer_spec.rb
@@ -1,0 +1,63 @@
+require "spec_helper"
+require "rbs_infer"
+
+RSpec.describe RbsInfer::AST::MultiWriteDecomposer do
+  def multi_write(source)
+    RbsInfer::Analyzer.find_all_nodes(Prism.parse(source).value) { |n| n.is_a?(Prism::MultiWriteNode) }.first
+  end
+
+  describe ".ivar_name_pairs" do
+    it "pairs each ivar target with the value that lands in it" do
+      node = multi_write("@user, @filter, @expanded = user, filter, expanded")
+
+      expect(described_class.ivar_name_pairs(node).map { |name, value| [name, value.name] })
+        .to eq([["user", :user], ["filter", :filter], ["expanded", :expanded]])
+    end
+
+    it "pairs by position, not by name" do
+      node = multi_write("@a, @b = b, a")
+
+      expect(described_class.ivar_name_pairs(node).map { |name, value| [name, value.name] })
+        .to eq([["a", :b], ["b", :a]])
+    end
+
+    it "skips non-ivar targets while keeping the others aligned" do
+      node = multi_write("@a, local, @c = 1, 2, 3")
+
+      expect(described_class.ivar_name_pairs(node).map { |name, value| [name, value.value] })
+        .to eq([["a", 1], ["c", 3]])
+    end
+
+    it "declines to pair a single value destructured at runtime" do
+      expect(described_class.ivar_name_pairs(multi_write("@a, @b = pair"))).to be_empty
+    end
+
+    it "declines to pair when a splat redistributes the values" do
+      expect(described_class.ivar_name_pairs(multi_write("@a, *@rest = 1, 2, 3"))).to be_empty
+      expect(described_class.ivar_name_pairs(multi_write("@a, @b = *values"))).to be_empty
+    end
+
+    it "declines to pair when the arities do not match" do
+      expect(described_class.ivar_name_pairs(multi_write("@a, @b, @c = 1, 2"))).to be_empty
+    end
+
+    it "declines to pair a nested target" do
+      expect(described_class.ivar_name_pairs(multi_write("@a, (@b, @c) = 1, [2, 3]")).map(&:first)).to eq(["a"])
+    end
+
+    it "returns nothing for a node that is not a multiple assignment" do
+      expect(described_class.ivar_name_pairs(Prism.parse("@a = 1").value)).to be_empty
+    end
+  end
+
+  describe ".ivar_target_names" do
+    it "names every ivar written, including targets it would not pair" do
+      expect(described_class.ivar_target_names(multi_write("@a, *@rest, @z = whatever")))
+        .to eq(["a", "rest", "z"])
+    end
+
+    it "names the ivars of a value it cannot destructure statically" do
+      expect(described_class.ivar_target_names(multi_write("@a, @b = pair"))).to eq(["a", "b"])
+    end
+  end
+end

--- a/spec/lib/rbs_infer/inference/initialize_body_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/inference/initialize_body_analyzer_spec.rb
@@ -213,4 +213,47 @@ RSpec.describe RbsInfer::Inference::InitializeBodyAnalyzer do
     expect(visitor.self_assignments["items"][:kind]).to eq(:literal)
     expect(visitor.self_assignments["items"][:type]).to eq("Array[Integer | String]")
   end
+
+  context "com atribuição múltipla (`@a, @b = a, b`)" do
+    it "liga cada ivar ao param que cai nele" do
+      source = <<~RUBY
+        class Foo
+          def initialize(user, filter, expanded: false)
+            @user, @filter, @expanded = user, filter, expanded
+          end
+        end
+      RUBY
+
+      visitor = analyze(source)
+      expect(visitor.self_assignments["user"]).to eq({ kind: :param, name: "user" })
+      expect(visitor.self_assignments["filter"]).to eq({ kind: :param, name: "filter" })
+      expect(visitor.self_assignments["expanded"]).to eq({ kind: :param, name: "expanded" })
+    end
+
+    it "resolve cada valor pelo mesmo caminho da forma uma-por-linha" do
+      source = <<~RUBY
+        class Foo
+          def initialize(email)
+            @email, @tags = Email.new(email), ["a"]
+          end
+        end
+      RUBY
+
+      visitor = analyze(source)
+      expect(visitor.self_assignments["email"]).to eq({ kind: :constant, type: "Email" })
+      expect(visitor.self_assignments["tags"]).to eq({ kind: :literal, type: "Array[String]" })
+    end
+
+    it "não adivinha quando o valor único é desestruturado em runtime" do
+      source = <<~RUBY
+        class Foo
+          def initialize(pair)
+            @a, @b = pair
+          end
+        end
+      RUBY
+
+      expect(analyze(source).self_assignments).to be_empty
+    end
+  end
 end

--- a/spec/lib/rbs_infer/signatures/steep_bridge/ivar_write_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/signatures/steep_bridge/ivar_write_analyzer_spec.rb
@@ -526,5 +526,69 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
         expect(user).not_to have_key("ran")
       end
     end
+
+    # felixefelip/rbs_infer#183 — em whitequark os alvos de um `masgn` são
+    # `:ivasgn` sem RHS, então a escrita não contribuía tipo nenhum.
+    context "com atribuição múltipla (`@a, @b = x, y`)" do
+      it "tipa cada ivar como a forma uma-por-linha tiparia" do
+        code = <<~RUBY
+          class Foo
+            def initialize
+              @name, @size = "hello", 3
+            end
+          end
+        RUBY
+
+        result = bridge.ivar_write_types(code, target_class: "Foo")
+        expect(result["name"]).to eq("String")
+        expect(result["size"]).to eq("Integer")
+      end
+
+      it "conta como inicialização definida, sem `| nil`" do
+        code = <<~RUBY
+          class Foo
+            def initialize
+              @name, @size = "hello", 3
+            end
+
+            def rename
+              @name = "other"
+            end
+          end
+        RUBY
+
+        result = bridge.ivar_write_types(code, target_class: "Foo")
+        expect(result["name"]).to eq("String")
+      end
+
+      it "não inventa tipo quando o valor único é desestruturado em runtime" do
+        code = <<~RUBY
+          class Foo
+            def initialize(pair)
+              @a, @b = pair
+            end
+          end
+        RUBY
+
+        result = bridge.ivar_write_types(code, target_class: "Foo")
+        expect(result).not_to have_key("a")
+        expect(result).not_to have_key("b")
+      end
+    end
+  end
+
+  describe "#ivar_write_types_per_method com atribuição múltipla" do
+    it "atribui cada ivar ao método que a escreveu" do
+      code = <<~RUBY
+        class Foo
+          def load
+            @name, @size = "hello", 3
+          end
+        end
+      RUBY
+
+      result = bridge.ivar_write_types_per_method(code, target_class: "Foo")
+      expect(result["load"]).to eq({ "name" => "String", "size" => "Integer" })
+    end
   end
 end


### PR DESCRIPTION
Closes #183.

## The gap

`@user, @filter, @expanded = user, filter, expanded` assigns exactly what the one-per-line form assigns, but Prism shapes it as a single `MultiWriteNode` whose targets are `InstanceVariableTargetNode`s — with no `.value` of their own. Every visitor is keyed on `InstanceVariableWriteNode`, so the assignment was invisible.

The same class written both ways, same call-site:

```
Multi   → attr_reader user: untyped,  label: untyped,  expanded: untyped
Single  → attr_reader user: User,     label: String,   expanded: bool
```

The `initialize` params were right in both — they come from the call-site. What was lost was only the ivar ↔ param link, and everything downstream of it.

## It is not one site

Fixing `InitializeBodyAnalyzer` alone makes the types come out **nilable** (`User?` instead of `User`), because the definite-initialization rule reads the old node too — a result that looks right and is worse than the honest `untyped`. So this wires the whole set:

| Site | What it regains |
|---|---|
| `Inference::InitializeBodyAnalyzer` | ivar → param link (the symptom) |
| `ReturnTypeResolver#walk_prism_init_targets` | definite initialization, no spurious `T?` |
| `ReturnTypeResolver#collect_ivar_writes` / `#collect_body_level_ivar_writes` | the ivar's type set |
| `Analyzer#widen_assigned_param_types` | the reverse direction (param typed from the ivar) |
| `Inference::NewCallCollector` (2 sites) | `@a, @b = Foo.new, Bar.new` |
| `Inference::ClassBodyAttrAnalyzer` | writes outside `initialize` |
| `SteepBridge::IvarWriteAnalyzer` | per-write and per-method types (controller ivars → views) |

## The shape of the fix

`AST::MultiWriteDecomposer` is the one place that decides how a multiple assignment pairs up; every consumer keeps its own semantics and only gains the shape.

The pairing is deliberately narrow — array literal, matching arities, no splat on either side. These stay untyped:

```ruby
@a, @b = pair           # one value destructured at runtime
@a, *@rest = 1, 2, 3    # a splat redistributes the elements
@a, (@b, @c) = 1, [2, 3]
```

Guessing there would be worse than the honest answer they already get. Definite initialization is the one question that *is* answerable for all of them ("was `@x` assigned here?"), so it uses every ivar target rather than only the pairable ones.

### The Steep/Parser side needed its own pass

whitequark represents `masgn` targets as argument-less `:ivasgn` nodes, so `walk_ivar_init_targets` was counting them as initialized *by accident* — but `ivar_write_name_and_rhs` returned `nil` for them and no type was ever recorded.

It now pairs over Parser nodes and hands back the RHS **element** rather than the target's own typing. That keeps `intrinsic_type_of` in play: a masgn target is subject to the same declared-ivar hint widening that helper exists to undo (the steep#35 mirror). The invariant throughout is that a multiple assignment types exactly like the form it stands for.

`masgn_values:` is threaded required, not defaulted — a caller that forgets it doesn't break, it silently stops typing every multiple assignment (`docs/engineering/required-threaded-deps.md`).

## Testing

- `bundle exec rspec` — 981 examples, 0 failures.
- New `spec/lib/rbs_infer/ast/multi_write_decomposer_spec.rb` (10 cases, including every shape it refuses to pair), plus cases in `initialize_body_analyzer_spec` and `ivar_write_analyzer_spec` (both `ivar_write_types` and `ivar_write_types_per_method`).
- Fixture `PostFiltering`, constructed from `PostsController#publish`.
- **Regenerating the whole dummy changed no existing expectation** — only the new snapshot and the fixture's postcondition entries appear. The Steep baseline is untouched.

## On Fizzy

`app/models/user/filtering.rb` is this class. Running the fixed analyzer against it:

```
attr_reader user:     untyped → (User & User::Validated)?
attr_reader filter:   untyped → (Filter & Filter::Validated)?
attr_reader expanded: untyped → bool
initialize ?expanded: untyped → bool
selected_board_titles: untyped → Array[String]
show_assignees? / show_creators? / show_closers? / show_boards?: untyped → bool
account:              untyped → (Account & Account::Validated)
```

## Not fixed here

`expanded?` (a method whose body is a bare `@expanded` read) still returns `untyped` on a single analyzer pass. Verified pre-existing and unrelated: the one-per-line form gives exactly the same `untyped`. It converges to `bool` on the second pass once the RBS is on disk, which is what the dummy's own generated output shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)