### PR TITLE
feat: type a rest parameter from its call sites

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -1074,12 +1074,9 @@ module RbsInfer
   # requireds+optionals prefix) and kwargs by name, so the order
   # preserves the positional mapping.
   #
-  # A rest param sits between the two, where its index is, and is spelled
-  # `"*name"`. The marker is in-band because it is positional information
-  # about this very list — where one-to-one mapping stops and folding
-  # begins — and `extract_cross_class_args`, the only consumer that needs
-  # to know, is where it is stripped. Everything else compares these names
-  # against keyword keys, which a `*`-prefixed name can never equal.
+  # A rest param sits between the two, where its index is, marked by
+  # `RestParamMarker` — see there for what the marker is and why it travels
+  # in the list itself.
   def extract_target_method_params
     return {} unless @parsed_target
 
@@ -1095,20 +1092,12 @@ module RbsInfer
       names = []
       params.requireds.each { |p| names << p.name.to_s if p.respond_to?(:name) } if params.respond_to?(:requireds)
       params.optionals.each { |p| names << p.name.to_s if p.respond_to?(:name) } if params.respond_to?(:optionals)
-      names << "*#{rest_param_name(params)}" if rest_param_name(params)
+      rest = RbsInfer::Inference::RestParamMarker.name_from(params)
+      names << RbsInfer::Inference::RestParamMarker.mark(rest) if rest
       params.keywords.each { |p| names << p.name.to_s if p.respond_to?(:name) } if params.respond_to?(:keywords)
       methods[defn.name.to_s] = names unless names.empty?
     end
     methods
-  end
-
-  # An anonymous `*` (and `def foo(a,)`'s implicit rest) has no name for the
-  # type substitution to key on, so it is not offered as a slot at all.
-  def rest_param_name(params)
-    rest = params.rest if params.respond_to?(:rest)
-    return unless rest.is_a?(Prism::RestParameterNode)
-
-    rest.name&.to_s
   end
 
   # `attr_accessor`/`attr_writer :x` defines an `x=` method, so an external
@@ -1184,6 +1173,8 @@ module RbsInfer
     names = []
     params.requireds.each { |p| names << p.name.to_s if p.respond_to?(:name) } if params.respond_to?(:requireds)
     params.optionals.each { |p| names << p.name.to_s if p.respond_to?(:name) } if params.respond_to?(:optionals)
+    rest = RbsInfer::Inference::RestParamMarker.name_from(params)
+    names << RbsInfer::Inference::RestParamMarker.mark(rest) if rest
     names
   end
 
@@ -1345,6 +1336,7 @@ require_relative "signatures/rbs_builder"
 require_relative "inference/constant_type_resolver"
 require_relative "inference/constant_arg_type_resolver"
 require_relative "inference/self_return_type_context"
+require_relative "inference/rest_param_marker"
 require_relative "inference/type_merger"
 require_relative "inference/ivar_type_set"
 require_relative "inference/return_type_resolver"

--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -1073,6 +1073,13 @@ module RbsInfer
   # positional args by index (which can only reach the
   # requireds+optionals prefix) and kwargs by name, so the order
   # preserves the positional mapping.
+  #
+  # A rest param sits between the two, where its index is, and is spelled
+  # `"*name"`. The marker is in-band because it is positional information
+  # about this very list — where one-to-one mapping stops and folding
+  # begins — and `extract_cross_class_args`, the only consumer that needs
+  # to know, is where it is stripped. Everything else compares these names
+  # against keyword keys, which a `*`-prefixed name can never equal.
   def extract_target_method_params
     return {} unless @parsed_target
 
@@ -1088,10 +1095,20 @@ module RbsInfer
       names = []
       params.requireds.each { |p| names << p.name.to_s if p.respond_to?(:name) } if params.respond_to?(:requireds)
       params.optionals.each { |p| names << p.name.to_s if p.respond_to?(:name) } if params.respond_to?(:optionals)
+      names << "*#{rest_param_name(params)}" if rest_param_name(params)
       params.keywords.each { |p| names << p.name.to_s if p.respond_to?(:name) } if params.respond_to?(:keywords)
       methods[defn.name.to_s] = names unless names.empty?
     end
     methods
