### PR TITLE
fix: extend a concern's ClassMethods on the includer, for app-local concerns too

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -181,7 +181,8 @@ module RbsInfer
       superclass_name: nil,
       namespace_classes: resolve_namespace_classes(receiver),
       is_module: false,
-      type_params: method_type_resolver.type_param_string(receiver)
+      type_params: method_type_resolver.type_param_string(receiver),
+      class_methods_index: class_methods_index
     ).build(members, {}, {}, ivar_types: {}, singleton_ivar_types: {}, markers: [])
   end
 
@@ -335,7 +336,7 @@ module RbsInfer
     markers = synthesize_markers(target_members, attr_types, ivar_types)
 
     namespace_classes = resolve_namespace_classes
-    rbs_builder = RbsInfer::Signatures::RbsBuilder.new(target_class: @target_class, superclass_name: @superclass_name, namespace_classes: namespace_classes, is_module: @is_module, type_params: method_type_resolver.type_param_string(@target_class))
+    rbs_builder = RbsInfer::Signatures::RbsBuilder.new(target_class: @target_class, superclass_name: @superclass_name, namespace_classes: namespace_classes, is_module: @is_module, type_params: method_type_resolver.type_param_string(@target_class), class_methods_index: class_methods_index)
     rbs_builder.build(target_members, init_arg_types, attr_types, optional_params, method_param_types, ivar_types: ivar_types, singleton_ivar_types: singleton_ivar_types, markers: markers)
   end
 
@@ -1156,6 +1157,12 @@ module RbsInfer
     @method_type_resolver ||= RbsInfer::Signatures::MethodTypeResolver.new(@source_files, source_index: @source_index, parse_cache: @parse_cache, file_index: @file_index, caller_file_cache: @caller_file_cache, constant_resolver: env_only_constant_resolver, mixin_index: mixin_index)
   end
 
+  # Shared by both `RbsBuilder` call-sites so a concern's file is read and
+  # expanded once per analysis, not once per includer.
+  def class_methods_index
+    @class_methods_index ||= RbsInfer::Project::ClassMethodsIndex.new(file_index: @file_index, parse_cache: @parse_cache)
+  end
+
   def type_merger
     @type_merger ||= RbsInfer::Inference::TypeMerger.new(target_file: @target_file, target_class: @target_class, instance_types: @instance_types || [], constant_resolver: constant_arg_resolver)
   end
@@ -1264,6 +1271,7 @@ end
 
 require_relative "project/parse_cache"
 require_relative "project/file_index"
+require_relative "project/class_methods_index"
 require_relative "project/caller_file_cache"
 require_relative "project/corpus"
 require_relative "ast/lexical_constant_resolver"

