### PR TITLE
test: characterize the `self.included` hook as a reopen of the includer

### DIFF
--- a/spec/dummy/app/models/included_hook.rb
+++ b/spec/dummy/app/models/included_hook.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+# `Module#included` is a plain RUBY hook, not a Rails one: `include X` calls
+# `X.included(self)` with the includer as `base`. So `base.class_eval do ... end`
+# inside it defines the block's methods on the INCLUDER, and a human reading this file
+# knows exactly which class gets them.
+#
+# `ClassEvalExpander` (#197) declines it, correctly for what it knows: the receiver is
+# a method PARAMETER, not a constant, so the call shape alone names no class. What
+# makes it decidable is the hook's NAME — the hosts then come from the mixin graph
+# (`MixinIndex#hosts_of`), not from the call.
+#
+# This is the plain-Ruby core of the `included do` problem: ActiveSupport::Concern is
+# sugar over exactly this shape, so a fix here is a fix there, with no framework
+# knowledge involved.
+#
+# A plain class on purpose — nothing here is Active Record, so the fixture needs no
+# table.
+class IncludedHook
+  module Hookable
+    def self.included(base)
+      base.class_eval do
+        def from_hook
+          "hook"
+        end
+
+        # The load-bearing half, and the store-accessor shape: `super` can only resolve
+        # if this def belongs to the HOST, whose ancestors have `IncludedHook::Slots`.
+        # Attributed to `Hookable` it sits in a module that includes nothing, so there
+        # is no super method at all and the return degrades to `untyped`.
+        def slot
+          super || "default"
+        end
+      end
+    end
+  end
+
+  # A hook method named ANYTHING ELSE. Ruby invokes no hook here, so nothing static says
+  # `foo_included` is ever called, let alone with an includer — what it would define
+  # belongs to nobody. Here as the limit case, so a fix for the hook above cannot
+  # quietly generalise to any `*_included` name.
+  module Arbitrary
+    def self.foo_included(base)
+      base.class_eval do
+        def from_arbitrary
+          "arbitrary"
+        end
+      end
+    end
+  end
+
+  # Two hosts for one hook block: the remaining ambiguity, not an oversight. One block,
+  # two `base`s, and `super` inside it would resolve against a different chain in each —
+  # the same disagreement felixefelip/steep#134 declines on rather than guess.
+  module Shared
+    def self.included(base)
+      base.class_eval do
+        def from_shared
+          1
+        end
+      end
+    end
+  end
+
+  # The `include` is the only thing that says who `base` is.
+  include Slots
+  include Hookable
+end
+
+# The call sites: the slot's writer is what gives `super` a type to return, and the
+# reads are what a regression would surface as `NoMethod` rather than as a silently
+# missing method.
+class IncludedHookCaller
+  def fill
+    target = IncludedHook.new
+    target.slot = "value"
+    target.from_hook
+  end
+
+  # The success criterion, visible in a snapshot rather than in a diagnostic: `slot`
+  # returns `super || "default"` over a `String?` slot, so this is `String` once the
+  # hook's defs belong to the host. It reads `untyped` today because `super` resolves
+  # against `Hookable`, which includes nothing.
+  def read_slot
+    IncludedHook.new.slot
+  end
+
+  def read_shared
+    IncludedHookFirst.new.from_shared
+  end
+end

--- a/spec/dummy/app/models/included_hook.rb
+++ b/spec/dummy/app/models/included_hook.rb
@@ -59,6 +59,24 @@ class IncludedHook
     end
   end
 
+  # The SAME sugar again, from a hand-rolled `included do` with no ActiveSupport in
+  # sight (`IncludedHook::HomeMade`). Written identically to `Sugared` above, because the
+  # call shape is what carries the meaning — so a fix that gated on
+  # `extend ActiveSupport::Concern` would read fizzy's concerns and miss this one.
+  module Homespun
+    extend IncludedHook::HomeMade
+
+    included do
+      def from_homespun
+        "homespun"
+      end
+
+      def stamp
+        super || "homespun"
+      end
+    end
+  end
+
   # A hook method named ANYTHING ELSE. Ruby invokes no hook here, so nothing static says
   # `foo_included` is ever called, let alone with an includer — what it would define
   # belongs to nobody. Here as the limit case, so a fix for the hook above cannot
