### PR TITLE
fix: take the checker's narrowed type for a constructor argument

### DIFF
--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -614,8 +614,7 @@ module RbsInfer::Inference
           key = extract_symbol_key(elem.key)
           next unless key
 
-          value_type = resolve_value_type(elem.value)
-          args[key] = value_type
+          args[key] = argument_type(elem.value)
         end
       end
 
@@ -633,7 +632,7 @@ module RbsInfer::Inference
         next if arg.is_a?(Prism::KeywordHashNode)
 
         param_name = @init_positional_params[index]
-        args[param_name] = resolve_value_type(arg)
+        args[param_name] = argument_type(arg)
         index += 1
       end
 
@@ -867,14 +866,35 @@ module RbsInfer::Inference
     # argument came out `untyped`, the Analyzer drops `untyped` usages, and the
     # attribute stayed untyped though Steep types that expression `String?`.
     #
-    # Only a fallback: the structural answer wins when it has one, since it
+    # Mostly a fallback: the structural answer wins when it has one, since it
     # carries the naming conventions (a class name for `Klass.new`, a record for
     # a hash literal) that a checker type does not.
+    #
+    # The exception is nilability. The structural path resolves a call through
+    # its DECLARATION — `Current.user` is `(User & User::Validated)?` because
+    # that is what the signature says. A declaration is what holds where flow
+    # can't be followed; at a position the checker has already proven non-nil,
+    # its answer is the better one, and taking the declaration there hands the
+    # callee's parameter a `nil` no call site can pass
+    # (felixefelip/rbs_infer#186).
     def argument_type(arg)
       resolved = resolve_value_type(arg)
+      checker = expression_type(arg)
+
+      return checker if narrowed_from?(resolved, checker)
       return resolved unless resolved.nil? || resolved == "untyped"
 
-      expression_type(arg) || resolved
+      checker || resolved
+    end
+
+    # Whether the two answers differ ONLY by nilability, with the checker on the
+    # non-nil side. Deliberately not a general subtype test: this is the one
+    # case where the checker is strictly better informed than the declaration,
+    # and every other disagreement leaves the structural answer in charge.
+    def narrowed_from?(declared, checked)
+      return false unless declared && checked
+
+      declared == RbsInfer::Signatures::RbsParserUtil.nilablize(checked)
     end
 
     def expression_type(node)

--- a/spec/dummy/app/controllers/posts_controller.rb
+++ b/spec/dummy/app/controllers/posts_controller.rb
@@ -43,9 +43,7 @@ class PostsController < ApplicationController
   def publish
     # Assignment call-site that types `Current.user` (rbs_infer#19)
     Current.user = @post.user
-    # Call-site that types the one-line `@user, @post, @expanded = ...` in
-    # PostFiltering#initialize (rbs_infer#183)
-    PostFiltering.new(@post.user, @post, expanded: true)
+    build_filtering_for_current_user
     publisher = PostPublisher.new(@post)
     if publisher.call
       redirect_to @post, notice: "Post published."
@@ -66,5 +64,17 @@ class PostsController < ApplicationController
 
   def post_params
     params.require(:post).permit(:title, :body, :pinned)
+  end
+
+  # The call-site that types `PostFiltering#initialize` — its one-line
+  # `@user, @post, @expanded = ...` (felixefelip/rbs_infer#183) and, for the
+  # `user` parameter, #186: `Current.user` is DECLARED nilable and
+  # the guard proves it non-nil for the rest of the body. Taking the declaration
+  # here handed the parameter a `nil` no call site can pass. Fizzy's
+  # `FilterScoped` is this shape.
+  def build_filtering_for_current_user
+    return unless Current.user
+
+    PostFiltering.new(Current.user, @post, expanded: false)
   end
 end

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -1933,6 +1933,16 @@ method_entry_facts:
     Current.user: "(::User & ::User::Validated)"
     Current.viewer_name: "::String"
 - class: PostsController
+  method: build_filtering_for_current_user
+  self_methods:
+    current_user: "(::User & ::User::Validated)"
+  consts:
+    Current.author_name: "::String"
+    Current.user: "((::User & ::User::Validated) | ::User)"
+    Current.viewer_name: "::String"
+  ivars:
+    "@post": "(::Post & ::Post::Validated)"
+- class: PostsController
   method: create
   self_methods:
     current_user: "(::User & ::User::Validated)"

--- a/spec/dummy/sig/rbs_infer/app/controllers/posts_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/app/controllers/posts_controller.rbs
@@ -19,4 +19,5 @@ class PostsController < ApplicationController
   def set_post: () -> (Post & Post::Validated)
   def set_test: () -> (Post & Post::Validated)?
   def post_params: () -> untyped
+  def build_filtering_for_current_user: () -> PostFiltering?
 end

--- a/spec/dummy/sig/rbs_infer/app/models/current.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/current.rbs
@@ -1,5 +1,5 @@
 class Current < ActiveSupport::CurrentAttributes
   def self.author_full_name: () -> String?
 
