### PR TITLE
fix: read a call site whose receiver reaches the target through its ancestry

### DIFF
--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -219,7 +219,8 @@ module RbsInfer::Inference
         method_name = node.name.to_s
         if @target_methods.key?(method_name)
           receiver_type = resolve_receiver_type(node.receiver)
-          if receiver_type && (match_class?(receiver_type) || owner_match?(receiver_type, method_name))
+          if receiver_type && (match_class?(receiver_type) || owner_match?(receiver_type, method_name) ||
+                               ancestry_match?(receiver_type, method_name))
             args = extract_cross_class_args(node, @target_methods[method_name])
             @method_call_usages[method_name] << args unless args.empty?
           end
@@ -443,6 +444,42 @@ module RbsInfer::Inference
         normalized = component.sub(/\A::/, "")
         normalized == owner || relative_receiver_matches_target?(normalized, owner)
       end
+    end
+
+    # Does the receiver reach the target's method through its ANCESTRY — a
+    # superclass, or a module it includes — rather than through its name?
+    #
+    # `match_class?` and `owner_match?` above both compare NAMES, which is all the
+    # sources can be asked. A receiver typed as the class that includes the target
+    # module never spells that module, so every such call site was invisible and
+    # the module's parameters stayed `untyped`. Active Record makes this the normal
+    # case rather than the exotic one: it delegates a model's class methods to its
+    # relations and proxies through `<Model>::GeneratedRelationMethods`, so
+    # `user.filters.from_params(filter_params)` — a receiver typed
+    # `User_Filter::ActiveRecord_Associations_CollectionProxy`, two ancestry links
+    # away — is how those methods are actually called, while the only call site the
+    # name-based match accepted was the AR-runtime pseudo-code's own
+    # `::Filter.from_params(params)`, forwarding a parameter still being inferred.
+    # `Filter.from_params` therefore read `(untyped params)` even though every real
+    # caller passes an `ActionController::Parameters & …::Permitted`.
+    #
+    # Asked LAST, and only for a method the target declares: the two name-based
+    # matches are string comparisons, this one consults the RBS environment.
+    #
+    # The RBS is also the only place that knows this — rbs_rails declares the
+    # relation shapes and their `include`s in signatures, never in Ruby, so
+    # `MixinIndex` (built from the sources' `include`s) cannot answer it.
+    def ancestry_match?(receiver_type, method_name)
+      normalized_target = @target_class.sub(/\A::/, "")
+
+      receiver_components(receiver_type).any? do |component|
+        owner = rbs_definition_resolver.instance_method_owner(component, method_name)
+        owner && owner.sub(/\A::/, "") == normalized_target
+      end
+    end
+
+    def rbs_definition_resolver
+      @rbs_definition_resolver ||= RbsInfer::Signatures::RbsDefinitionResolver.new
     end
 
     def relative_receiver_matches_target?(relative_name, target)

--- a/lib/rbs_infer/signatures/rbs_definition_resolver.rb
+++ b/lib/rbs_infer/signatures/rbs_definition_resolver.rb
@@ -9,6 +9,11 @@ module RbsInfer::Signatures
     def initialize
       @rbs_builder = nil
       @rbs_builder_loaded = false
+      # Memo for `instance_method_owner`. Lives beside `@rbs_builder`, which is
+      # fetched once per instance, so the cache can never outlive the environment
+      # it was computed against — the invariant the README states for everything
+      # derived from `SteepEnvironment`.
+      @instance_method_owners = {}
     end
 
     def resolve_via_rbs_builder(kind, class_name, method_name, block_body_type: nil)
@@ -92,6 +97,28 @@ module RbsInfer::Signatures
       nil
     rescue RBS::BaseError
       nil
+    end
+
+    # The class or module an instance method is DEFINED IN for `class_name`, walking
+    # the RBS ancestor chain — superclasses and included modules alike — or nil when
+    # the type has no such method (or isn't in the environment at all).
+    #
+    # This answers "whose method is this receiver calling?" for the case where the
+    # answer is not readable from the receiver's NAME. Active Record is the extreme
+    # example: `user.filters.from_params(...)` has a receiver typed
+    # `User_Filter::ActiveRecord_Associations_CollectionProxy`, and the method it
+    # reaches is defined two links up the chain, in
+    # `Filter::GeneratedRelationMethods` — a per-association subclass of a proxy
+    # that includes the delegating module. Neither link is a name the call site
+    # spells, and both exist only in rbs_rails' RBS, so the mixin graph built from
+    # the Ruby sources cannot see them either.
+    def instance_method_owner(class_name, method_name)
+      return nil unless rbs_builder
+
+      key = [class_name, method_name]
+      return @instance_method_owners[key] if @instance_method_owners.key?(key)
+
+      @instance_method_owners[key] = compute_instance_method_owner(class_name, method_name)
     end
 
     def format_rbs_return_type(rbs_type, context_class = nil)
@@ -190,6 +217,19 @@ module RbsInfer::Signatures
 
     def build_rbs_type_name(class_name)
       RBS::TypeName.parse(class_name).absolute!