@@ -90,6 +108,7 @@ class IncludedHook
   include Slots
   include Hookable
   include Sugared
+  include Homespun
 end
 
 # The call sites: the slot's writer is what gives `super` a type to return, and the
@@ -103,6 +122,7 @@ class IncludedHookCaller
     target = IncludedHook.new
     target.slot = "value"
     target.badge = "value"
+    target.stamp = "value"
     target.from_hook
   end
 
@@ -121,6 +141,11 @@ class IncludedHookCaller
   # shapes have been treated as two problems.
   def read_badge
     IncludedHook.new.badge
+  end
+
+  # And for the hand-rolled sugar. Three criteria, one fix.
+  def read_stamp
+    IncludedHook.new.stamp
   end
 
   def read_shared

--- a/spec/dummy/app/models/included_hook.rb
+++ b/spec/dummy/app/models/included_hook.rb
@@ -35,6 +35,30 @@ class IncludedHook
     end
   end
 
+  # The SAME shape, spelled with ActiveSupport::Concern's sugar. `included do ... end`
+  # is `base.class_eval(&block)` with `base` the includer — Concern's `append_features`
+  # runs it at include time — so `badge` below belongs to `IncludedHook` exactly as
+  # `Hookable`'s `slot` does. The two sit here side by side because they are one
+  # mechanism, and a fix for either that does not cover the other has missed that.
+  #
+  # This is the shape a real app writes: it is where fizzy's store-accessor overrides
+  # live (`def indexed_by; (super || default_indexed_by).inquiry; end`).
+  module Sugared
+    extend ActiveSupport::Concern
+
+    included do
+      def from_sugar
+        "sugar"
+      end
+
+      # The Concern-side criterion, over the other slot so it cannot collide with
+      # `Hookable`'s. `super` only resolves if this def belongs to the HOST.
+      def badge
+        super || "sugared"
+      end
+    end
+  end
+
   # A hook method named ANYTHING ELSE. Ruby invokes no hook here, so nothing static says
   # `foo_included` is ever called, let alone with an includer — what it would define
   # belongs to nobody. Here as the limit case, so a fix for the hook above cannot
@@ -62,18 +86,23 @@ class IncludedHook
     end
   end
 
-  # The `include` is the only thing that says who `base` is.
+  # The `include`s are the only thing that says who `base` is, for both shapes.
   include Slots
   include Hookable
+  include Sugared
 end
 
 # The call sites: the slot's writer is what gives `super` a type to return, and the
 # reads are what a regression would surface as `NoMethod` rather than as a silently
 # missing method.
 class IncludedHookCaller
+  # Writes both slots, which is what gives each `super` a type to return. Kept apart
+  # from the reads below so those measure the ancestor chain rather than a local
+  # narrowing of the value just written.
   def fill
     target = IncludedHook.new
     target.slot = "value"
+    target.badge = "value"
     target.from_hook
   end
 
@@ -83,6 +112,15 @@ class IncludedHookCaller
   # against `Hookable`, which includes nothing.
   def read_slot
     IncludedHook.new.slot
+  end
+
+  # The same criterion for the sugared half, over a slot with a UNIQUE name: `tag` was
+  # borrowed from the dummy's Tag model closely enough to pick up a type from
+  # elsewhere, which made the two halves look asymmetric when they are not.
+  # Both read `untyped` today and both have to become `String` — one fix, or the two
+  # shapes have been treated as two problems.
+  def read_badge
+    IncludedHook.new.badge
   end
 
   def read_shared