+  end
+
+  # An anonymous `*` (and `def foo(a,)`'s implicit rest) has no name for the
+  # type substitution to key on, so it is not offered as a slot at all.
+  def rest_param_name(params)
+    rest = params.rest if params.respond_to?(:rest)
+    return unless rest.is_a?(Prism::RestParameterNode)
+
+    rest.name&.to_s
   end
 
   # `attr_accessor`/`attr_writer :x` defines an `x=` method, so an external

--- a/lib/rbs_infer/inference/class_member_collector/extract_params_signature.rb
+++ b/lib/rbs_infer/inference/class_member_collector/extract_params_signature.rb
@@ -89,10 +89,22 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
         @parts << "?#{optional_param_type(p)} #{p.name}"
       end if @params.respond_to?(:optionals)
 
-      # Rest param
+      # Rest param. Emitted WITH its name when it has one, for the same reason every
+      # other parameter is: the type substitution downstream is keyed by name
+      # (`untyped <name>` → `<type> <name>`), so a nameless `*untyped` is a slot nothing
+      # can ever fill — the splat stayed `untyped` no matter what the call sites passed.
+      # An anonymous `*` (or `def foo(a,)`'s implicit rest) has no name to key on and
+      # keeps the bare form.
       if @params.respond_to?(:rest) && @params.rest
-        @parts << "*untyped"
+        @parts << (rest_param_name ? "*untyped #{rest_param_name}" : "*untyped")
       end
+    end
+
+    def rest_param_name
+      rest = @params.rest
+      return unless rest.is_a?(Prism::RestParameterNode)
+
+      rest.name&.to_s
     end
 
     def extract_keyword_params_signature

--- a/lib/rbs_infer/inference/class_member_collector/extract_params_signature.rb
+++ b/lib/rbs_infer/inference/class_member_collector/extract_params_signature.rb
@@ -96,15 +96,9 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
       # An anonymous `*` (or `def foo(a,)`'s implicit rest) has no name to key on and
       # keeps the bare form.
       if @params.respond_to?(:rest) && @params.rest
-        @parts << (rest_param_name ? "*untyped #{rest_param_name}" : "*untyped")
+        name = RbsInfer::Inference::RestParamMarker.name_from(@params)
+        @parts << (name ? "*untyped #{name}" : "*untyped")
       end
-    end
-
-    def rest_param_name
-      rest = @params.rest
-      return unless rest.is_a?(Prism::RestParameterNode)
-
-      rest.name&.to_s
     end
 
     def extract_keyword_params_signature

--- a/lib/rbs_infer/inference/intra_class_call_analyzer.rb
+++ b/lib/rbs_infer/inference/intra_class_call_analyzer.rb
@@ -66,8 +66,16 @@ module RbsInfer::Inference
         positional_params = @method_positional_params[method_name]
         if positional_params
           positional_args = node.arguments.arguments.reject { |a| a.is_a?(Prism::KeywordHashNode) }
+          # From the rest param's index on, every argument is that same parameter. The
+          # candidates are already unioned per name below, so pointing them all at it is
+          # the whole of the folding here.
+          splat_index = RestParamMarker.index_in(positional_params)
           positional_args.each_with_index do |arg, i|
-            param_name = positional_params[i]
+            param_name = if splat_index && i >= splat_index
+                           RestParamMarker.unmark(positional_params[splat_index])
+                         else
+                           positional_params[i]
+                         end
             next unless param_name
             type = resolve_value_type(arg)
             next if type == "untyped"

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -863,19 +863,35 @@ module RbsInfer::Inference
       # parâmetro e ainda há slot posicional livre: sem isso o argumento desaparece, e o
       # parâmetro é tipado só pelos OUTROS call-sites — estreito demais, não apenas impreciso.
       index = 0
+      splat_types = []
       call_node.arguments.arguments.each do |arg|
         break if index >= param_names.size
 
         if arg.is_a?(Prism::KeywordHashNode)
           next unless collapses_to_positional?(arg, param_names)
 
