### PR TITLE
test: characterize `send` reaching a private method

### DIFF
--- a/spec/dummy/app/models/send_dispatch.rb
+++ b/spec/dummy/app/models/send_dispatch.rb
@@ -17,6 +17,14 @@
 #   misspelled name and a call on the result are all accepted in silence (measured: three
 #   such lines, `No type error detected`).
 #
+# The caller below has two halves. The first is inference that is missing: a parameter and
+# a return type that read `untyped` and have to read a type. The second is code that has to
+# start FAILING — `public_send` reaching a private method, a name that resolves nowhere, a
+# wrong arity — accepted in silence today, and each one a runtime error. Both halves are
+# invisible in the snapshot for the same reason (`send` is `untyped`), which is why the
+# second half is spelled out in comments here and belongs in `steep_baseline.txt` once
+# resolved.
+#
 # A plain class on purpose — nothing here is Active Record, so the fixture needs no table.
 class SendDispatch
   def call
@@ -65,5 +73,58 @@ class SendDispatchCaller
   # types this one has guessed.
   def dynamic(name)
     SendDispatch.new.send(name)
+  end
+
+  # The same thing, spelled the other three ways Ruby spells it. A fix that fires only on
+  # `send` with a `:symbol` covers the fixture above and misses these — all four are one
+  # dispatch, and `__send__` is the one a defensive library uses precisely because `send`
+  # can be overridden.
+  def underscored
+    SendDispatch.new.__send__(:stamp, "post")
+  end
+
+  def string_named
+    SendDispatch.new.send("stamp", "post")
+  end
+
+  # ─── The half that has to become an ERROR ────────────────────────────────────────
+  #
+  # Everything below is accepted in silence today, and each line is a runtime failure —
+  # which is the whole argument for resolving a literal-name `send`. They are deliberately
+  # wrong, like the intentional errors in `example7.rb`, and after a fix each one belongs
+  # in `sig/generated/steep_baseline.txt` rather than in the source.
+
+  # `public_send` respects visibility, so this is a `NoMethodError` at runtime even though
+  # `stamp` exists. A different error from "no such method" and worth a different message:
+  # the name resolves, the call does not.
+  def stamped_publicly
+    SendDispatch.new.public_send(:stamp, "post")
+  end
+
+  # No method by this name, at any visibility. Measured: Steep already reports the plain
+  # spelling of this (`Ruby::NoMethod`) even for a class that declares `method_missing`,
+  # so resolving `send` adds no new judgment — it removes an exception.
+  def missing_name
+    SendDispatch.new.send(:no_such_method_anywhere)
+  end
+
+  # Right name, wrong number of arguments: `ArgumentError` at runtime.
+  def wrong_arity
+    SendDispatch.new.send(:stamp, "a", "b", "c")
+  end
+
+  # And the case that must NOT error: a splat of unknown length says nothing about how
+  # many arguments arrive, so a fix resolves the name and the return type and stays quiet
+  # about the arguments.
+  def splatted(*args)
+    SendDispatch.new.send(:stamp, *args)
+  end
+
+  # The shape that will make the most noise in a real codebase, and the reason the
+  # diagnostic wants an ID of its own to tune: a `respond_to?` guard does not put the
+  # method in the RBS, so this errors even though the code is careful. Silent today.
+  def guarded
+    target = SendDispatch.new
+    target.send(:no_such_method_anywhere) if target.respond_to?(:no_such_method_anywhere)
   end
 end