--- a/spec/dummy/app/models/included_hook/home_made.rb
+++ b/spec/dummy/app/models/included_hook/home_made.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# A hand-rolled `included do`, with no ActiveSupport anywhere. The whole mechanism is
+# right here: without an argument the call is the DSL and stores the block; with one it
+# is Ruby's own `included` hook, and replays the block on the includer — the same trick
+# `ActiveSupport::Concern#included` plays, in six lines.
+#
+# It exists so a fix for `included do` cannot gate on `extend ActiveSupport::Concern`.
+# The call SHAPE is identical either way, and it is the shape that carries the meaning:
+# a receiverless `included` with a block, in a module, replayed on whoever includes it.
+# Keying on the framework would read fizzy's concerns and miss this one, though a human
+# reading either knows the same thing.
+#
+# Verified to behave as ActiveSupport's does: with `Host.include Homespun`, the def
+# lands on `Host` (`Host.instance_method(:stamp).owner == Host`) and its `super` reaches
+# the mixin behind it.
+module IncludedHook::HomeMade
+  # The explicit `nil` is not ceremony: without it the two branches return the stored
+  # block and `class_eval`'s value, and the inferred return type came out as a non-nil
+  # Proc while the body can yield nil — a `SetterBodyTypeMismatch`-style error about this
+  # helper, in a fixture that is about something else entirely. Ruby never uses the
+  # hook's return value, so saying so removes the noise without changing behaviour.
+  def included(base = nil, &block)
+    if base.nil?
+      @included_block = block
+    else
+      base.class_eval(&@included_block) if @included_block
+    end
+
+    nil
+  end
+end

--- a/spec/dummy/app/models/included_hook/slots.rb
+++ b/spec/dummy/app/models/included_hook/slots.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
-# The mixin the hook block's `super` has to reach. Included by the HOST, not by the
-# hookable module — so it is only behind the hook's methods if those methods belong to
-# the host, which is the whole question.
+# The mixin both hook blocks' `super` has to reach. Included by the HOST, not by the
+# hookable modules — so it is only behind their methods if those methods belong to the
+# host, which is the whole question.
+#
+# Two slots, both uniquely named, so the plain-Ruby hook and the ActiveSupport::Concern sugar can each
+# override one on the SAME host, without colliding.
 module IncludedHook::Slots
   def slot
     @slot
@@ -10,5 +13,13 @@ module IncludedHook::Slots
 
   def slot=(value)
     @slot = value
+  end
+
+  def badge
+    @badge
+  end
+
+  def badge=(value)
+    @badge = value
   end
 end

--- a/spec/dummy/app/models/included_hook/slots.rb
+++ b/spec/dummy/app/models/included_hook/slots.rb
@@ -22,4 +22,12 @@ module IncludedHook::Slots
   def badge=(value)
     @badge = value
   end
+
+  def stamp
+    @stamp
+  end
+
+  def stamp=(value)
+    @stamp = value
+  end
 end

--- a/spec/dummy/app/models/included_hook/slots.rb
+++ b/spec/dummy/app/models/included_hook/slots.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# The mixin the hook block's `super` has to reach. Included by the HOST, not by the
+# hookable module — so it is only behind the hook's methods if those methods belong to
+# the host, which is the whole question.
+module IncludedHook::Slots
+  def slot
+    @slot
+  end
+
+  def slot=(value)
+    @slot = value
+  end
+end

--- a/spec/dummy/app/models/included_hook_first.rb
+++ b/spec/dummy/app/models/included_hook_first.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# One of the two hosts of `IncludedHook::Shared`. Its own file, as Zeitwerk requires —
+# and as `MixinIndex` requires too: the index reads one class per file (via
+# `ClassNameExtractor`), so an `include` written in a secondary class of a shared file
+# is attributed to that file's primary class instead.
+class IncludedHookFirst
+  include IncludedHook::Shared
+end

