### PR TITLE
test: characterize class_eval/module_eval as a reopen

### DIFF
--- a/spec/dummy/app/models/eval_reopen.rb
+++ b/spec/dummy/app/models/eval_reopen.rb
@@ -65,5 +65,7 @@ class EvalReopenCaller
   def fill
     target = EvalReopen.new
     target.slot = "value"
+    target.by_class_eval
+    target.by_module_eval
   end
 end

--- a/spec/dummy/app/models/eval_reopen.rb
+++ b/spec/dummy/app/models/eval_reopen.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# `class_eval` with a CONSTANT receiver is plain Ruby and statically decidable: the
+# `def`s inside the block belong to the receiver, exactly as if the class had been
+# reopened. Neither repo reads it today — rbs_infer drops the methods from the RBS
+# and Steep type-checks them at top level (`UndeclaredMethodDefinition`).
+#
+# It is the shape `ActiveSupport.on_load` is already desugared into
+# (`OnLoadExpander`), and the one a concern's `included do` reduces to once the host
+# is known: Rails `class_eval`s that block on the includer, which is why an override
+# written there can call `super` and one written in the concern's body cannot.
+class EvalReopen
+  include EvalReopen::Slots
+
+  def own
+    "own"
+  end
+end
+
+# `class_eval` is the same operation as reopening the class, only spelled with a
+# receiver — so everything below has to land on `EvalReopen` exactly as if it had
+# been written inside the body above. (A literal second `class EvalReopen` body is
+# deliberately NOT used as the control here: rbs_infer emits the merged members once
+# per reopen, which makes the RBS invalid — see felixefelip/rbs_infer, unrelated to
+# this fixture.)
+EvalReopen.class_eval do
+  def by_class_eval
+    2
+  end
+
+  # The point of the exercise. `super` has to resolve against the RECEIVER's
+  # ancestors (`EvalReopen` -> `EvalReopen::Slots`), not against wherever the block
+  # is written — there is no enclosing class or module here at all. This is exactly
+  # what a store-accessor override inside `included do` needs.
+  def slot
+    super || "default"
+  end
+end
+
+# `module_eval` is an alias of `class_eval`, so a fix that special-cased one name
+# shows up here as a missing `by_module_eval`.
+EvalReopen.module_eval do
+  def by_module_eval
+    :three
+  end
+end
+
+# NOT the same operation: `instance_eval` defines a SINGLETON method, so this is
+# `EvalReopen.by_instance_eval` and never an instance method. Treating every
+# `*_eval` block alike would put it on the wrong side.
+EvalReopen.instance_eval do
+  def by_instance_eval
+    4.0
+  end
+end
+
+# Genuinely undecidable — the body is a string, so no static analysis can read the
+# def. Out of scope (the README's `eval` exclusion), and here so it stays out rather
+# than being half-supported.
+EvalReopen.class_eval "def by_string_eval; 5; end"
+
+# The call site the slot's type comes from: inference reads assignments, not
+# annotations, so a slot nobody writes stays untyped however it is read.
+class EvalReopenCaller
+  def fill
+    target = EvalReopen.new
+    target.slot = "value"
+  end
+end

--- a/spec/dummy/app/models/eval_reopen/slots.rb
+++ b/spec/dummy/app/models/eval_reopen/slots.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# The mixin the `class_eval` block's `super` has to reach. Nothing here is special
+# — the point of the fixture is entirely on the `class_eval` side, where the `def`
+# is written outside any `class`/`module` body and so has no lexical owner at all.
+module EvalReopen::Slots
+  def slot
+    @slot
+  end
+
+  def slot=(value)
+    @slot = value
+  end
+end

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -22,6 +22,11 @@ app/models/concerns/test/filtrable.rb:
     annotations:
     - "# @type self: singleton(Post) & singleton(Test::Filtrable)"
     - "# @type instance: Post & Test::Filtrable"
+app/models/eval_reopen/slots.rb:
+  modules:
+  - anchor: Slots
+    annotations:
+    - "# @type instance: EvalReopen & EvalReopen::Slots"
 app/models/eventable.rb:
   modules:
   - anchor: Eventable

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -272,6 +272,15 @@ postconditions:
     may_write:
     - "@delivery_method"
     - "@from_address"
+- class: EvalReopen::Slots
+  method: slot
+  effects:
+    returns_ivar: "@slot"
+- class: EvalReopen::Slots
+  method: slot=
+  effects:
+    may_write:
+    - "@slot"
 - class: Example10
   method: run
   unconditional:

--- a/spec/dummy/sig/rbs_infer/app/models/eval_reopen.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/eval_reopen.rbs
@@ -1,0 +1,9 @@
+class EvalReopen
+  include ::EvalReopen::Slots
+
+  def own: () -> String
+end
+
+class EvalReopenCaller
+  def fill: () -> String
+end

--- a/spec/dummy/sig/rbs_infer/app/models/eval_reopen/slots.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/eval_reopen/slots.rbs
@@ -1,0 +1,8 @@
+class EvalReopen
+  module Slots
+    @slot: String?
+
+    def slot: () -> String?
+    def slot=: (String? value) -> String?
+  end
+end

--- a/spec/expectations/models/eval_reopen.rbs
+++ b/spec/expectations/models/eval_reopen.rbs
@@ -1,0 +1,5 @@
+class EvalReopen
+  include ::EvalReopen::Slots
+
+  def own: () -> String
+end