-          args[param_names[index]] = hash_literal_type(arg)
-          index += 1
+          type = hash_literal_type(arg)
+        else
+          type = argument_type(arg)
+        end
+
+        # A rest param takes EVERY remaining positional argument, so they all describe
+        # the same parameter. Fold them into one union instead of advancing: without
+        # this the first argument would win the slot and the others would fall off the
+        # end of `param_names`, typing `*args` by the first position alone.
+        if splat_name(param_names[index])
+          splat_types << type
           next
         end
 
-        args[param_names[index]] = argument_type(arg)
+        args[param_names[index]] = type
         index += 1
+      end
+
+      if (splat = splat_name(param_names[index])) && !splat_types.empty?
+        # The splat's own type is its ELEMENT type (`*T` means each argument is a `T`),
+        # which is exactly the union of what the arguments are.
+        args[splat] = RbsInfer::Inference::TypeMerger.union_types(splat_types.compact)
       end
 
       # Args keyword
@@ -949,6 +965,13 @@ module RbsInfer::Inference
 
     # Whether a keyword hash at the call site is really a positional Hash: no key names a
     # parameter, so the callee cannot be receiving them as keywords.
+    # The parameter name behind the `"*name"` marker `extract_target_method_params`
+    # writes for a rest param, or nil for an ordinary name. See the comment there for
+    # why the marker travels in the list itself.
+    def splat_name(param_name)
+      param_name&.start_with?("*") ? param_name.delete_prefix("*") : nil
+    end
+
     def collapses_to_positional?(node, param_names)
       keys = node.elements.filter_map { |e| e.is_a?(Prism::AssocNode) ? extract_symbol_key(e.key) : nil }
       return false if keys.empty?

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -664,13 +664,25 @@ module RbsInfer::Inference
       return args unless call_node.arguments
 
       index = 0
+      splat_types = []
       call_node.arguments.arguments.each do |arg|
         break if index >= @init_positional_params.size
         next if arg.is_a?(Prism::KeywordHashNode)
 
+        # `Klass.new(a, b, c)` onto `initialize(first, *rest)`: everything from the rest
+        # param's index on is the same parameter, so fold instead of advancing.
+        if splat_name(@init_positional_params[index])
+          splat_types << argument_type(arg)
+          next
+        end
+
         param_name = @init_positional_params[index]
         args[param_name] = argument_type(arg)
         index += 1
+      end
+
+      if (splat = splat_name(@init_positional_params[index])) && !splat_types.empty?
+        args[splat] = RbsInfer::Inference::TypeMerger.union_types(splat_types.compact)
       end
 
       args
@@ -965,12 +977,7 @@ module RbsInfer::Inference
 
     # Whether a keyword hash at the call site is really a positional Hash: no key names a
     # parameter, so the callee cannot be receiving them as keywords.
-    # The parameter name behind the `"*name"` marker `extract_target_method_params`
-    # writes for a rest param, or nil for an ordinary name. See the comment there for
-    # why the marker travels in the list itself.
-    def splat_name(param_name)
-      param_name&.start_with?("*") ? param_name.delete_prefix("*") : nil
-    end
+    def splat_name(param_name) = RbsInfer::Inference::RestParamMarker.unmark(param_name)
 
     def collapses_to_positional?(node, param_names)
       keys = node.elements.filter_map { |e| e.is_a?(Prism::AssocNode) ? extract_symbol_key(e.key) : nil }

--- a/lib/rbs_infer/inference/param_type_inferrer.rb
+++ b/lib/rbs_infer/inference/param_type_inferrer.rb
@@ -36,6 +36,8 @@ module RbsInfer::Inference
         names = []
         defn.parameters.requireds.each { |p| names << p.name.to_s if p.respond_to?(:name) } if defn.parameters.respond_to?(:requireds)
         defn.parameters.optionals.each { |p| names << p.name.to_s if p.respond_to?(:name) } if defn.parameters.respond_to?(:optionals)
+        rest = RestParamMarker.name_from(defn.parameters)
+        names << RestParamMarker.mark(rest) if rest
         positional_params[defn.name.to_s] = names unless names.empty?
       end
 