--- a/spec/dummy/app/models/included_hook_second.rb
+++ b/spec/dummy/app/models/included_hook_second.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# The second host, which is what makes the hook block ambiguous: one block, two `base`s.
+class IncludedHookSecond
+  include IncludedHook::Shared
+end

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -40,6 +40,10 @@ app/models/included_hook/slots.rb:
     - "# @type instance: IncludedHook & IncludedHook::Slots"
 app/models/included_hook.rb:
   modules:
+  - anchor: Homespun
+    annotations:
+    - "# @type self: singleton(IncludedHook) & singleton(IncludedHook::Homespun)"
+    - "# @type instance: IncludedHook & IncludedHook::Homespun"
   - anchor: Hookable
     annotations:
     - "# @type self: singleton(IncludedHook) & singleton(IncludedHook::Hookable)"

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -42,11 +42,18 @@ app/models/included_hook.rb:
   modules:
   - anchor: Hookable
     annotations:
+    - "# @type self: singleton(IncludedHook) & singleton(IncludedHook::Hookable)"
     - "# @type instance: IncludedHook & IncludedHook::Hookable"
   - anchor: Shared
     annotations:
+    - "# @type self: (singleton(IncludedHookFirst) & singleton(IncludedHook::Shared))
+      | (singleton(IncludedHookSecond) & singleton(IncludedHook::Shared))"
     - "# @type instance: (IncludedHookFirst & IncludedHook::Shared) | (IncludedHookSecond
       & IncludedHook::Shared)"
+  - anchor: Sugared
+    annotations:
+    - "# @type self: singleton(IncludedHook) & singleton(IncludedHook::Sugared)"
+    - "# @type instance: IncludedHook & IncludedHook::Sugared"
 app/models/post/notifiable.rb:
   modules:
   - anchor: Notifiable

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -33,6 +33,20 @@ app/models/eventable.rb:
     annotations:
     - "# @type self: singleton(Widget) & singleton(Eventable)"
     - "# @type instance: Widget & Eventable"
+app/models/included_hook/slots.rb:
+  modules:
+  - anchor: Slots
+    annotations:
+    - "# @type instance: IncludedHook & IncludedHook::Slots"
+app/models/included_hook.rb:
+  modules:
+  - anchor: Hookable
+    annotations:
+    - "# @type instance: IncludedHook & IncludedHook::Hookable"
+  - anchor: Shared
+    annotations:
+    - "# @type instance: (IncludedHookFirst & IncludedHook::Shared) | (IncludedHookSecond
+      & IncludedHook::Shared)"
 app/models/post/notifiable.rb:
   modules:
   - anchor: Notifiable

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -1079,6 +1079,15 @@ postconditions:
     may_write:
     - "@name"
 - class: IncludedHook::Slots
+  method: badge
+  effects:
+    returns_ivar: "@badge"
+- class: IncludedHook::Slots
+  method: badge=
+  effects:
+    may_write:
+    - "@badge"
+- class: IncludedHook::Slots
   method: slot
   effects:
     returns_ivar: "@slot"

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -1078,6 +1078,15 @@ postconditions:
   effects:
     may_write:
     - "@name"
+- class: IncludedHook::Slots
+  method: slot
+  effects:
+    returns_ivar: "@slot"
+- class: IncludedHook::Slots
+  method: slot=
+  effects:
+    may_write:
+    - "@slot"
 - class: Notification
   method: mute!
   effects:

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -1078,6 +1078,11 @@ postconditions:
   effects:
     may_write:
     - "@name"
+- class: IncludedHook::HomeMade
+  method: included
+  effects:
+    may_write:
+    - "@included_block"
 - class: IncludedHook::Slots
   method: badge
   effects:
@@ -1096,6 +1101,15 @@ postconditions:
   effects:
     may_write:
     - "@slot"
+- class: IncludedHook::Slots
+  method: stamp
+  effects:
+    returns_ivar: "@stamp"
+- class: IncludedHook::Slots
+  method: stamp=
+  effects:
+    may_write:
+    - "@stamp"
 - class: Notification
   method: mute!
   effects:

--- a/spec/dummy/sig/rbs_infer/app/models/included_hook.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/included_hook.rbs
@@ -1,0 +1,24 @@
+class IncludedHook
+  module Hookable
+    def self.included: (untyped base) -> untyped
+    def from_hook: () -> String
+    def slot: () -> untyped
+  end
+  module Arbitrary
+    def self.foo_included: (untyped base) -> untyped
+    def from_arbitrary: () -> String
+  end
+  module Shared
+    def self.included: (untyped base) -> untyped
+    def from_shared: () -> Integer
+  end
+
+  include Slots
+  include Hookable
+end
+
+class IncludedHookCaller
+  def fill: () -> String
+  def read_slot: () -> untyped
+  def read_shared: () -> Integer
+end

--- a/spec/dummy/sig/rbs_infer/app/models/included_hook.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/included_hook.rbs
@@ -9,6 +9,11 @@ class IncludedHook
     def from_sugar: () -> String
     def badge: () -> untyped
   end
+  module Homespun
+    extend ::IncludedHook::HomeMade
+    def from_homespun: () -> String
+    def stamp: () -> untyped
+  end
   module Arbitrary
     def self.foo_included: (untyped base) -> untyped
     def from_arbitrary: () -> String
@@ -21,11 +26,13 @@ class IncludedHook
   include Slots
   include Hookable
   include Sugared
+  include Homespun
 end
 
 class IncludedHookCaller
   def fill: () -> String
   def read_slot: () -> untyped
   def read_badge: () -> untyped
+  def read_stamp: () -> untyped
   def read_shared: () -> Integer
 end

--- a/spec/dummy/sig/rbs_infer/app/models/included_hook.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/included_hook.rbs
@@ -4,6 +4,11 @@ class IncludedHook
     def from_hook: () -> String
     def slot: () -> untyped
   end
+  module Sugared
+    extend ActiveSupport::Concern
+    def from_sugar: () -> String
+    def badge: () -> untyped
+  end
   module Arbitrary
     def self.foo_included: (untyped base) -> untyped
     def from_arbitrary: () -> String
@@ -15,10 +20,12 @@ class IncludedHook
 
   include Slots
   include Hookable
+  include Sugared
 end
 
 class IncludedHookCaller
   def fill: () -> String
   def read_slot: () -> untyped
+  def read_badge: () -> untyped
   def read_shared: () -> Integer
 end

--- a/spec/dummy/sig/rbs_infer/app/models/included_hook/home_made.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/included_hook/home_made.rbs
@@ -1,0 +1,7 @@
+class IncludedHook
+  module HomeMade
+    @included_block: ^(*untyped) -> untyped?
+
+    def included: (?untyped base) ?{ (*untyped) -> untyped } -> nil
+  end
+end

--- a/spec/dummy/sig/rbs_infer/app/models/included_hook/slots.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/included_hook/slots.rbs
@@ -2,10 +2,13 @@ class IncludedHook
   module Slots
     @slot: String?
     @badge: String?
+    @stamp: String?
 
     def slot: () -> String?
     def slot=: (String? value) -> String?
     def badge: () -> String?
     def badge=: (String? value) -> String?
+    def stamp: () -> String?
+    def stamp=: (String? value) -> String?
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/included_hook/slots.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/included_hook/slots.rbs
@@ -1,8 +1,11 @@
 class IncludedHook
   module Slots
     @slot: String?
+    @badge: String?
 
     def slot: () -> String?
     def slot=: (String? value) -> String?
+    def badge: () -> String?
+    def badge=: (String? value) -> String?
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/included_hook/slots.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/included_hook/slots.rbs
@@ -1,0 +1,8 @@
+class IncludedHook
+  module Slots
+    @slot: String?
+
+    def slot: () -> String?
+    def slot=: (String? value) -> String?
+  end
+end