--- a/lib/rbs_infer/project/class_methods_index.rb
+++ b/lib/rbs_infer/project/class_methods_index.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "prism"
+require_relative "source_expanders"
+require_relative "../ast/lexical_constant_resolver"
+
+module RbsInfer::Project
+  # Answers one question, for the `extend X::ClassMethods` that `RbsBuilder`
+  # emits after an `include X`: does `X` define a nested `ClassMethods`?
+  #
+  # Two places can know, and both are consulted — a module's `ClassMethods` may
+  # be declared in a gem's RBS (`.gem_rbs_collection/`) or, for a concern the
+  # project itself defines, only in its own source. Looking at the gem
+  # collection alone made every app-local concern answer "no": the
+  # `module ClassMethods` was generated for the concern, the includer never got
+  # the matching `extend`, and calls to those class methods came out
+  # `Ruby::NoMethod` on the includer's singleton (felixefelip/rbs_infer#188).
+  #
+  # The source side reads the module's file through `SourceExpanders`, so a
+  # concern whose class methods are written as a `class_methods do` block is
+  # seen the same way a hand-written `module ClassMethods` is — this index
+  # matches the plain nested module the expanders leave behind and stays
+  # unaware of the DSL that produced it (docs/engineering/keep-core-framework-agnostic.md).
+  #
+  # The `X` of `include X` is written in `X`'s lexical scope, so candidates are
+  # walked in Ruby's constant-lookup order: `include Params` inside `Filter`
+  # asks about `Filter::Params` before top-level `Params`.
+  class ClassMethodsIndex
+    MODULE_NAME = "ClassMethods"
+
+    # `file_index` and `parse_cache` are required: the sole production caller
+    # (Analyzer) always has both, and an index built without them would answer
+    # "no ClassMethods" for every project concern — silently reinstating the
+    # very bug this exists to fix (docs/engineering/required-threaded-deps.md).
+    def initialize(file_index:, parse_cache:)
+      @file_index = file_index
+      @parse_cache = parse_cache
+      @answers = {}
+      @roots = {}
+    end
+
+    # Whether `module_name`, as written inside `enclosing`, defines a nested
+    # `module ClassMethods`.
+    def has?(module_name, enclosing:)
+      return false if module_name.nil? || module_name.empty?
+
+      key = [module_name, enclosing]
+      return @answers[key] if @answers.key?(key)
+
+      @answers[key] = resolve(module_name, enclosing)
+    end
+
+    private
+
+    def resolve(module_name, enclosing)
+      candidates = RbsInfer::AST::LexicalConstantResolver.candidates(name: module_name, enclosing: enclosing)
+
+      candidates.any? { |candidate| source_declares?(candidate) } ||
+        candidates.any? { |candidate| gem_rbs_declares?(candidate) }
+    end
+
+    # Whether any file in the project declares `<full_name>::ClassMethods`.
+    #
+    # `FileIndex#candidates` matches by path SUFFIX, which is not unique, so
+    # every candidate file is checked rather than just the first — the walk
+    # compares the fully-qualified declared name, so a file that happens to
+    # share a suffix simply fails to match (felixefelip/rbs_infer#185).
+    def source_declares?(full_name)
+      path = RbsInfer.class_name_to_path(full_name)
+
+      @file_index.candidates(path).any? do |file|
+        root = expanded_root(file)
+        root && declares_module?(root, "#{full_name}::#{MODULE_NAME}")
+      end
+    end
+
+    # The parsed root of `file` as the pipeline sees it — after the registered
+    # expanders desugar their macros. Memoized per file: the same concern is
+    # asked about once per class that includes it.
+    def expanded_root(file)
+      return @roots[file] if @roots.key?(file)
+
+      @roots[file] = begin
+        entry = @parse_cache.get(file)
+        if entry.nil?
+          nil
+        elsif (expanded = RbsInfer::Project::SourceExpanders.apply(entry.source))
+          result = Prism.parse(expanded)
+          result.success? ? result.value : entry.result.value
+        else
+          entry.result.value
+        end
+      end
+    end
+
+    def declares_module?(root, qualified_name)
+      finder = ModuleDeclarationFinder.new(qualified_name)
+      root.accept(finder)
+      finder.found?
+    end
+
+    # Whether a gem's RBS declares `<full_name>::ClassMethods`. This is the
+    # original lookup, unchanged: a gem has no source in `source_files`, so its
+    # checked-in RBS is the only thing that can answer.
+    def gem_rbs_declares?(full_name)
+      parts = full_name.split("::")
+      first = parts.first
+
+      gem_hints = [
+        first.downcase,
+        first.gsub(/([a-z])([A-Z])/, '\1_\2').downcase,
+        first.gsub(/([a-z])([A-Z])/, '\1-\2').downcase,
+      ].uniq
+
+      rbs_files = gem_hints.flat_map { |hint| Dir[".gem_rbs_collection/#{hint}/**/*.rbs"] }.uniq
+      return false if rbs_files.empty?
+
+      rbs_files.any? do |file|
+        content = File.read(file)
+        content.include?(parts.last) &&
+          RbsInfer::Signatures::RbsParserUtil.has_class_methods_submodule?(content, full_name)
+      end
+    end
+
+    # Finds a `module <qualified_name>` declaration anywhere in a file,
+    # tracking lexical nesting so `module Filter::Params; module ClassMethods`
+    # and `module Filter; module Params; module ClassMethods` both resolve to
+    # the same fully-qualified name.
+    #
+    # Only a `module` satisfies the match: `extend` takes a module, so a class
+    # of that name would not be extendable and must not produce the mixin.
+    class ModuleDeclarationFinder < Prism::Visitor
+      def initialize(qualified_name)
+        @qualified_name = qualified_name
+        @namespace = []
+        @found = false
+      end
+
+      def found? = @found
+
+      def visit_module_node(node)
+        enter(node) do
+          @found = true if @namespace.join("::") == @qualified_name
+          super
+        end
+      end
+
+      # A class contributes its name to the nesting but can never BE the match.
+      def visit_class_node(node)
+        enter(node) { super }
+      end
+
+      private
+
+      def enter(node)
+        @namespace.push(const_name(node))
+        yield
+        @namespace.pop
+      end
+
+      def const_name(node)
+        RbsInfer::Analyzer.extract_constant_path(node.constant_path) || node.constant_path.to_s
+      end
+    end
+  end
+end