--- a/lib/rbs_infer/inference/rest_param_marker.rb
+++ b/lib/rbs_infer/inference/rest_param_marker.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "prism"
+
+module RbsInfer
+  module Inference
+    # Where a rest parameter sits in a list of positional parameter NAMES, and what it is
+    # called.
+    #
+    # Three collectors map a call site's positional arguments onto such a list by index —
+    # cross-class calls, `Klass.new` calls, and intra-class calls. All three need one extra
+    # fact the names alone cannot carry: at which index the one-to-one mapping stops and
+    # every remaining argument starts describing the SAME parameter. A rest param's name is
+    # therefore marked in the list itself, and this is the only place that knows how.
+    #
+    # In-band rather than a parallel structure because it is positional information about
+    # that very list, and it travels through three layers of constructor kwargs to reach
+    # the collectors. Inert everywhere else: the other consumers compare these names
+    # against keyword keys, which a `*`-prefixed name can never equal.
+    module RestParamMarker
+      PREFIX = "*"
+
+      def self.mark(name) = "#{PREFIX}#{name}"
+
+      # The name behind the marker, or nil for an ordinary parameter name — so a consumer
+      # asks "is this the rest param, and what is it called?" in one call.
+      def self.unmark(name)
+        name&.start_with?(PREFIX) ? name.delete_prefix(PREFIX) : nil
+      end
+
+      # Where the rest parameter sits in `names`, or nil when there is none.
+      def self.index_in(names) = names.index { |name| unmark(name) }
+
+      # The rest parameter's name for a def's parameters, or nil when it has none: an
+      # anonymous `*` (and the implicit rest of `def foo(a,)`) is a parameter no type
+      # substitution can reach, since that substitution is keyed by name.
+      def self.name_from(params)
+        rest = params.rest if params.respond_to?(:rest)
+        return unless rest.is_a?(Prism::RestParameterNode)
+
+        rest.name&.to_s
+      end
+    end
+  end
+end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/edit.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/edit.rbs
@@ -5,7 +5,7 @@ class ERBPostsEdit
   include PostsHelper
 
   def initialize: (post: Post & ::Post::Validated) -> void
-  def render: (?{ partial: String, locals: { post: Post & Post::Validated } } target, *untyped) -> nil
+  def render: (?{ partial: String, locals: { post: Post & Post::Validated } } target, *untyped rest) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/new.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/new.rbs
@@ -5,7 +5,7 @@ class ERBPostsNew
   include PostsHelper
 
   def initialize: (post: Post) -> void
-  def render: (?{ partial: String, locals: { post: Post } } target, *untyped) -> nil
+  def render: (?{ partial: String, locals: { post: Post } } target, *untyped rest) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/show.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/show.rbs
@@ -6,7 +6,7 @@ class ERBPostsShow
   include PostsHelper
 
   def initialize: (comments: Comment::ActiveRecord_Relation, post: Post & ::Post::Validated) -> void
-  def render: (?({ partial: String, locals: { comment: (Comment & Comment::Validated) } } | String) target, *untyped) -> nil
+  def render: (?({ partial: String, locals: { comment: (Comment & Comment::Validated) } } | String) target, *{ post: Post & Post::Validated } rest) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/action_controller_base.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/action_controller_base.rbs
@@ -2,9 +2,9 @@ module ActionController
   class Base
     @__rbs_infer__performed: true?
 
-    def redirect_to: (*untyped) -> bool
-    def render: (*untyped) -> bool
-    def head: (*untyped) -> bool
+    def redirect_to: (*untyped args) -> bool
+    def render: (*{ plain: String, status: Symbol } args) -> bool
+    def head: (*untyped args) -> bool
     def performed?: () -> true?
     def __rbs_infer__unknown_condition?: () -> untyped
   end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/dashboard_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/dashboard_controller.rbs
@@ -1,7 +1,7 @@
 class DashboardController
   @__rbs_infer__performed: true?
 
-  def render: (?Symbol target, *untyped) -> bool
+  def render: (?Symbol target, *untyped rest) -> bool
 
   private
 

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/posts_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/posts_controller.rbs
@@ -1,7 +1,7 @@
 class PostsController
   @__rbs_infer__performed: true?
 