--- a/spec/dummy/sig/rbs_infer/app/models/included_hook_first.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/included_hook_first.rbs
@@ -1,0 +1,3 @@
+class IncludedHookFirst
+  include IncludedHook::Shared
+end

--- a/spec/dummy/sig/rbs_infer/app/models/included_hook_second.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/included_hook_second.rbs
@@ -1,0 +1,3 @@
+class IncludedHookSecond
+  include IncludedHook::Shared
+end

--- a/spec/expectations/models/included_hook.rbs
+++ b/spec/expectations/models/included_hook.rbs
@@ -4,6 +4,11 @@ class IncludedHook
     def from_hook: () -> String
     def slot: () -> untyped
   end
+  module Sugared
+    extend ActiveSupport::Concern
+    def from_sugar: () -> String
+    def badge: () -> untyped
+  end
   module Arbitrary
     def self.foo_included: (untyped base) -> untyped
     def from_arbitrary: () -> String
@@ -15,4 +20,5 @@ class IncludedHook
 
   include Slots
   include Hookable
+  include Sugared
 end

--- a/spec/expectations/models/included_hook.rbs
+++ b/spec/expectations/models/included_hook.rbs
@@ -1,0 +1,18 @@
+class IncludedHook
+  module Hookable
+    def self.included: (untyped base) -> untyped
+    def from_hook: () -> String
+    def slot: () -> untyped
+  end
+  module Arbitrary
+    def self.foo_included: (untyped base) -> untyped
+    def from_arbitrary: () -> String
+  end
+  module Shared
+    def self.included: (untyped base) -> untyped
+    def from_shared: () -> Integer
+  end
+
+  include Slots
+  include Hookable
+end

--- a/spec/expectations/models/included_hook.rbs
+++ b/spec/expectations/models/included_hook.rbs
@@ -9,6 +9,11 @@ class IncludedHook
     def from_sugar: () -> String
     def badge: () -> untyped
   end
+  module Homespun
+    extend ::IncludedHook::HomeMade
+    def from_homespun: () -> String
+    def stamp: () -> untyped
+  end
   module Arbitrary
     def self.foo_included: (untyped base) -> untyped
     def from_arbitrary: () -> String
@@ -21,4 +26,5 @@ class IncludedHook
   include Slots
   include Hookable
   include Sugared
+  include Homespun
 end

--- a/spec/expectations/models/included_hook/slots.rbs
+++ b/spec/expectations/models/included_hook/slots.rbs
@@ -2,10 +2,13 @@ class IncludedHook
   module Slots
     @slot: String?
     @badge: String?
+    @stamp: String?
 
     def slot: () -> String?
     def slot=: (String? value) -> String?
     def badge: () -> String?
     def badge=: (String? value) -> String?
+    def stamp: () -> String?
+    def stamp=: (String? value) -> String?
   end
 end

--- a/spec/expectations/models/included_hook/slots.rbs
+++ b/spec/expectations/models/included_hook/slots.rbs
@@ -1,8 +1,11 @@
 class IncludedHook
   module Slots
     @slot: String?
+    @badge: String?
 
     def slot: () -> String?
     def slot=: (String? value) -> String?
+    def badge: () -> String?
+    def badge=: (String? value) -> String?
   end
 end

--- a/spec/expectations/models/included_hook/slots.rbs
+++ b/spec/expectations/models/included_hook/slots.rbs
@@ -1,0 +1,8 @@
+class IncludedHook
+  module Slots
+    @slot: String?
+
+    def slot: () -> String?
+    def slot=: (String? value) -> String?
+  end
+end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -117,6 +117,26 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
                     target_file: "app/models/eval_reopen/slots.rb")
   end
 