--- a/lib/rbs_infer/signatures/rbs_builder.rb
+++ b/lib/rbs_infer/signatures/rbs_builder.rb
@@ -3,14 +3,19 @@ module RbsInfer::Signatures
     # All keyword args are required: both call-sites always supply them, and
     # omitting any would be silently wrong (a missing `type_params` reopens a
     # generic class without its params → GenericParameterMismatchError; a
-    # missing `is_module`/`namespace_classes` mis-renders the declaration).
+    # missing `is_module`/`namespace_classes` mis-renders the declaration; a
+    # missing `class_methods_index` drops every `extend X::ClassMethods`).
     # Per docs/engineering/required-threaded-deps.md, that's "required", not
     # "defaulted".
-    def initialize(target_class:, superclass_name:, namespace_classes:, is_module:, type_params:)
+    def initialize(target_class:, superclass_name:, namespace_classes:, is_module:, type_params:, class_methods_index:)
       @target_class = target_class
       @superclass_name = superclass_name
       @namespace_classes = namespace_classes
       @is_module = is_module
+      # Answers whether an included module carries a nested `ClassMethods`, over
+      # both the project's own source and the gem RBS collection
+      # (felixefelip/rbs_infer#188).
+      @class_methods_index = class_methods_index
       # Generic type-parameter list ("[unchecked out Elem]") for the leaf
       # declaration when reopening a generic class; "" for the common
       # non-generic case (felixefelip/rbs_infer#38).
@@ -360,27 +365,14 @@ module RbsInfer::Signatures
       signature
     end
 
-    # Verifica se o módulo incluído tem um sub-módulo ClassMethods em .gem_rbs_collection/
+    # Whether the included module carries a nested `ClassMethods` — the shape
+    # that makes `include X` also `extend X::ClassMethods`.
+    #
+    # The module name is written in the INCLUDER's lexical scope (`include
+    # Params` inside `Filter` means `Filter::Params`), so the target class goes
+    # along as the scope to resolve it against.
     def has_class_methods_module?(module_name)
-      parts = module_name.split("::")
-      first = parts.first
-
-      gem_hints = [
-        first.downcase,
-        first.gsub(/([a-z])([A-Z])/, '\1_\2').downcase,
-        first.gsub(/([a-z])([A-Z])/, '\1-\2').downcase,
-      ].uniq
-
-      rbs_files = gem_hints.flat_map { |hint| Dir[".gem_rbs_collection/#{hint}/**/*.rbs"] }.uniq
-      return false if rbs_files.empty?
-
-      rbs_files.each do |file|
-        content = File.read(file)
-        next unless content.include?(parts.last)
-        return true if RbsParserUtil.has_class_methods_submodule?(content, module_name)
-      end
-
-      false
+      @class_methods_index.has?(module_name, enclosing: @target_class)
     end
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/post.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/post.rbs
@@ -1,6 +1,7 @@
 class Post < ApplicationRecord
   extend Enumerize
   include ::Post::Taggable
+  extend ::Post::Taggable::ClassMethods
   include ::Post::Notifiable
   include Test::Filtrable
 

--- a/spec/expectations/models/post.rbs
+++ b/spec/expectations/models/post.rbs
@@ -1,6 +1,7 @@
 class Post < ApplicationRecord
   extend Enumerize
   include ::Post::Taggable
+  extend ::Post::Taggable::ClassMethods
   include ::Post::Notifiable
   include Test::Filtrable
 