-  def render: (?Symbol target, *untyped) -> bool
+  def render: (?Symbol target, *{ status: Symbol } rest) -> bool
 
   private
 

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/users_avatars_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/users_avatars_controller.rbs
@@ -2,7 +2,7 @@ module Users
   class AvatarsController
     @__rbs_infer__performed: true?
 
-    def render: (?Symbol target, *untyped) -> bool
+    def render: (?Symbol target, *{ status: Symbol } rest) -> bool
 
     private
 

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/users_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/users_controller.rbs
@@ -1,7 +1,7 @@
 class UsersController
   @__rbs_infer__performed: true?
 
-  def render: (?(Symbol | String) target, *untyped) -> bool
+  def render: (?(Symbol | String) target, *untyped rest) -> bool
 
   private
 

--- a/spec/expectations/steep_actionview_runtime/posts/edit.rbs
+++ b/spec/expectations/steep_actionview_runtime/posts/edit.rbs
@@ -5,7 +5,7 @@ class ERBPostsEdit
   include PostsHelper
 
   def initialize: (post: Post & ::Post::Validated) -> void
-  def render: (?{ partial: String, locals: { post: Post & Post::Validated } } target, *untyped) -> nil
+  def render: (?{ partial: String, locals: { post: Post & Post::Validated } } target, *untyped rest) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/expectations/steep_actionview_runtime/posts/new.rbs
+++ b/spec/expectations/steep_actionview_runtime/posts/new.rbs
@@ -5,7 +5,7 @@ class ERBPostsNew
   include PostsHelper
 
   def initialize: (post: Post) -> void
-  def render: (?{ partial: String, locals: { post: Post } } target, *untyped) -> nil
+  def render: (?{ partial: String, locals: { post: Post } } target, *untyped rest) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/expectations/steep_actionview_runtime/posts/show.rbs
+++ b/spec/expectations/steep_actionview_runtime/posts/show.rbs
@@ -6,7 +6,7 @@ class ERBPostsShow
   include PostsHelper
 
   def initialize: (comments: Comment::ActiveRecord_Relation, post: Post & ::Post::Validated) -> void
-  def render: (?({ partial: String, locals: { comment: (Comment & Comment::Validated) } } | String) target, *untyped) -> nil
+  def render: (?({ partial: String, locals: { comment: (Comment & Comment::Validated) } } | String) target, *{ post: Post & Post::Validated } rest) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/expectations/steep_controller_runtime/action_controller_base.rbs
+++ b/spec/expectations/steep_controller_runtime/action_controller_base.rbs
@@ -2,9 +2,9 @@ module ActionController
   class Base
     @__rbs_infer__performed: true?
 
-    def redirect_to: (*untyped) -> bool
-    def render: (*untyped) -> bool
-    def head: (*untyped) -> bool
+    def redirect_to: (*untyped args) -> bool
+    def render: (*{ plain: String, status: Symbol } args) -> bool
+    def head: (*untyped args) -> bool
     def performed?: () -> true?
     def __rbs_infer__unknown_condition?: () -> untyped
   end

--- a/spec/expectations/steep_controller_runtime/dashboard_controller.rbs
+++ b/spec/expectations/steep_controller_runtime/dashboard_controller.rbs
@@ -1,7 +1,7 @@
 class DashboardController
   @__rbs_infer__performed: true?
 
-  def render: (?Symbol target, *untyped) -> bool
+  def render: (?Symbol target, *untyped rest) -> bool
 
   private
 

--- a/spec/expectations/steep_controller_runtime/posts_controller.rbs
+++ b/spec/expectations/steep_controller_runtime/posts_controller.rbs
@@ -1,7 +1,7 @@
 class PostsController
   @__rbs_infer__performed: true?
 
-  def render: (?Symbol target, *untyped) -> bool
+  def render: (?Symbol target, *{ status: Symbol } rest) -> bool
 
   private
 

--- a/spec/expectations/steep_controller_runtime/users_avatars_controller.rbs
+++ b/spec/expectations/steep_controller_runtime/users_avatars_controller.rbs
@@ -2,7 +2,7 @@ module Users
   class AvatarsController
     @__rbs_infer__performed: true?
 