--- a/spec/expectations/models/eval_reopen/slots.rbs
+++ b/spec/expectations/models/eval_reopen/slots.rbs
@@ -1,0 +1,8 @@
+class EvalReopen
+  module Slots
+    @slot: String?
+
+    def slot: () -> String?
+    def slot=: (String? value) -> String?
+  end
+end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -1,5 +1,9 @@
 app/models/concerns/test/filtrable.rb:16:13: [error] Type `(::Post & ::Test::Filtrable)` does not have method `adddd`
 app/models/concerns/test/filtrable.rb:16:4: [error] Type `(::Post & ::Test::Filtrable)` does not have method `asdasd`
+app/models/eval_reopen.rb:27:6: [warning] Method `::Object#by_class_eval` is not declared in RBS
+app/models/eval_reopen.rb:35:6: [warning] Method `::Object#slot` is not declared in RBS
+app/models/eval_reopen.rb:43:6: [warning] Method `::Object#by_module_eval` is not declared in RBS
+app/models/eval_reopen.rb:52:6: [warning] Method `::Object#by_instance_eval` is not declared in RBS
 app/models/example14.rb:15:17: [error] Type `(::Example14::User | nil)` does not have method `name`
 app/models/example15.rb:25:25: [error] Type `(::Example15::User | nil)` does not have method `name`
 app/models/example21.rb:105:31: [error] Type `(::Example21::Holder | nil)` does not have method `name`

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -99,6 +99,24 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     assert_snapshot("models/palette", target_class: "Palette", target_file: "app/models/palette.rb")
   end
 
+  # `class_eval` / `module_eval` with a constant receiver: plain Ruby, statically
+  # decidable, and read by NEITHER repo today — the snapshot records the gap. Every
+  # method defined inside the blocks is absent here, and `steep check` attributes
+  # them to `::Object` (four entries in `steep_baseline.txt`).
+  #
+  # `EvalReopen::Slots` next door is fully typed (`slot: () -> String?`), so the
+  # `super` inside the `class_eval` block has a real target waiting for it: this is
+  # the same shape as a store-accessor override in a concern's `included do`, which
+  # Rails implements *as* a `class_eval` on the includer.
+  it "EvalReopen (class_eval reopen) matches expected RBS" do
+    assert_snapshot("models/eval_reopen", target_class: "EvalReopen", target_file: "app/models/eval_reopen.rb")
+  end
+
+  it "EvalReopen::Slots (the class_eval block's super target) matches expected RBS" do
+    assert_snapshot("models/eval_reopen/slots", target_class: "EvalReopen::Slots",
+                    target_file: "app/models/eval_reopen/slots.rb")
+  end
+
   # A namespaced service object called by its BARE name from the model that
   # encloses it (felixefelip/rbs_infer#129). The interesting half is `Post#archive` /
   # `#archive_via_singleton` in the Post snapshot above: `Archiver` there is


### PR DESCRIPTION
`class_eval` with a **constant receiver** is plain Ruby and statically decidable: the `def`s inside the block belong to the receiver, exactly as if the class had been reopened. Neither repo reads it. This PR is the failing fixture only — no behaviour change.

## The gap, on both sides

```rbs
class EvalReopen
  include ::EvalReopen::Slots

  def own: () -> String      # and that is all
end
```

Missing: `by_class_eval`, `by_module_eval`, `slot` (the `super` override), `self.by_instance_eval`. And `steep check` attributes them to `::Object` — four new baseline entries:

```
app/models/eval_reopen.rb:27:6: [warning] Method `::Object#by_class_eval` is not declared in RBS
app/models/eval_reopen.rb:35:6: [warning] Method `::Object#slot` is not declared in RBS
app/models/eval_reopen.rb:43:6: [warning] Method `::Object#by_module_eval` is not declared in RBS
app/models/eval_reopen.rb:52:6: [warning] Method `::Object#by_instance_eval` is not declared in RBS
```

## Why this shape

It is what `ActiveSupport.on_load` is already desugared into by `OnLoadExpander`, and the one a concern's `included do` reduces to once the host is known: **Rails `class_eval`s that block on the includer**. That is why an override written inside `included do` can call `super` and one written in the concern's body cannot — measured on fizzy's `Filter`, where `_store_accessors_module` sits at ancestor position 1, `Filter::Fields` at 2, and moving `column_ids` out of the block makes `Filter.instance_method(:column_ids).owner` the store module (i.e. the override becomes dead code).

`EvalReopen::Slots` is fully typed (`slot: () -> String?`, via the external writer and #195's `RECEIVER_WRITE`), so the `super` inside the `class_eval` block has a real target waiting. When the fix lands, `slot` has to come out `-> String` — the same proof used for `Notification#channel` in #195.

## Also pinned, so a fix cannot over-reach

- `module_eval` is an alias and must behave identically.
- `instance_eval` defines a **singleton** method (`EvalReopen.by_instance_eval`), and must not be conflated with either.
- `class_eval` with a string body stays out — genuinely undecidable, the README's `eval` exclusion.

`bundle exec rspec` — 1035 examples, 0 failures.

## Separate bug found while writing this

The fixture originally had a literal second `class EvalReopen` body as a control, and the emitted RBS came out with the class **duplicated, merged members in each copy**. Isolated to a minimal case — a class reopened twice in ONE file:

```rbs
class ZzTwo
  def a: () -> Integer
  def b: () -> String
end

class ZzTwo          # the same members again
  def a: () -> Integer
  def b: () -> String
end
```

`RBS::DefinitionBuilder#build_instance` raises `RBS::DuplicatedMethodDefinitionError` on that, so it poisons the whole environment rather than one file. Pre-existing, unrelated to `class_eval`, and latent only because no dummy fixture has that shape today. The control reopen was removed from the fixture (a comment stands in its place) to keep the two apart — worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)