+    end
+
+    def compute_instance_method_owner(class_name, method_name)
+      type_name = build_rbs_type_name(class_name)
+      return nil unless type_name
+      # A spelling that is not a class at all (`singleton(Foo)`, an alias) parses
+      # into a name no declaration answers to, which this lookup already rejects.
+      return nil unless rbs_builder.env.class_decls.key?(type_name)
+
+      member = rbs_builder.build_instance(type_name).methods[method_name.to_sym]
+      member&.defined_in&.to_s
+    rescue RBS::BaseError
+      nil
     end
   end
 end

--- a/spec/dummy/app/models/post.rb
+++ b/spec/dummy/app/models/post.rb
@@ -99,6 +99,15 @@ class Post < ApplicationRecord
     tags.default_limit
   end
 
+  # The ARGUMENT direction of that same delegation: the receiver is the has_many
+  # proxy, so `Tag.named`'s parameter is only typed if the proxy's type is
+  # recognized as reaching `Tag::GeneratedRelationMethods#named` through its
+  # ancestry — the name it is spelled with (`Post_Tag::…CollectionProxy`) says
+  # nothing about either link.
+  def tag_named
+    tags.named(title.to_s)
+  end
+
   def sibling_tag_names
     Post.recently_tagged.default_tag_names
   end

--- a/spec/dummy/app/models/tag.rb
+++ b/spec/dummy/app/models/tag.rb
@@ -25,5 +25,15 @@ class Tag < ApplicationRecord
     def default_limit
       10
     end
+
+    # A parameter with NO default, so its type can only come from a call site —
+    # and the only caller (`Post#tag_named`) goes through the has_many proxy, two
+    # ancestry links away from this class. Both halves of the chain are under
+    # test: the proxy's receiver type has to be recognized as reaching
+    # `Tag::GeneratedRelationMethods#named`, and the pseudo-code's
+    # `::Tag.named(value)` then has to carry that type here.
+    def named(value)
+      find_by(name: value)
+    end
   end
 end

--- a/spec/dummy/sig/generated/steep_ar_runtime/tag/generated_relation_methods.rb
+++ b/spec/dummy/sig/generated/steep_ar_runtime/tag/generated_relation_methods.rb
@@ -11,4 +11,8 @@ module Tag::GeneratedRelationMethods
   def default_limit
     ::Tag.default_limit
   end
+
+  def named(value)
+    ::Tag.named(value)
+  end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/post.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/post.rbs
@@ -18,6 +18,7 @@ class Post < ApplicationRecord
   def publish_in_transaction: () -> self
   def popular_tags: (?Integer limit) -> untyped
   def tag_limit: () -> Integer
+  def tag_named: () -> (Tag & Tag::Validated)?
   def sibling_tag_names: () -> Array[String]
   def iterate_tags: () -> Post_Tag::ActiveRecord_Associations_CollectionProxy
   def archive: () -> Post_Comment::ActiveRecord_Associations_CollectionProxy

--- a/spec/dummy/sig/rbs_infer/app/models/tag.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/tag.rbs
@@ -1,4 +1,5 @@
 class Tag < ApplicationRecord
   def self.popular: (?Integer limit) -> untyped
   def self.default_limit: () -> Integer
+  def self.named: (String value) -> (Tag & Tag::Validated)?
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_ar_runtime/tag/generated_relation_methods.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_ar_runtime/tag/generated_relation_methods.rbs
@@ -2,5 +2,6 @@ class Tag
   module GeneratedRelationMethods
     def popular: (?Integer limit) -> untyped
     def default_limit: () -> Integer
+    def named: (String value) -> (Tag & Tag::Validated)?
   end
 end

--- a/spec/dummy/sig/rbs_rails/app/models/user.rbs
+++ b/spec/dummy/sig/rbs_rails/app/models/user.rbs
@@ -324,8 +324,11 @@ class ::User < ::ApplicationRecord
 
     def updated_at_for_database: () -> ::Time?
 
+    def avatar: () -> ::String?
 
+    def avatar=: (::String?) -> ::String?
 
+    def avatar?: () -> bool
 
     def avatar_changed?: (?from: ::String?, ?to: ::String?) -> bool
 

--- a/spec/expectations/models/post.rbs
+++ b/spec/expectations/models/post.rbs
@@ -18,6 +18,7 @@ class Post < ApplicationRecord
   def publish_in_transaction: () -> self
   def popular_tags: (?Integer limit) -> untyped
   def tag_limit: () -> Integer
+  def tag_named: () -> (Tag & Tag::Validated)?
   def sibling_tag_names: () -> Array[String]
   def iterate_tags: () -> Post_Tag::ActiveRecord_Associations_CollectionProxy
   def archive: () -> Post_Comment::ActiveRecord_Associations_CollectionProxy

--- a/spec/expectations/models/tag.rbs
+++ b/spec/expectations/models/tag.rbs
@@ -1,4 +1,5 @@
 class Tag < ApplicationRecord
   def self.popular: (?Integer limit) -> untyped
   def self.default_limit: () -> Integer