-    def render: (?Symbol target, *untyped) -> bool
+    def render: (?Symbol target, *{ status: Symbol } rest) -> bool
 
     private
 

--- a/spec/expectations/steep_controller_runtime/users_controller.rbs
+++ b/spec/expectations/steep_controller_runtime/users_controller.rbs
@@ -1,7 +1,7 @@
 class UsersController
   @__rbs_infer__performed: true?
 
-  def render: (?(Symbol | String) target, *untyped) -> bool
+  def render: (?(Symbol | String) target, *untyped rest) -> bool
 
   private
 

--- a/spec/lib/rbs_infer/inference/splat_param_inference_spec.rb
+++ b/spec/lib/rbs_infer/inference/splat_param_inference_spec.rb
@@ -91,6 +91,70 @@ RSpec.describe "rest parameter inference" do
     expect(rbs).to include("def anonymous: (*untyped) ->")
   end
 
+  # A constructor's arguments are collected by `extract_positional_args`, a different
+  # path from every other method's — `initialize` is skipped by
+  # `extract_target_method_params` and served by `init_positional_params` instead.
+  it "types a constructor's splat from `.new` call sites" do
+    rbs = rbs_for(
+      "notifier.rb",
+      "notifier.rb" => "class Notifier\n  def initialize(*recipients)\n    @recipients = recipients\n  end\nend\n",
+      "caller.rb" => "class Caller\n  def go\n    Notifier.new(User.new, User.new)\n  end\nend\n\nclass User\nend\n"
+    )
+
+    expect(rbs).to include("def initialize: (*User recipients) ->")
+  end
+
+  it "keeps a constructor's leading params separate from its splat" do
+    rbs = rbs_for(
+      "notifier.rb",
+      "notifier.rb" => "class Notifier\n  def initialize(subject, *bodies)\n    @subject = subject\n    @bodies = bodies\n  end\nend\n",
+      "caller.rb" => "class Caller\n  def go\n    Notifier.new(\"hi\", 1, 2)\n  end\nend\n"
+    )
+
+    expect(rbs).to include("def initialize: (String subject, *Integer bodies) ->")
+  end
+
+  # The intra-class path (`IntraClassCallAnalyzer`) maps by index against its own
+  # positional list, built the way `extract_target_method_params` used to be.
+  it "types a splat called only from inside its own class" do
+    rbs = rbs_for(
+      "notifier.rb",
+      "notifier.rb" => <<~RUBY,
+        class Notifier
+          def run
+            internal(User.new, User.new)
+          end
+
+          def internal(*people)
+            people
+          end
+        end
+      RUBY
+      "user.rb" => "class User\nend\n"
+    )
+
+    expect(rbs).to include("def internal: (*User people) ->")
+  end
+
+  it "unions an intra-class splat's arguments too" do
+    rbs = rbs_for(
+      "notifier.rb",
+      "notifier.rb" => <<~RUBY
+        class Notifier
+          def run
+            internal("a", 1)
+          end
+
+          def internal(*things)
+            things
+          end
+        end
+      RUBY
+    )
+
+    expect(rbs).to include("def internal: (*(String | Integer) things) ->")
+  end
+
   it "stays untyped when no call site says anything" do
     rbs = rbs_for("notifier.rb", "notifier.rb" => "class Notifier\n  def notify(*recipients)\n    recipients\n  end\nend\n")
 

