### PR TITLE
feat: `# @rbs_infer |...` emits RBS's overloading form

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -189,6 +189,7 @@ module RbsInfer
   def build_single_target_rbs
     # Parsear o arquivo-alvo para extrair todos os membros da classe
     target_members = parse_target_class
+    confirm_overloading!(target_members)
     resolve_delegate_methods(target_members)
 
     # Extrair classes da anotação @type instance (para concerns)
@@ -770,6 +771,34 @@ module RbsInfer
 
       owners[member.name] ||= "#{@target_class}::#{member.owner}"
     end
+  end
+
+  # `# @rbs_infer |...` above a def asks for RBS's overloading form (`... | ...`), which
+  # puts our signature AHEAD of one something else already declares instead of colliding
+  # with it. The marker states intent; this confirms it, because `| ...` with nothing to
+  # overload is an `InvalidOverloadMethodError` — the same class of hard failure, poisoning
+  # the whole environment, that it exists to avoid. A marker on a method nobody else
+  # declares silently emits the plain form rather than breaking the run.
+  #
+  # Our own previous output is excluded: it already declares the method, and confirming
+  # against it would be circular — a method only we declare would gain `| ...` and then
+  # have nothing left to overload.
+  def confirm_overloading!(members)
+    marked = members.select(&:overloading)
+    return if marked.empty?
+
+    own_output_suffix = @target_file&.sub(/\.rb\z/, ".rbs")
+
+    marked.each do |member|
+      confirmed = rbs_definition_resolver.foreign_plain_declaration?(
+        @target_class, member.name, excluding_suffix: own_output_suffix
+      )
+      member.overloading = false unless confirmed
+    end
+  end
+
+  def rbs_definition_resolver
+    @rbs_definition_resolver ||= RbsInfer::Signatures::RbsDefinitionResolver.new
   end
 
   # ─── Extrair nomes dos keyword params opcionais do initialize ─────

--- a/lib/rbs_infer/inference/class_member_collector.rb
+++ b/lib/rbs_infer/inference/class_member_collector.rb
@@ -22,7 +22,7 @@ module RbsInfer::Inference
   # `block_open_forward` = o corpo só repassa o bloco (`foo(&block)`), sem
   # chamá-lo nem testá-lo, então quem decide se ele é obrigatório é o callee —
   # também resolvido no Analyzer (#149).
-  Member = Struct.new(:kind, :name, :signature, :visibility, :owner, :value_node, :param_constant_defaults, :old_name, :singleton, :block_arg_positions, :block_open_forward, keyword_init: true)
+  Member = Struct.new(:kind, :name, :signature, :visibility, :owner, :value_node, :param_constant_defaults, :old_name, :singleton, :block_arg_positions, :block_open_forward, :overloading, keyword_init: true)
 
   # Metadata extraída de uma chamada `delegate` — tipos são resolvidos depois no Analyzer
   DelegateInfo = Struct.new(:methods, :target, :prefix, :allow_nil, keyword_init: true)
@@ -122,6 +122,7 @@ module RbsInfer::Inference
       is_class_method = class_method_def?(node)
       name = node.name.to_s
       sig = find_rbs_signature(@comments, @lines, node.location.start_line)
+      overloading = find_overloading_marker(@comments, @lines, node.location.start_line)
 
       extractor = ExtractParamsSignature.new(node.parameters, body: node.body)
       params_sig = extractor.call
@@ -147,7 +148,8 @@ module RbsInfer::Inference
         # annotation is authoritative and must not be overridden.
         param_constant_defaults: sig ? nil : extractor.constant_default_params,
         block_arg_positions: sig ? nil : extractor.block_arg_positions,
-        block_open_forward: sig ? nil : extractor.block_open_forward?
+        block_open_forward: sig ? nil : extractor.block_open_forward?,
+        overloading: overloading
       )
       super
     end
@@ -461,6 +463,37 @@ module RbsInfer::Inference
         end
       end
       nil