-  def user=: (((User & User::Validated)? | User?) value) -> untyped
+  def user=: (((User & User::Validated) | User?) value) -> untyped
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example13.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example13.rbs
@@ -7,7 +7,7 @@ class Example13
     self.@registry_instance: Registry?
 
     module GeneratedAttributes
-      attr_accessor user: (Example13Viewer? | nil)?
+      attr_accessor user: (Example13Viewer | nil)?
       attr_accessor tenant: (Example13Tenant | nil)?
       attr_writer registry_instance: untyped
     end
@@ -15,8 +15,8 @@ class Example13
     include GeneratedAttributes
 
     def self.registry_instance: () -> Example13::Registry
-    def self.user: () -> (Example13Viewer? | nil)?
-    def self.user=: ((Example13Viewer? | nil) value) -> (Example13Viewer? | nil)
+    def self.user: () -> (Example13Viewer | nil)?
+    def self.user=: ((Example13Viewer | nil) value) -> (Example13Viewer | nil)
     def self.tenant: () -> (Example13Tenant | nil)?
     def self.tenant=: ((Example13Tenant | nil) value) -> (Example13Tenant | nil)
   end

--- a/spec/dummy/sig/rbs_infer/app/services/post_filtering.rbs
+++ b/spec/dummy/sig/rbs_infer/app/services/post_filtering.rbs
@@ -1,10 +1,14 @@
 class PostFiltering
-  attr_reader user: User?
+  attr_reader user: (User & User::Validated | User)
   attr_reader post: Post
   attr_reader expanded: bool
 
-  def initialize: (User? user, Post post, ?expanded: bool) -> void
+  def initialize: ((User & User::Validated | User) user, Post post, ?expanded: bool) -> void
   def expanded?: () -> bool
   def title: () -> String?
   def author_name: () -> String?
+
+  class AfterInitialize
+    attr_reader user: (User & User::Validated) | User
+  end
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs
@@ -12,7 +12,7 @@ class Current
 
   module GeneratedAttributeMethods
     def user: () -> ((User & User::Validated) | User)?
-    def user=: (((User & User::Validated)? | User?) value) -> ((User & User::Validated) | User)?
+    def user=: (((User & User::Validated) | User?) value) -> ((User & User::Validated) | User)?
     def author_name: () -> String?
     def author_name=: (String? value) -> String?
     def account: () -> (Account & Account::Validated)?
@@ -24,7 +24,7 @@ class Current
   include GeneratedAttributeMethods
 
   def self.user: () -> ((User & User::Validated) | User)?
-  def self.user=: (((User & User::Validated)? | User?) value) -> ((User & User::Validated)? | User?)
+  def self.user=: (((User & User::Validated) | User?) value) -> ((User & User::Validated) | User?)
   def self.author_name: () -> String?
   def self.author_name=: (String? value) -> String?
   def self.account: () -> (Account & Account::Validated)?

--- a/spec/expectations/controllers/posts_controller.rbs
+++ b/spec/expectations/controllers/posts_controller.rbs
@@ -19,4 +19,5 @@ class PostsController < ApplicationController
   def set_post: () -> (Post & Post::Validated)
   def set_test: () -> (Post & Post::Validated)?
   def post_params: () -> untyped
+  def build_filtering_for_current_user: () -> PostFiltering?
 end

--- a/spec/expectations/models/current.rbs
+++ b/spec/expectations/models/current.rbs
@@ -1,5 +1,5 @@
 class Current < ActiveSupport::CurrentAttributes
   def self.author_full_name: () -> String?
 
-  def user=: (((User & User::Validated)? | User?) value) -> untyped
+  def user=: (((User & User::Validated) | User?) value) -> untyped
 end

--- a/spec/expectations/models/example13.rbs
+++ b/spec/expectations/models/example13.rbs
@@ -7,7 +7,7 @@ class Example13
     self.@registry_instance: Registry?
 
     module GeneratedAttributes
-      attr_accessor user: (Example13Viewer? | nil)?
+      attr_accessor user: (Example13Viewer | nil)?
       attr_accessor tenant: (Example13Tenant | nil)?
       attr_writer registry_instance: untyped
     end
@@ -15,8 +15,8 @@ class Example13
     include GeneratedAttributes
 
     def self.registry_instance: () -> Example13::Registry
-    def self.user: () -> (Example13Viewer? | nil)?
-    def self.user=: ((Example13Viewer? | nil) value) -> (Example13Viewer? | nil)
+    def self.user: () -> (Example13Viewer | nil)?
+    def self.user=: ((Example13Viewer | nil) value) -> (Example13Viewer | nil)
     def self.tenant: () -> (Example13Tenant | nil)?
     def self.tenant=: ((Example13Tenant | nil) value) -> (Example13Tenant | nil)
   end

--- a/spec/expectations/services/post_filtering.rbs
+++ b/spec/expectations/services/post_filtering.rbs
@@ -1,10 +1,14 @@
 class PostFiltering
-  attr_reader user: User?
+  attr_reader user: (User & User::Validated | User)
   attr_reader post: Post
   attr_reader expanded: bool
 
-  def initialize: (User? user, Post post, ?expanded: bool) -> void
+  def initialize: ((User & User::Validated | User) user, Post post, ?expanded: bool) -> void
   def expanded?: () -> bool
   def title: () -> String?
   def author_name: () -> String?