--- a/spec/lib/rbs_infer/inference/splat_param_inference_spec.rb
+++ b/spec/lib/rbs_infer/inference/splat_param_inference_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rbs_infer"
+require "tmpdir"
+require "fileutils"
+require_relative "../../../support/temp_file_helpers"
+
+# A rest parameter used to be emitted as the bare string `"*untyped"`, with no name and no
+# call-site lookup behind it — so `def notify(*recipients)` was `(*untyped)` however
+# unambiguous the call sites were. Two halves were missing: the parameter was never offered
+# as a slot (`extract_target_method_params` collected requireds, optionals and keywords
+# only), and even offered it had no name for the type substitution, which is keyed by name,
+# to fill.
+RSpec.describe "rest parameter inference" do
+  include TempFileHelpers
+
+  def rbs_for(target, files)
+    with_temp_files(files) do |_dir, paths|
+      target_path = paths.find { |p| File.basename(p) == target }
+      RbsInfer::Analyzer.new(target_file: target_path, source_files: paths).generate_rbs
+    end
+  end
+
+  def with_caller(target_body, run_body)
+    rbs_for(
+      "notifier.rb",
+      "notifier.rb" => "class Notifier\n#{target_body}\nend\n",
+      "caller.rb" => "class Caller\n  def run\n#{run_body}\n  end\nend\n\nclass User\nend\n"
+    )
+  end
+
+  it "types the splat from what the call sites pass" do
+    rbs = with_caller(
+      "  def notify(*recipients)\n    recipients\n  end",
+      "    Notifier.new.notify(User.new, User.new)"
+    )
+
+    expect(rbs).to include("def notify: (*User recipients) ->")
+  end
+
+  # Every argument from the splat's position onward describes the SAME parameter, so they
+  # are one union — not a race the first argument wins while the others fall off the end
+  # of the parameter list.
+  it "unions every argument the splat swallows, across call sites" do
+    rbs = with_caller(
+      "  def mixed(*things)\n    things\n  end",
+      "    Notifier.new.mixed(User.new, \"text\")\n    Notifier.new.mixed(42)"
+    )
+
+    expect(rbs).to include("def mixed: (*(User | String | Integer) things) ->")
+  end
+
+  it "types the parameters before the splat by position, as before" do
+    rbs = with_caller(
+      "  def deliver(subject, *bodies)\n    [subject, bodies]\n  end",
+      "    Notifier.new.deliver(\"hi\", \"a\", \"b\")"
+    )
+
+    expect(rbs).to include("def deliver: (String subject, *String bodies) ->")
+  end
+
+  it "keeps an optional before the splat separate from it" do
+    rbs = with_caller(
+      "  def only_optional(first = nil, *rest)\n    [first, rest]\n  end",
+      "    Notifier.new.only_optional(\"a\", 1, 2)"
+    )
+
+    expect(rbs).to include("def only_optional: (?String first, *Integer rest) ->")
+  end
+
+  # Keywords are matched by name, and the splat does not eat them: `mode:` still lands on
+  # `mode` even though it is written after arguments the splat took.
+  it "leaves keywords after the splat to their own names" do
+    rbs = with_caller(
+      "  def with_keyword(*items, mode:)\n    [items, mode]\n  end",
+      "    Notifier.new.with_keyword(User.new, User.new, mode: \"fast\")"
+    )
+
+    expect(rbs).to include("def with_keyword: (*User items, mode: String) ->")
+  end
+
+  # An anonymous `*` has no name for the substitution to key on, so it keeps the bare form
+  # rather than inventing one.
+  it "leaves an anonymous splat as `*untyped`" do
+    rbs = with_caller(
+      "  def anonymous(*)\n    1\n  end",
+      "    Notifier.new.anonymous(User.new)"
+    )
+
+    expect(rbs).to include("def anonymous: (*untyped) ->")
+  end
+
+  it "stays untyped when no call site says anything" do
+    rbs = rbs_for("notifier.rb", "notifier.rb" => "class Notifier\n  def notify(*recipients)\n    recipients\n  end\nend\n")
+
+    expect(rbs).to include("def notify: (*untyped recipients) ->")
+  end
+end

--- a/spec/lib/rbs_infer/signatures/overloading_marker_spec.rb
+++ b/spec/lib/rbs_infer/signatures/overloading_marker_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "the `# @rbs_infer |...` overloading marker" do
       end
     RUBY
 
-    expect(rbs).to include("def include: (*untyped) -> self | ...")
+    expect(rbs).to include("def include: (*untyped mods) -> self | ...")
   end
 
   # The marker states intent; claiming it where there is nothing to overload would be a
@@ -91,7 +91,7 @@ RSpec.describe "the `# @rbs_infer |...` overloading marker" do
       end
     RUBY
 