+    end
+
+    # `# @rbs_infer |...` on its own line above a `def`: emit the signature as an
+    # RBS *overloading* member (`def x: (...) -> T | ...`) rather than a plain one.
+    #
+    # It is what lets pseudo-code give a body to a method something else already
+    # declares. Two declarations of one method in a class is a
+    # `DuplicatedMethodDefinitionError` — which does not degrade, it poisons the whole
+    # environment — while the overloading form adds the signature AHEAD of the existing
+    # ones instead. Reopening `Module#include` to say what `include` does is the case
+    # that needs it; `RBS::Environment` refuses the plain form outright.
+    #
+    # The marker states INTENT and is not trusted on its own: `| ...` requires a prior
+    # definition, so claiming it where there is none is `InvalidOverloadMethodError`,
+    # the same class of hard failure it exists to avoid. The analyzer confirms against
+    # the environment before emitting (see `Analyzer#confirm_overloading!`).
+    def find_overloading_marker(comments, lines, def_line)
+      comments.any? do |comment|
+        comment_line = comment.location.start_line
+        next false unless comment_line.between?(def_line - 3, def_line - 1)
+        next false unless lines_between_are_blank_or_comments(lines, comment_line, def_line)
+
+        source_line = lines[comment_line - 1]
+        if source_line
+          code_before = source_line[0...comment.location.start_column].strip
+          next false unless code_before.empty?
+        end
+
+        # `|...`, `| ...` and a trailing `...` alone all read as the same request.
+        comment.location.slice.match?(/@rbs_infer\s+\|?\s*\.\.\./)
+      end
     end
 
     def infer_return_type(defn)

--- a/lib/rbs_infer/signatures/rbs_builder.rb
+++ b/lib/rbs_infer/signatures/rbs_builder.rb
@@ -251,7 +251,13 @@ module RbsInfer::Signatures
         elsif method_param_types[member.name]
           sig = apply_inferred_param_types(sig, method_param_types[member.name])
         end
-        "#{indent}def #{RbsInfer::Signatures::RbsParserUtil.parenthesize_return_type(sig)}"
+        rendered = RbsInfer::Signatures::RbsParserUtil.parenthesize_return_type(sig)
+        # RBS's *overloading* form: this signature goes AHEAD of the ones something else
+        # already declares for the same method, instead of colliding with them. Requested
+        # by `# @rbs_infer |...` above the def and confirmed against the environment
+        # before it gets here — see `ClassMemberCollector#find_overloading_marker`.
+        rendered = "#{rendered} | ..." if member.overloading
+        "#{indent}def #{rendered}"
       when :attr_accessor, :attr_reader, :attr_writer
         sig = member.signature
         sig = "#{member.name}: #{attr_types[member.name]}" if sig.end_with?(": untyped") && attr_types[member.name]

--- a/lib/rbs_infer/signatures/rbs_definition_resolver.rb
+++ b/lib/rbs_infer/signatures/rbs_definition_resolver.rb
@@ -112,6 +112,42 @@ module RbsInfer::Signatures
     # that includes the delegating module. Neither link is a name the call site
     # spells, and both exist only in rbs_rails' RBS, so the mixin graph built from
     # the Ruby sources cannot see them either.
+    # Does some OTHER file already declare `class_name#method_name` as a plain
+    # (non-overloading) member? That is the precondition for emitting the overloading
+    # form: `| ...` with nothing to overload is `InvalidOverloadMethodError`, and two
+    # plain declarations are `DuplicatedMethodDefinitionError` — both of which poison the
+    # whole environment rather than degrading.
+    #
+    # `excluding_suffix` drops the declaration WE are about to rewrite. Our own previous
+    # output already declares the method, and confirming against it would be circular: a
+    # method only we declare would gain `| ...` and then have nothing left to overload.
+    # The suffix is `<source path>.rbs`, which is stable whatever `--output-dir` is.
+    #
+    # Only the same class counts. An ancestor's declaration is inheritance, which RBS
+    # models as ordinary overriding and never rejects.
+    def foreign_plain_declaration?(class_name, method_name, excluding_suffix: nil)
+      return false unless rbs_builder
+
+      type_name = build_rbs_type_name(class_name)
+      return false unless type_name
+
+      entry = rbs_builder.env.class_decls[type_name]
+      return false unless entry
+
+      entry.each_decl.any? do |decl|
+        path = decl.location&.buffer&.name.to_s
+        next false if excluding_suffix && path.end_with?(excluding_suffix)
+
+        decl.members.any? do |member|
+          member.is_a?(RBS::AST::Members::MethodDefinition) &&
+            member.name.to_s == method_name.to_s &&
+            !member.overloading?
+        end
+      end
+    rescue RBS::BaseError
+      false
+    end
+
     def instance_method_owner(class_name, method_name)
       return nil unless rbs_builder
 