--- a/spec/lib/rbs_infer/project/class_methods_index_spec.rb
+++ b/spec/lib/rbs_infer/project/class_methods_index_spec.rb
@@ -1,0 +1,125 @@
+require "spec_helper"
+require "rbs_infer"
+require "tmpdir"
+
+RSpec.describe RbsInfer::Project::ClassMethodsIndex do
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @dir = dir
+      example.run
+    end
+  end
+
+  def write_file(name, content)
+    path = File.join(@dir, name)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+    path
+  end
+
+  def index_for(*files)
+    described_class.new(
+      file_index: RbsInfer::Project::FileIndex.new(files),
+      parse_cache: RbsInfer::Project::ParseCache.new
+    )
+  end
+
+  it "encontra ClassMethods escrito literalmente" do
+    file = write_file("post/taggable.rb", <<~RUBY)
+      module Post::Taggable
+        module ClassMethods
+          def default_tag_names = []
+        end
+      end
+    RUBY
+
+    expect(index_for(file).has?("Post::Taggable", enclosing: "Post")).to eq(true)
+  end
+
+  # The shape the expanders leave behind is what this index matches — the
+  # `class_methods do` DSL itself is never named here.
+  it "encontra ClassMethods desugarado de um bloco class_methods" do
+    file = write_file("post/taggable.rb", <<~RUBY)
+      module Post::Taggable
+        extend ActiveSupport::Concern
+
+        class_methods do
+          def default_tag_names = []
+        end
+      end
+    RUBY
+
+    expect(index_for(file).has?("Post::Taggable", enclosing: "Post")).to eq(true)
+  end
+
+  # The Fizzy shape: `include Params` written inside `class Filter` means
+  # `Filter::Params`, never top-level `Params` (felixefelip/rbs_infer#188).
+  it "resolve o nome do módulo no escopo léxico do includer" do
+    file = write_file("filter/params.rb", <<~RUBY)
+      module Filter::Params
+        class_methods do
+          def find_by_params(params) = nil
+        end
+      end
+    RUBY
+
+    index = index_for(file)
+
+    expect(index.has?("Params", enclosing: "Filter")).to eq(true)
+    expect(index.has?("Params", enclosing: nil)).to eq(false)
+  end
+
+  it "encontra ClassMethods sob namespace aninhado escrito por extenso" do
+    file = write_file("filter/params.rb", <<~RUBY)
+      module Filter
+        module Params
+          module ClassMethods
+            def find_by_params(params) = nil
+          end
+        end
+      end
+    RUBY
+
+    expect(index_for(file).has?("Params", enclosing: "Filter")).to eq(true)
+  end
+
+  it "retorna false para módulo sem ClassMethods" do
+    file = write_file("post/notifiable.rb", <<~RUBY)
+      module Post::Notifiable
+        def notify = nil
+      end
+    RUBY
+
+    expect(index_for(file).has?("Post::Notifiable", enclosing: "Post")).to eq(false)
+  end
+
+  # `extend` takes a module: a class of that name could not be extended, so it
+  # must not produce the mixin.
+  it "retorna false quando ClassMethods é uma classe, não um módulo" do
+    file = write_file("post/taggable.rb", <<~RUBY)
+      module Post::Taggable
+        class ClassMethods
+        end
+      end
+    RUBY
+
+    expect(index_for(file).has?("Post::Taggable", enclosing: "Post")).to eq(false)
+  end
+
+  it "retorna false para módulo que o projeto não declara" do
+    expect(index_for.has?("TotallyFakeModule::DoesNotExist", enclosing: nil)).to eq(false)
+  end
+
+  # A path suffix is not unique, so a file matching by suffix alone must not
+  # answer for a module it does not declare (felixefelip/rbs_infer#185).
+  it "ignora arquivo que casa por sufixo mas declara outro módulo" do
+    file = write_file("other/params.rb", <<~RUBY)
+      module Other::Params
+        module ClassMethods
+        end
+      end
+    RUBY
+
+    expect(index_for(file).has?("Params", enclosing: "Filter")).to eq(false)
+  end
+end