+  def self.named: (String value) -> (Tag & Tag::Validated)?
 end

--- a/spec/expectations/steep_ar_runtime/tag/generated_relation_methods.rb
+++ b/spec/expectations/steep_ar_runtime/tag/generated_relation_methods.rb
@@ -11,4 +11,8 @@ module Tag::GeneratedRelationMethods
   def default_limit
     ::Tag.default_limit
   end
+
+  def named(value)
+    ::Tag.named(value)
+  end
 end

--- a/spec/expectations/steep_ar_runtime/tag/generated_relation_methods.rbs
+++ b/spec/expectations/steep_ar_runtime/tag/generated_relation_methods.rbs
@@ -2,5 +2,6 @@ class Tag
   module GeneratedRelationMethods
     def popular: (?Integer limit) -> untyped
     def default_limit: () -> Integer
+    def named: (String value) -> (Tag & Tag::Validated)?
   end
 end


### PR DESCRIPTION
## Sintoma

`Filter.from_params` era gerado como `(untyped params)` mesmo com todo caller passando um tipo conhecido:

```ruby
# app/controllers/concerns/filter_scoped.rb
@filter = Current.user.filters.from_params filter_params   # filter_params: (Parameters & Parameters::Permitted)
```

```rbs
def self.from_params: (untyped params) -> ((Filter & Filter::Validated) | Array[Filter])
```

## Causa

O casamento de receiver em call-sites cross-class (`NewCallCollector#visit_call_node`) só aceitava o call-site quando o **nome do tipo** do receiver era o target — `match_class?` — ou o owner de um método de módulo aninhado — `owner_match?`. Nome é tudo que as fontes sabem responder, então um receiver tipado como a classe que **inclui** o módulo-alvo era rejeitado, e os parâmetros do módulo ficavam `untyped`.

O Active Record faz disso o caso normal, não o exótico: ele delega os métodos de classe do model para relations e proxies via `<Model>::GeneratedRelationMethods`, então toda chamada real acontece num receiver a duas ligações de ancestralidade do módulo — `Current.user.filters` é `User_Filter::ActiveRecord_Associations_CollectionProxy`, uma subclasse por-associação de um proxy que inclui o módulo. Nenhuma das duas ligações é um nome que o call-site escreve, e ambas existem **só no RBS do rbs_rails** — logo o `MixinIndex`, montado a partir dos `include` escritos em Ruby, também não sabe.

O único call-site que casava era o do próprio pseudo-código AR-runtime (`::Filter.from_params(params)`), que repassa um parâmetro ainda em inferência. Daí o `untyped`.

## Fix

Perguntar ao ambiente RBS, que é quem sabe: `RbsDefinitionResolver#instance_method_owner` percorre a cadeia de ancestrais do receiver (superclasses **e** includes, via `DefinitionBuilder#build_instance`) e responde onde o método está definido. Consultado **por último**, depois das duas comparações nominais (que são comparação de string), e só para um método que o target declara — `defined_in` tem que ser exatamente o target, então não há alargamento por aproximação.

Sem `.rb` novo, sem enumerar shapes de relation, sem duplicar a delegação por par (owner × associação).

## Efeito

No Fizzy, o módulo delegante passa a carregar o tipo real:

```rbs
def from_params: (ActionController::Parameters & ActionController::Parameters::Permitted params) -> ((Filter & Filter::Validated) | Array[Filter])
```

e daí o pseudo-código propaga para `Filter.from_params`.

## Fixture

O dummy tranca as duas metades da cadeia: `Tag.named` tem parâmetro **sem default**, então o tipo só pode vir de `Post#tag_named` (chamada no proxy do has_many) chegando a `Tag::GeneratedRelationMethods#named`, cujo pseudo-código então devolve o tipo ao método singleton:

```rbs
# steep_ar_runtime/tag/generated_relation_methods.rbs
def named: (String value) -> (Tag & Tag::Validated)?
# models/tag.rbs
def self.named: (String value) -> (Tag & Tag::Validated)?
```

## Verificação

- `bundle exec rspec` — 1018 examples, 0 failures
- `steep check` no dummy — só os erros do baseline
- Caso real conferido no Fizzy (`rbs_infer` no pseudo-código do relation, sem escrever nada lá)

## Fica de fora (deliberado)

1. **Propagação precisa de duas runs.** Dentro de uma run, o loop de estabilização re-roda o arquivo cuja RBS mudou (o módulo relation), mas não os **dependentes** dele (o model), então `Filter.from_params` só recebe o tipo na run seguinte. É limitação do loop, ortogonal a este fix — vale uma issue própria para re-enfileirar dependentes.
2. **Path singleton.** O análogo com `extend` (método de classe vindo de um `class_methods do`, chamado como `Post.foo(arg)`) tem o mesmo formato de bug e seria `build_singleton`; ficou fora porque o tipo de receiver que chega aqui não distingue instância de classe, e o alargamento indevido seria silencioso. Não é o que o issue relatado precisa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)