--- a/spec/lib/rbs_infer/signatures/overloading_marker_spec.rb
+++ b/spec/lib/rbs_infer/signatures/overloading_marker_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rbs_infer"
+require "tmpdir"
+
+# `# @rbs_infer |...` above a def emits RBS's *overloading* form, putting the signature
+# AHEAD of one something else already declares instead of colliding with it. Two plain
+# declarations of one method in a class is a `DuplicatedMethodDefinitionError`, and `| ...`
+# with nothing to overload is an `InvalidOverloadMethodError` — both poison the whole
+# environment rather than degrading, which is why the marker is confirmed and not trusted.
+RSpec.describe "the `# @rbs_infer |...` overloading marker" do
+  around do |example|
+    Dir.mktmpdir { |dir| @dir = dir; example.run }
+  end
+
+  def rbs_for(class_name, source)
+    path = File.join(@dir, "probe.rb")
+    File.write(path, source)
+    RbsInfer::Analyzer.new(target_class: class_name, target_file: path, source_files: [path]).generate_rbs
+  end
+
+  it "emits the overloading form for a method the environment already declares" do
+    rbs = rbs_for("Module", <<~RUBY)
+      class Module
+        # @rbs_infer |...
+        def include(*mods)
+          self
+        end
+      end
+    RUBY
+
+    expect(rbs).to include("def include: (*untyped) -> self | ...")
+  end
+
+  # The marker states intent; claiming it where there is nothing to overload would be a
+  # hard failure, so it degrades to the plain form instead.
+  it "ignores the marker when nothing else declares the method" do
+    rbs = rbs_for("ZzLoneProbe", <<~RUBY)
+      class ZzLoneProbe
+        # @rbs_infer |...
+        def only_here(x)
+          x.to_s
+        end
+      end
+    RUBY
+
+    expect(rbs).to include("def only_here: (untyped x) -> untyped")
+    expect(rbs).not_to include("| ...")
+  end
+
+  it "leaves an unmarked method alone even when the environment declares it" do
+    rbs = rbs_for("Module", <<~RUBY)
+      class Module
+        def include(*mods)
+          self
+        end
+      end
+    RUBY
+
+    expect(rbs).to include("def include:")
+    expect(rbs).not_to include("| ...")
+  end
+
+  it "accepts `| ...`, `|...` and a bare `...`" do
+    ["# @rbs_infer |...", "# @rbs_infer | ...", "# @rbs_infer ..."].each do |marker|
+      rbs = rbs_for("Module", <<~RUBY)
+        class Module
+          #{marker}
+          def include(*mods)
+            self
+          end
+        end
+      RUBY
+
+      expect(rbs).to include("| ..."), "esperava a forma overloading para #{marker.inspect}"
+    end
+  end
+
+  it "marks only the def the comment sits above" do
+    rbs = rbs_for("Module", <<~RUBY)
+      class Module
+        # @rbs_infer |...
+        def include(*mods)
+          self
+        end
+
+        def prepend(*mods)
+          self
+        end
+      end
+    RUBY
+
+    expect(rbs).to include("def include: (*untyped) -> self | ...")
+    expect(rbs).to match(/def prepend: [^|]+$/m)
+  end
+
+  # An RBS environment refuses both failure modes outright, so the point of the marker is
+  # that the emitted signature actually LOADS beside the one it overloads.
+  it "produces RBS the environment accepts beside the core declaration" do
+    rbs = rbs_for("Module", <<~RUBY)
+      class Module
+        # @rbs_infer |...
+        def include(*mods)
+          self
+        end
+      end
+    RUBY
+
+    sig = File.join(@dir, "probe.rbs")
+    File.write(sig, rbs)
+
+    loader = RBS::EnvironmentLoader.new(core_root: RBS::EnvironmentLoader::DEFAULT_CORE_ROOT)
+    loader.add(path: Pathname(sig))
+    env = RBS::Environment.from_loader(loader).resolve_type_names
+    definition = RBS::DefinitionBuilder.new(env: env).build_instance(RBS::TypeName.parse("::Module").absolute!)
+
+    expect(definition.methods[:include].method_types.map(&:to_s).first).to eq("(*untyped) -> self")
+  end
+end