+
+  class AfterInitialize
+    attr_reader user: (User & User::Validated) | User
+  end
 end

--- a/spec/expectations/steep_current_runtime/current.rbs
+++ b/spec/expectations/steep_current_runtime/current.rbs
@@ -12,7 +12,7 @@ class Current
 
   module GeneratedAttributeMethods
     def user: () -> ((User & User::Validated) | User)?
-    def user=: (((User & User::Validated)? | User?) value) -> ((User & User::Validated) | User)?
+    def user=: (((User & User::Validated) | User?) value) -> ((User & User::Validated) | User)?
     def author_name: () -> String?
     def author_name=: (String? value) -> String?
     def account: () -> (Account & Account::Validated)?
@@ -24,7 +24,7 @@ class Current
   include GeneratedAttributeMethods
 
   def self.user: () -> ((User & User::Validated) | User)?
-  def self.user=: (((User & User::Validated)? | User?) value) -> ((User & User::Validated)? | User?)
+  def self.user=: (((User & User::Validated) | User?) value) -> ((User & User::Validated) | User?)
   def self.author_name: () -> String?
   def self.author_name=: (String? value) -> String?
   def self.account: () -> (Account & Account::Validated)?


### PR DESCRIPTION
## The symptom

`User::Filtering#user` came out nilable even though the only call site passes a value Steep has already proven non-nil:

```ruby
# app/controllers/concerns/filter_scoped.rb
def set_user_filtering
  @user_filtering = User::Filtering.new(Current.user, @filter, expanded: expanded_param)
end
```

Probing Steep at that exact position:

```
line 23: Current.user => (::User & ::User::Validated)     # non-nil
```

and `all_expression_types` files that answer under the argument's key. The pipeline threw it away and took the **declaration** — `Current.user: () -> (User & User::Validated)?` — handing the parameter a `nil` no call site can pass.

## Two things were wrong

**1. Constructor arguments never consulted the checker at all.**

`extract_positional_args` / `extract_keyword_args` call `resolve_value_type` directly. `argument_type` — the one place with the checker fallback — was reached only from `extract_cross_class_args`, the cross-class *method* call path. So `.new(...)` arguments had no access to the checker's answer, not even the pre-existing untyped fallback. Both now go through `argument_type`.

I found this the slow way: fixing precedence alone changed nothing, and instrumenting `argument_type` showed it was never invoked for this call.

**2. The fallback could never beat a declaration.**

It fires only when the structural answer is `nil`/`untyped`, and `resolve_method_chain` resolves `Current.user` through its signature — a real answer, just a flow-blind one.

`argument_type` now prefers the checker when the two differ **only by nilability**, with the checker on the non-nil side:

```ruby
def narrowed_from?(declared, checked)
  return false unless declared && checked
  declared == RbsInfer::Signatures::RbsParserUtil.nilablize(checked)
end
```

Deliberately not a general subtype test. This is the one case where the checker is strictly better informed than the declaration; every other disagreement leaves the structural answer in charge, because it carries the naming conventions (a class name for `Klass.new`, a record for a hash literal) that a checker type does not.

Per-call-site only — the parameter's type is still the union over all call sites, so one site passing something genuinely nilable keeps the union nilable.

## Effect on Fizzy

```
attr_reader user: (User & User::Validated)?  →  (User & User::Validated)
def initialize: ((User & User::Validated)? user, ...)  →  ((User & User::Validated) user, ...)
```

with knock-on resolution of `tags`, `users` and `expanded?`, which were `untyped`. `filter` correctly stays nilable — it is `@filter`, set in another method body.

## Testing

- `bundle exec rspec` — **981 examples, 0 failures**, at a fixed point (regenerate → run → regenerate until stable).
- New fixture: `PostsController#build_filtering_for_current_user` guards `Current.user` and passes it to `PostFiltering.new`. Its snapshot asserts `user: (User & User::Validated | User)`, non-nilable.
- Four other expectations move, all the same benign shape: `(T? | nil)` → `(T | nil)` — the same type without a `?` that was redundant inside a union already carrying `nil`.
- The Steep baseline is unchanged.

## One thing this surfaced, not fixed here

The new snapshot carries a `PostFiltering::AfterInitialize` marker whose type differs from the declared one only by parenthesization:

```
declared: (User & User::Validated | User)   normalizes to  User&User::Validated|User
written:  (User & User::Validated) | User   normalizes to  (User&User::Validated)|User
```

`SetterMarkerSynthesizer#normalize` compares strings and strips only the outermost parens, so it reads a real narrowing where there is none. The same type in RBS (`&` binds tighter than `|`), so the marker is a no-op intersection — harmless, but noise in the output. The principled fix is comparing parsed types (`RBS::Parser.parse_type`) rather than strings; that is a separate change and its own PR.

Worth recording that the marker's *nilable* form on Fizzy was **lag**, not a regression: `ivar_write_types_per_method` reads the `sig/` on disk, which still held the old signature. Regenerating the dummy to a fixed point converged it to the declared type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)