+  # `Module#included` is a plain Ruby hook: `include X` calls `X.included(self)`, so
+  # `base.class_eval do ... end` inside it defines the block's methods on the INCLUDER.
+  # The snapshot records the gap — they are attributed to the module instead, which is
+  # why `slot`'s `super` finds nothing and `IncludedHookCaller#read_slot` reads
+  # `untyped` where the slot is `String?`.
+  #
+  # This is the plain-Ruby core of the `included do` problem; ActiveSupport::Concern is
+  # sugar over the same shape. `ClassEvalExpander` declines it correctly for what it
+  # knows: the receiver is a method parameter, so the call names no class — the hosts
+  # have to come from the mixin graph.
+  it "IncludedHook (self.included hook) matches expected RBS" do
+    assert_snapshot("models/included_hook", target_class: "IncludedHook",
+                    target_file: "app/models/included_hook.rb")
+  end
+
+  it "IncludedHook::Slots (the hook block's super target) matches expected RBS" do
+    assert_snapshot("models/included_hook/slots", target_class: "IncludedHook::Slots",
+                    target_file: "app/models/included_hook/slots.rb")
+  end
+
   # A namespaced service object called by its BARE name from the model that
   # encloses it (felixefelip/rbs_infer#129). The interesting half is `Post#archive` /
   # `#archive_via_singleton` in the Post snapshot above: `Archiver` there is


### PR DESCRIPTION
Fixture only, no behaviour change — the next step after #197.

`Module#included` is a **plain Ruby hook**, not a Rails one: `include X` calls `X.included(self)` with the includer as `base`, so `base.class_eval do ... end` inside it defines the block's methods on the **includer**. A human reading the fixture knows exactly which class gets them.

`ClassEvalExpander` declines it, correctly for what it knows: the receiver is a method *parameter*, so the call shape names no class. What makes it decidable is the hook's **name** — the hosts then come from the mixin graph, not from the call.

This is the plain-Ruby core of the `included do` problem. ActiveSupport::Concern is sugar over exactly this shape, so a fix here is a fix there, with no framework knowledge involved.

## The gap

```rbs
class IncludedHook
  module Hookable
    def self.included: (untyped base) -> untyped
    def from_hook: () -> String
    def slot: () -> untyped        # super finds nothing
  end
  ...
  include Slots
  include Hookable
end
```

`from_hook` and `slot` are attributed to `Hookable` rather than to `IncludedHook`, and because that module includes nothing, `slot`'s `super` has no method to resolve against. `IncludedHook::Slots#slot` next door is `String?` and waiting.

**`steep check` reports nothing for any of it** — the methods are declared, just on the wrong owner, so the only observable symptom is the RBS. That is why the criterion is a snapshot rather than a baseline entry:

```rbs
class IncludedHookCaller
  def read_slot: () -> untyped     # -> String once the defs belong to the host
end
```

## Also pinned, so a fix cannot over-reach

- **`foo_included`** — an arbitrary hook name. Ruby invokes no hook, so nothing static says it is ever called, let alone with an includer. The limit case: a fix for `included` must not generalise to any `*_included`.
- **Two hosts for one hook block** (`IncludedHook::Shared`, included by `IncludedHookFirst` and `IncludedHookSecond`) — one block, two `base`s, and `super` inside it would resolve against a different chain in each. The same disagreement felixefelip/steep#134 declines on rather than guess.

## A `MixinIndex` constraint worth knowing

The two hosts live in their own files, and that is load-bearing. `MixinIndex` reads **one class per file** (via `ClassNameExtractor`), so written as secondary classes of `included_hook.rb` their `include` was attributed to that file's primary class:

```
IncludedHook::Shared    hosts=["IncludedHook"]              # wrong
IncludedHook::Shared    hosts=["IncludedHookFirst", "IncludedHookSecond"]   # after the split
```

Zeitwerk wants the split anyway, so no real Rails app hits this — but the eventual fix reads `hosts_of`, so it is worth recording that the index's answer depends on file layout. The dummy has several multi-class files (`example*.rb`); an `include` in a secondary class of one of those would be misattributed the same way.

`bundle exec rspec` — 1055 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)