### PR DESCRIPTION
Pseudo-code that gives a body to a method something else already declares could not be expressed. Two plain declarations of one method in a class is a `DuplicatedMethodDefinitionError`, and that does not degrade — it poisons the whole environment. Reopening `Module#include` to say what `include` does aborted the entire run:

```
::Module#include has duplicated definitions in
  core/module.rbs:868  vs  sig/rbs_infer/.../module_include.rbs:2
RBS::DuplicatedMethodDefinitionError
```

RBS already has the escape hatch, so this needs no feature in rbs or steep. A member whose type ends in `| ...` is an **overloading** member: `MethodBuilder` keeps it in `defn.overloads` rather than `defn.originals`, and `validate!` only rejects duplicated originals. Measured:

| emitted | result |
|---|---|
| `def include: (*Module mods) -> self` | `RBS::DuplicatedMethodDefinitionError` |
| `def include: (*Module mods) -> self \| ...` | loads — `["(*::Module mods) -> self", "(::Module, *::Module arg0) -> self"]` |

Ours goes **ahead** of the existing overloads.

## The marker

`# @rbs_infer |...` on its own line above a def. `|...`, `| ...` and a bare `...` all read the same. It rides the comment scanner already used for `#:` / `@rbs` signatures — so only a comment on its own line above the def counts, and `/@rbs\s+/` does not match `@rbs_infer`, leaving the existing forms untouched.

## Confirmed, not trusted

`| ...` with nothing to overload is an `InvalidOverloadMethodError`:

```
def only_here: (Integer x) -> String | ...
→ Invalid method overloading: ::LoneThing#only_here
```

That is the same class of hard failure the marker exists to avoid, so a marker alone must not decide. `Analyzer#confirm_overloading!` asks the environment whether another file declares the method **plainly** on that **same** class, and silently emits the plain form when not. An ancestor's declaration does not count — that is inheritance, which RBS never rejects.

Our own previous output is excluded from the check, by the `<source path>.rbs` suffix (stable whatever `--output-dir` is). Confirming against ourselves would be circular: a method only we declare would gain `| ...` and then have nothing left to overload.

## Verification

- A `Module#include` reopen in the dummy now loads beside the core declaration with **zero** errors, where it aborted the run before.
- Six specs, including one that writes the emitted RBS to disk and asserts `RBS::DefinitionBuilder` builds `::Module` from it beside core — the failure modes are environment-level, so the test has to be too.
- `bundle exec rspec` — **1075 examples, 0 failures**. No generator emits the marker yet, so no snapshot moves.

## What it does not do

`| ...` **adds** an overload; it does not replace. The older signature stays in the list and a call matching it still matches. So this does not cover the carrierwave case, which wants rbs_rails' column accessor *gone* rather than out-ranked — that would need a real "force/override", removing the competing declaration, and is a separate and considerably more dangerous capability.

It also does not on its own make a `Module#include` reopen useful: the generic body (`mod.included(self)`) carries no concrete class, so a hook's `base` stays `untyped`. Measured separately with a non-colliding name. That half is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)