--- a/spec/lib/rbs_infer/signatures/rbs_builder_spec.rb
+++ b/spec/lib/rbs_infer/signatures/rbs_builder_spec.rb
@@ -5,13 +5,18 @@ RSpec.describe RbsInfer::Signatures::RbsBuilder do
   # RbsBuilder's kwargs are all required (see its initialize). This helper
   # supplies test-only defaults so each example states only what it cares
   # about — keeping the production API strict while specs stay terse.
-  def make_builder(target_class:, superclass_name:, namespace_classes: Set.new, is_module: false, type_params: "")
+  def make_builder(target_class:, superclass_name:, namespace_classes: Set.new, is_module: false, type_params: "",
+                   source_files: [])
     described_class.new(
       target_class: target_class,
       superclass_name: superclass_name,
       namespace_classes: namespace_classes,
       is_module: is_module,
-      type_params: type_params
+      type_params: type_params,
+      class_methods_index: RbsInfer::Project::ClassMethodsIndex.new(
+        file_index: RbsInfer::Project::FileIndex.new(source_files),
+        parse_cache: RbsInfer::Project::ParseCache.new
+      )
     )
   end
 


### PR DESCRIPTION
## The bug

`RbsBuilder` emits `extend X::ClassMethods` after an `include X` when `X` carries a nested `ClassMethods` — but it decided that by globbing `.gem_rbs_collection/<gem-hint>/**/*.rbs`. Only a concern shipped by a **gem** ever qualified.

A concern the app itself defines got its `module ClassMethods` generated just fine, and the includer never got the matching `extend`. Every call to those class methods came out as a `Ruby::NoMethod` on the includer's singleton:

```
Type `singleton(::Filter)` does not have method `find_by_params`
```

The numbers from a real app say it plainly:

| | |
|---|---|
| app-local concerns with `class_methods do` | 14 |
| `module ClassMethods` generated for them | 14 |
| `extend ...::ClassMethods` emitted | **3** — all 3 from gems |

`spec/dummy` had the same shape all along: `Post::Taggable` generates its `ClassMethods`, and `spec/expectations/models/post.rbs` showed `include ::Post::Taggable` with no `extend`.

## The fix

The lookup moves out of the RBS printer into `Project::ClassMethodsIndex`, which consults the project's own source as well as the gem collection.

The source side reads the module's file through `SourceExpanders`, so a concern whose class methods are written as `class_methods do` is seen the same way a hand-written `module ClassMethods` is — the index matches the plain nested module the expanders leave behind and never names the DSL, keeping the core framework-agnostic per `docs/engineering/keep-core-framework-agnostic.md`.

Candidates are walked in Ruby's constant-lookup order (`AST::LexicalConstantResolver`), so `include Params` written inside `class Filter` asks about `Filter::Params` before top-level `Params` — the shape that made this bug concrete.

`class_methods_index:` is a **required** kwarg: both production call-sites have one, and an omitted index would answer "no ClassMethods" for every project concern, silently reinstating the bug (`docs/engineering/required-threaded-deps.md`).

## Verification

The generator change, in the dummy:

```diff
 class Post < ApplicationRecord
   extend Enumerize
   include ::Post::Taggable
+  extend ::Post::Taggable::ClassMethods
   include ::Post::Notifiable
```

That it actually resolves the `NoMethod` — a temporary probe calling `Post.default_tag_names` / `Post.known_tag?`, checked both ways:

- **with** the `extend`: clean (only the expected "probe class has no RBS" warning)
- **without** it: `Type `singleton(::Post)` does not have method `default_tag_names`` — the same error shape as the app

- `spec/lib/` — 910 examples, 0 failures (8 new, covering literal `ClassMethods`, the desugared `class_methods do`, lexical resolution, a `class ClassMethods` correctly rejected, and a suffix-matching file that declares a different module)
- `spec/integration/` — 83 examples, 0 failures; the only snapshot change is the one line above
- `steep check` on the dummy — 24 problems before, 24 after, identical set

## Scope

This is the first of two independent blockers on the same expression. `Filter.from_params` is `find_by_params(params) || build(params)`; with this merged the left operand resolves, but the method still infers `untyped` because `||` is not inferred. That's a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)