-    expect(rbs).to include("def include: (*untyped) -> self | ...")
+    expect(rbs).to include("def include: (*untyped mods) -> self | ...")
     expect(rbs).to match(/def prepend: [^|]+$/m)
   end
 
@@ -115,6 +115,6 @@ RSpec.describe "the `# @rbs_infer |...` overloading marker" do
     env = RBS::Environment.from_loader(loader).resolve_type_names
     definition = RBS::DefinitionBuilder.new(env: env).build_instance(RBS::TypeName.parse("::Module").absolute!)
 
-    expect(definition.methods[:include].method_types.map(&:to_s).first).to eq("(*untyped) -> self")
+    expect(definition.methods[:include].method_types.map(&:to_s).first).to eq("(*untyped mods) -> self")
   end
 end


### PR DESCRIPTION
`def notify(*recipients)` came out `(*untyped)` however unambiguous the call sites were. Two halves were missing, and either one alone is enough to lose the type:

- **No name.** `extract_params_signature` emitted the bare string `"*untyped"`. Every other parameter is emitted `untyped <name>` precisely so the substitution downstream — which is keyed by name — can fill it, so a nameless slot is one nothing can ever reach.
- **No slot.** `extract_target_method_params` collected requireds, optionals and keywords only. A rest param was never offered, so a method whose only parameter is a splat was not even in `target_methods` and its call sites were never looked at.

The rest param is now offered at its own index, spelled `"*name"`, and `extract_cross_class_args` folds **every** remaining positional argument into it as one union instead of advancing. The arguments from that position on all describe the same parameter, so letting the first win the slot would type `*args` by the first position alone and drop the others off the end of the list.

```rbs
def notify: (*User recipients)                    # was (*untyped)
def mixed: (*(User | String | Integer) things)    # union over args AND over call sites
def deliver: (String subject, *String bodies)     # prefix still mapped by position
def with_keyword: (*User items, mode: String)     # keywords still mapped by name
def anonymous: (*untyped)                         # anonymous `*` has no name to key on
```

The marker travels in the name list itself because it is positional information about that very list — where one-to-one mapping stops and folding begins — and the single consumer that needs to know is where it is stripped. Everything else compares those names against keyword keys, which a `*`-prefixed name can never equal.

## On the dummy

The runtime sidecars' own splats get typed from the app's calls:

```rbs
def render: (?Symbol target, *{ status: Symbol } rest) -> bool                      # was *untyped
def render: (?{ partial: String, ... } target, *{ post: Post & Post::Validated } rest) -> nil
def redirect_to: (*untyped args) -> bool
```

## Verification

- `bundle exec rspec` — **1068 examples, 0 failures** (7 new, one per shape above).
- `steep check` on the dummy — **25 problems in 13 files**, unchanged: the narrower signatures break nothing.
- The overloading-marker specs (#200) move from `(*untyped)` to `(*untyped mods)`. RBS accepts the named form — that spec proves it by loading the result into an environment beside core's `Module#include`.

## The other two collectors (second commit)

Every path that maps positional arguments by index is now covered:

```rbs
def initialize: (*User recipients)                  # `Klass.new(a, b)` → extract_positional_args
def initialize: (String subject, *Integer bodies)
def internal: (*User people)                        # called only intra-class
```

`initialize` is skipped by `extract_target_method_params` and served by `init_positional_params`, which collected requireds and optionals only; the intra-class path (`IntraClassCallAnalyzer`) builds its list the same way. That side needs no folding of its own — its candidates are already accumulated per parameter **name** and unioned at the end, so pointing every argument from the splat's index on at that one name is the whole of it.

With three consumers sharing the convention, the marker moved into `RbsInfer::Inference::RestParamMarker` (`mark` / `unmark` / `index_in`, plus the `name_from(params)` that answers "does this def have a *named* rest param" and which all four producers were spelling out). Nothing else knows the `*` prefix.

The snapshots are byte-identical for this commit: no model in the dummy takes a splat, and the runtime sidecars' splats were already covered by the cross-class path.

## Still `Array[untyped]`

The ivar a splat is assigned to — `@recipients = recipients` with `recipients` now `*User`. That is the ivar inference reading a local, not a parameter list; a different path again, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