--- a/spec/dummy/app/models/send_dispatch.rb
+++ b/spec/dummy/app/models/send_dispatch.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# `send` reaches a PRIVATE method by name, and that is not a corner of the language: it is
+# how MRI itself invokes the mixin hooks. `rb_mod_include` calls `append_features` and
+# `included` with `rb_funcall`, which dispatches by name ignoring visibility, and both are
+# private on `Module` — so the pseudo-code in `sig/generated/steep_ruby_runtime/module.rb`
+# spells them `mod.send(:included, self)`, the only spelling that is true to the C.
+#
+# Nothing about a literal-symbol `send` is undecidable: the receiver's type is known and
+# the method name is right there. Both repos read it as nothing today, and this fixture is
+# where that shows:
+#
+# - rbs_infer does not see the call site. `SourceIndex` indexes the file under `send`, so
+#   `files_calling("stamp")` is empty and `stamp`'s parameter is never typed — the same
+#   class of miss as the bare `include` that rbs_infer#202 fixed, from the other end.
+# - Steep checks nothing inside it. `send` returns `untyped`, so a wrong arity, a
+#   misspelled name and a call on the result are all accepted in silence (measured: three
+#   such lines, `No type error detected`).
+#
+# A plain class on purpose — nothing here is Active Record, so the fixture needs no table.
+class SendDispatch
+  def call
+    "called"
+  end
+
+  private
+
+  # The rbs_infer criterion: `value` has to come from the `send` call site in
+  # `SendDispatchCaller#stamped`, exactly like any other cross-class argument. It reads
+  # `untyped` today; it has to read `String`.
+  def stamp(value)
+    "stamped: #{value}"
+  end
+
+  # A private predicate, for the shape a real app sends to most: reaching past `private`
+  # to ask something the public API does not expose.
+  def stamped?(value)
+    value.start_with?("stamped")
+  end
+end
+
+# The call sites. Kept in their own class so they are cross-class calls, which is the path
+# that types a parameter from its callers.
+class SendDispatchCaller
+  # The checker criterion: `send` with a literal symbol IS a call to that method, so this
+  # is `String`. It reads `untyped` today, and neither a wrong arity nor a misspelled name
+  # here would be reported at all.
+  def stamped
+    SendDispatch.new.send(:stamp, "post")
+  end
+
+  def stamped_predicate
+    SendDispatch.new.send(:stamped?, "stamped: post")
+  end
+
+  # `public_send` respects visibility: reaching `stamp` with it raises `NoMethodError` at
+  # runtime, so a fix must resolve it only for the PUBLIC method. Here as the boundary
+  # between the two, over a method that is public.
+  def called
+    SendDispatch.new.public_send(:call)
+  end
+
+  # The limit case, and the reason a fix keys on the literal: the name is a value, so no
+  # static analysis decides which method this is. It has to stay `untyped` — a fix that
+  # types this one has guessed.
+  def dynamic(name)
+    SendDispatch.new.send(name)
+  end
+end

--- a/spec/dummy/sig/rbs_infer/app/models/send_dispatch.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/send_dispatch.rbs
@@ -12,4 +12,11 @@ class SendDispatchCaller
   def stamped_predicate: () -> untyped
   def called: () -> untyped
   def dynamic: (untyped name) -> untyped
+  def underscored: () -> untyped
+  def string_named: () -> untyped
+  def stamped_publicly: () -> untyped
+  def missing_name: () -> untyped
+  def wrong_arity: () -> untyped
+  def splatted: (*untyped args) -> untyped
+  def guarded: () -> untyped
 end

--- a/spec/dummy/sig/rbs_infer/app/models/send_dispatch.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/send_dispatch.rbs
@@ -1,0 +1,15 @@
+class SendDispatch
+  def call: () -> String
+
+  private
+
+  def stamp: (untyped value) -> String
+  def stamped?: (untyped value) -> untyped
+end
+
+class SendDispatchCaller
+  def stamped: () -> untyped
+  def stamped_predicate: () -> untyped
+  def called: () -> untyped
+  def dynamic: (untyped name) -> untyped
+end

--- a/spec/expectations/models/send_dispatch.rbs
+++ b/spec/expectations/models/send_dispatch.rbs
@@ -1,0 +1,8 @@
+class SendDispatch
+  def call: () -> String
+
+  private
+
+  def stamp: (untyped value) -> String
+  def stamped?: (untyped value) -> untyped
+end

--- a/spec/expectations/models/send_dispatch_caller.rbs
+++ b/spec/expectations/models/send_dispatch_caller.rbs
@@ -1,0 +1,6 @@
+class SendDispatchCaller
+  def stamped: () -> untyped
+  def stamped_predicate: () -> untyped
+  def called: () -> untyped
+  def dynamic: (untyped name) -> untyped
+end

--- a/spec/expectations/models/send_dispatch_caller.rbs
+++ b/spec/expectations/models/send_dispatch_caller.rbs
@@ -3,4 +3,11 @@ class SendDispatchCaller
   def stamped_predicate: () -> untyped
   def called: () -> untyped
   def dynamic: (untyped name) -> untyped
+  def underscored: () -> untyped
+  def string_named: () -> untyped
+  def stamped_publicly: () -> untyped
+  def missing_name: () -> untyped
+  def wrong_arity: () -> untyped
+  def splatted: (*untyped args) -> untyped
+  def guarded: () -> untyped
 end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -137,6 +137,27 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
                     target_file: "app/models/included_hook/slots.rb")
   end
 
+  # `send` with a literal symbol reaching a PRIVATE method — how MRI itself invokes the
+  # mixin hooks (`rb_funcall` ignores visibility, and `included`/`append_features` are
+  # private on `Module`), which is why the `Module#include` pseudo-code spells them that
+  # way. Nothing here is undecidable: the receiver's type is known and the name is a
+  # literal. The snapshot records both gaps — `stamp`'s parameter reads `untyped` because
+  # rbs_infer indexes the file under `send` and never looks at the call site, and every
+  # `#stamped`/`#called` reads `untyped` because Steep types `send` as `untyped` and so
+  # checks nothing inside it. `#dynamic` is the limit case and must stay `untyped`.
+  it "SendDispatch (send reaching a private method) matches expected RBS" do
+    assert_snapshot("models/send_dispatch", target_class: "SendDispatch",
+                    target_file: "app/models/send_dispatch.rb")
+  end
+
+  # The call-site half, where the checker's answer shows: every one of these is the type
+  # of a `send`, so every one reads `untyped` while `send` returns `untyped`. `#dynamic`
+  # is the one that has to keep reading it.
+  it "SendDispatchCaller (the send call sites) matches expected RBS" do
+    assert_snapshot("models/send_dispatch_caller", target_class: "SendDispatchCaller",
+                    target_file: "app/models/send_dispatch.rb")
+  end
+
   # A namespaced service object called by its BARE name from the model that
   # encloses it (felixefelip/rbs_infer#129). The interesting half is `Post#archive` /
   # `#archive_via_singleton` in the Post snapshot above: `Archiver` there is


### PR DESCRIPTION
`send` com símbolo literal despachando para um método **privado** não é canto da linguagem: é como o MRI invoca os hooks de mixin. `rb_mod_include` chama `append_features` e `included` por `rb_funcall`, que ignora visibilidade, e os dois são privados em `Module` — é por isso que o pseudocódigo do `Module#include` (#202) os escreve como `mod.send(:included, self)`.

Nada nessa forma é indecidível: o tipo do receiver é conhecido e o nome do método está ali. E os dois repos leem isso como nada. O fixture registra cada metade:

```rbs
class SendDispatch
  def call: () -> String

  private

  def stamp: (untyped value) -> String      # call site: send(:stamp, "post") — devia ser String
  def stamped?: (untyped value) -> untyped
end

class SendDispatchCaller
  def stamped: () -> untyped                # o tipo do próprio send
  def stamped_predicate: () -> untyped
  def called: () -> untyped                 # public_send num método público
  def dynamic: (untyped name) -> untyped    # caso-limite: tem que continuar untyped
end
```

## As duas faltas, medidas

**rbs_infer não olha o call site.** O `SourceIndex` indexa o arquivo sob `send`:

```
files_calling("stamp") => []
files_calling("send")  => ["send_dispatch_caller.rb"]
```

É a mesma classe de miss que o #202 resolveu para chamada bare, agora pela outra ponta.

**Steep não checa nada dentro de um `send`.** Sondado com o RBS da classe presente — sem ele a sonda é vazia, o corpo não é checado:

```ruby
Post.new.send(:title).no_such_method_on_the_result   # aceito
Post.new.send(:title, 1, 2, 3)                       # aridade errada, aceito
Post.new.send(:no_such_method_anywhere)              # nome inexistente, aceito
# => No type error detected. 🫖
```

Não há tratamento de `__send__`/`public_send` em `lib/steep/` no fork.

## As duas fronteiras que o fixture fixa

- **`public_send` respeita visibilidade** — alcançar `stamp` com ele é `NoMethodError` em runtime, então uma correção tem de resolvê-lo só para o método público. Está no fixture sobre um método público, para marcar a diferença sem codificar um erro de runtime como exemplo.
- **`#dynamic` é o caso-limite**: o nome é um valor, nenhuma análise estática decide. Tem de continuar `untyped` — uma correção que tipar esse chutou.

## Verificação

- `bundle exec rspec` — **1094 examples, 0 failures** (2 snapshots novos).
- `steep check` no dummy — **25 problemas / 13 arquivos**, o mesmo baseline: a forma é invisível para o checker, que é justamente o ponto.
- Classe simples, sem Active Record, então o fixture não precisa de tabela.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
