### PR TITLE
feat: resolve a receiver to its method's owner through `extend` (#208)

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -257,6 +257,14 @@ module RbsInfer
       end
     end
 
+    # A param whose default is the literal `nil` accepts nil however many
+    # non-nil arguments the call sites passed — the method's own default is a
+    # call site, and the one nobody writes down. Applied here, as soon as the
+    # inferred types are merged and before anything reads them, so the ivar it
+    # is assigned to and the setter it widens both see the nilable type
+    # (felixefelip/rbs_infer#208). Same rule `initialize` already follows above.
+    nilablize_nil_default_params(target_members, method_param_types)
+
     # An attr set from outside via `receiver.attr = value` (receiver typed
     # as this class) has no local write to infer from — but the setter is a
     # method, so the cross-class call-site inference above already typed its
@@ -320,6 +328,11 @@ module RbsInfer
     # obrigatoriedade e o formato dele — pergunta que só o Steep responde,
     # porque depende de qual sobrecarga se aplica (felixefelip/rbs_infer#149).
     resolve_forwarded_block_requirements(target_members)
+
+    # Um bloco que o corpo GUARDA numa ivar roda contra o `self` de quem o
+    # repassa depois (`base.class_eval(&@included_block)`) — de novo uma
+    # pergunta do callee, e de novo só o Steep responde (felixefelip/rbs_infer#208).
+    resolve_stored_block_self_types(target_members)
 
     # O que os blocos passados nos call-sites devolvem. É a metade do tipo do
     # bloco que o corpo do método não responde — ele recebe esse valor, não o
@@ -599,6 +612,29 @@ module RbsInfer
     end
   end
 
+  # `def included(base = nil)` says two things, and only one of them survives
+  # the call sites: they answer what a caller passes (`Module`), the default
+  # answers what the method gets when nobody passes anything (`nil`). Taking
+  # only the first emits `?Module base` for a body written around `base.nil?`,
+  # which then reads as dead code — and the default itself stops type-checking.
+  #
+  # Only touched once a type is there to widen: while the parameter is `untyped`
+  # the nil is already admitted, and `untyped?` is not a spelling.
+  def nilablize_nil_default_params(target_members, method_param_types)
+    target_members.each do |member|
+      next unless [:method, :class_method].include?(member.kind)
+      next if member.param_nil_defaults.nil? || member.param_nil_defaults.empty?
+
+      types = method_param_types[member.name] or next
+      member.param_nil_defaults.each do |param_name|
+        current = types[param_name]
+        next if current.nil? || current == "untyped"
+
+        types[param_name] = RbsInfer::Signatures::RbsParserUtil.nilablize(current)
+      end
+    end
+  end
+
   # A block's parameters are whatever the method PASSES to it, so the sites
   # that use the block are the evidence — and Steep has already typed those
   # expressions while checking the file. `authenticate` calls
@@ -660,6 +696,34 @@ module RbsInfer
       next unless requirement
 
       member.signature = RbsInfer::Signatures::RbsParserUtil.require_block(member.signature, requirement[:params])
+    end
+  end
+
+  # A block kept in an ivar is replayed later, and the replay decides what `self`
+  # is inside it — `base.class_eval(&@included_block)` runs the block against the
+  # includer. That binding belongs in the signature: a caller writing
+  # `included do … end` is writing a body against that `self`, and without it the
+  # stored proc cannot be handed to `class_eval` at all (felixefelip/rbs_infer#208).
+  #
+  # Only members the collector left stored, and only the binding — see
+  # `RbsParserUtil.bind_block_self` for what is deliberately not taken.
+  def resolve_stored_block_self_types(target_members)
+    return if @parsed_target.nil?
+
+    members = target_members.select do |m|
+      [:method, :class_method].include?(m.kind) && m.block_stored_forward
+    end
+    return if members.empty?
+
+    bindings = steep_bridge.stored_block_self_types(@parsed_target.source)
+    return if bindings.empty?
+
+    members.each do |member|
+      key = member.kind == :class_method ? "self.#{member.name}" : member.name
+      binding = bindings[key]
+      next unless binding
+
+      member.signature = RbsInfer::Signatures::RbsParserUtil.bind_block_self(member.signature, binding)
     end
   end
 

--- a/lib/rbs_infer/inference/class_member_collector.rb
+++ b/lib/rbs_infer/inference/class_member_collector.rb
@@ -22,7 +22,14 @@ module RbsInfer::Inference
   # `block_open_forward` = o corpo só repassa o bloco (`foo(&block)`), sem
   # chamá-lo nem testá-lo, então quem decide se ele é obrigatório é o callee —
   # também resolvido no Analyzer (#149).
-  Member = Struct.new(:kind, :name, :signature, :visibility, :owner, :value_node, :param_constant_defaults, :old_name, :singleton, :block_arg_positions, :block_open_forward, :overloading, keyword_init: true)
+  # `block_stored_forward` = o corpo GUARDA o bloco numa ivar (`@x = block`) em
+  # vez de usá-lo, então quem decide contra qual `self` ele foi escrito é quem o
+  # repassa depois — resolvido no Analyzer (#208).
+  # `param_nil_defaults` = nomes dos params opcionais cujo default é o literal
+  # `nil`. Enquanto o tipo é `untyped` não muda nada; quando os call-sites dão
+  # um tipo de verdade ao param, é o que faz o `?` do nilable aparecer junto —
+  # aplicado no Analyzer, onde o tipo inferido existe (#208).
+  Member = Struct.new(:kind, :name, :signature, :visibility, :owner, :value_node, :param_constant_defaults, :old_name, :singleton, :block_arg_positions, :block_open_forward, :overloading, :param_nil_defaults, :block_stored_forward, keyword_init: true)
 
   # Metadata extraída de uma chamada `delegate` — tipos são resolvidos depois no Analyzer
   DelegateInfo = Struct.new(:methods, :target, :prefix, :allow_nil, keyword_init: true)
@@ -147,8 +154,10 @@ module RbsInfer::Inference
         # Only when we synthesized the signature — an explicit `#:`/`@rbs`
         # annotation is authoritative and must not be overridden.
         param_constant_defaults: sig ? nil : extractor.constant_default_params,
+        param_nil_defaults: sig ? nil : extractor.nil_default_params,
         block_arg_positions: sig ? nil : extractor.block_arg_positions,
         block_open_forward: sig ? nil : extractor.block_open_forward?,
+        block_stored_forward: sig ? nil : extractor.block_stored_forward?,
         overloading: overloading
       )
       super

--- a/lib/rbs_infer/inference/class_member_collector/block_signature.rb
+++ b/lib/rbs_infer/inference/class_member_collector/block_signature.rb
@@ -68,7 +68,35 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
       block_param? && use_sites.empty? && forwards_block? && !guards_block?
     end
 
+    # True when the body STORES the block in an ivar instead of using it —
+    # `@included_block = block`, the `included do … end` mechanism in one line.
+    #
+    # A stored block outlives the call that brought it, so what it must BE is
+    # decided by whoever replays it later, not by anything here. The Analyzer
+    # goes looking for that too (felixefelip/rbs_infer#208), but for a different
+    # answer than `open_forward?` asks for: a block nobody calls yet cannot be
+    # required, and the store is the proof — it exists precisely so the call may
+    # never happen. Only the self BINDING transfers, and it must: a block written
+    # against one `self` cannot be swapped for a block written against another,
+    # while an argument it does not declare it can simply ignore.
+    #
+    # A call of its own still wins, same as above: `block.call(x)` says more
+    # about the block than any later replay does.
+    def stored_forward?
+      block_param? && use_sites.empty? && stores_block?
+    end
+
     private
+
+    # `@x = block` — the block leaving this method by being kept. An anonymous
+    # `&` has no name to read and so cannot be stored.
+    def stores_block?
+      name = block_param_name or return false
+
+      walk_body do |node|
+        node.is_a?(Prism::InstanceVariableWriteNode) && reads_block?(node.value, name)
+      end
+    end
 
     def required?
       (yields? || calls_block_param?) && !guards_block?

--- a/lib/rbs_infer/inference/class_member_collector/extract_params_signature.rb
+++ b/lib/rbs_infer/inference/class_member_collector/extract_params_signature.rb
@@ -10,6 +10,17 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
     # mirroring how `:constant` members defer (felixefelip/rbs_infer#37, #46).
     attr_reader :constant_default_params
 
+    # Optional params defaulting to a literal `nil`, by name. The signature says
+    # `?untyped` for them (see `optional_param_type`), and `untyped` swallows the
+    # nil — but the moment the call sites give the parameter a real type, the
+    # default stops being covered by it: `def included(base = nil)` called once
+    # with a `Module` would read `?Module base`, and calling it the way its own
+    # default invites binds `nil` to a parameter that does not admit one.
+    #
+    # Recorded rather than resolved, the same deferral `constant_default_params`
+    # makes: the type to widen does not exist yet here.
+    attr_reader :nil_default_params
+
     # Structural: constant defaults are captured into @constant_default_params and
     # emitted as `?untyped` for the Analyzer to fill, so this never resolves a
     # value-position constant itself (felixefelip/rbs_infer#56).
@@ -28,6 +39,12 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
       block_signature.open_forward?
     end
 
+    # Whether the block is STORED rather than used, which leaves its self
+    # binding to whoever replays it (felixefelip/rbs_infer#208).
+    def block_stored_forward?
+      block_signature.stored_forward?
+    end
+
     # `body` decides whether a block is required, and whether a method that only
     # `yield`s takes one at all — neither is visible from the parameters alone.
     def initialize(params, body: nil)
@@ -35,6 +52,7 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
       @body = body
       @parts = []
       @constant_default_params = {}
+      @nil_default_params = Set.new
     end
 
     def call
@@ -72,6 +90,11 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
         # `render :edit` fail with "Cannot pass ::Symbol as an argument of type nil".
         # Nothing is lost by widening: a parameter genuinely only ever passed nil is
         # degenerate, and `untyped` still admits it.
+        #
+        # What the default DOES say is that nil is a legal value, which matters again
+        # once a call site replaces this `untyped` with a real type — see
+        # `nil_default_params`.
+        @nil_default_params << param.name.to_s
         "untyped"
       else
         infer_node_type(value) || "untyped"
@@ -108,6 +131,7 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
         when Prism::RequiredKeywordParameterNode
           @parts << "#{p.name}: untyped"
         when Prism::OptionalKeywordParameterNode
+          @nil_default_params << p.name.to_s if p.value.is_a?(Prism::NilNode)
           @parts << "?#{p.name}: untyped"
         end
       end if @params.respond_to?(:keywords)

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -457,7 +457,8 @@ module RbsInfer::Inference
     end
 
     # Does the receiver reach the target's method through its ANCESTRY — a
-    # superclass, or a module it includes — rather than through its name?
+    # superclass, a module it includes, a module it extends — rather than
+    # through its name?
     #
     # `match_class?` and `owner_match?` above both compare NAMES, which is all the
     # sources can be asked. A receiver typed as the class that includes the target
@@ -478,12 +479,16 @@ module RbsInfer::Inference
     #
     # The RBS is also the only place that knows this — rbs_rails declares the
     # relation shapes and their `include`s in signatures, never in Ruby, so
-    # `MixinIndex` (built from the sources' `include`s) cannot answer it.
+    # `MixinIndex` (built from the sources' `include`s) cannot answer it. The
+    # same holds for the SINGLETON side, which `method_owner` reads off the
+    # same graph: `MixinIndex` records `include`/`prepend` and nothing else, so
+    # a receiver that reaches the target by `extend` has no other oracle
+    # (felixefelip/rbs_infer#208).
     def ancestry_match?(receiver_type, method_name)
       normalized_target = @target_class.sub(/\A::/, "")
 
       receiver_components(receiver_type).any? do |component|
-        owner = rbs_definition_resolver.instance_method_owner(component, method_name)
+        owner = rbs_definition_resolver.method_owner(component, method_name)
         owner && owner.sub(/\A::/, "") == normalized_target
       end
     end

--- a/lib/rbs_infer/signatures/rbs_definition_resolver.rb
+++ b/lib/rbs_infer/signatures/rbs_definition_resolver.rb
@@ -9,11 +9,11 @@ module RbsInfer::Signatures
     def initialize
       @rbs_builder = nil
       @rbs_builder_loaded = false
-      # Memo for `instance_method_owner`. Lives beside `@rbs_builder`, which is
+      # Memo for `method_owner`. Lives beside `@rbs_builder`, which is
       # fetched once per instance, so the cache can never outlive the environment
       # it was computed against — the invariant the README states for everything
       # derived from `SteepEnvironment`.
-      @instance_method_owners = {}
+      @method_owners = {}
     end
 
     def resolve_via_rbs_builder(kind, class_name, method_name, block_body_type: nil)
@@ -148,13 +148,30 @@ module RbsInfer::Signatures
       false
     end
 
-    def instance_method_owner(class_name, method_name)
+    # Which class or module OWNS the method a receiver of this type dispatches
+    # to — the answer RBS's ancestor graph gives, for a receiver that never
+    # spells the owner's name.
+    #
+    # Two chains, and the type says which: `Foo` is an instance, so the method
+    # comes from `Foo`'s ancestors; `singleton(Foo)` is the module object
+    # itself, whose methods come from `Foo`'s `def self.`s, from everything
+    # `Foo` EXTENDS, and from `Module`/`Object` behind them. RBS builds both
+    # (`AncestorBuilder#one_singleton_ancestors` is where `extended_modules`
+    # is threaded in), so the singleton side costs nothing more than asking
+    # `build_singleton` instead of `build_instance`.
+    #
+    # Without the singleton side every call site whose receiver reaches the
+    # target through `extend` is invisible: `mod.send(:included, self)` in the
+    # `Module#include` pseudo-code has a receiver typed as the includers'
+    # singletons, and a hand-rolled `included` hook is reached from one of them
+    # only by `extend` (felixefelip/rbs_infer#208).
+    def method_owner(type_str, method_name)
       return nil unless rbs_builder
 
-      key = [class_name, method_name]
-      return @instance_method_owners[key] if @instance_method_owners.key?(key)
+      key = [type_str, method_name]
+      return @method_owners[key] if @method_owners.key?(key)
 
-      @instance_method_owners[key] = compute_instance_method_owner(class_name, method_name)
+      @method_owners[key] = compute_method_owner(type_str, method_name)
     end
 
     def format_rbs_return_type(rbs_type, context_class = nil)
@@ -255,15 +272,33 @@ module RbsInfer::Signatures
       RBS::TypeName.parse(class_name).absolute!
     end
 
-    def compute_instance_method_owner(class_name, method_name)
-      type_name = build_rbs_type_name(class_name)
+    # `singleton(Foo)` has to be READ as a type rather than pattern-matched as a
+    # string: `RBS::TypeName.parse` happily digests the spelling into a namespace
+    # of `singleton(` and a name of `Foo)`, which no declaration answers to — a
+    # silent nil where the answer was available.
+    def compute_method_owner(type_str, method_name)
+      parsed = RBS::Parser.parse_type(type_str)
+
+      if parsed.is_a?(RBS::Types::ClassSingleton)
+        method_owner_in(parsed.name.absolute!, method_name, :singleton)
+      else
+        # The instance side keeps reading the STRING, unchanged: taking
+        # `parsed.name` here would also start answering for generic spellings
+        # (`Array[String]`), which this lookup has always declined.
+        method_owner_in(build_rbs_type_name(type_str), method_name, :instance)
+      end
+    rescue RBS::ParsingError, RBS::BaseError
+      nil
+    end
+
+    def method_owner_in(type_name, method_name, kind)
       return nil unless type_name
-      # A spelling that is not a class at all (`singleton(Foo)`, an alias) parses
-      # into a name no declaration answers to, which this lookup already rejects.
+      # A spelling no declaration answers to (an alias, a class this run has not
+      # seen) is rejected here rather than raised over.
       return nil unless rbs_builder.env.class_decls.key?(type_name)
 
-      member = rbs_builder.build_instance(type_name).methods[method_name.to_sym]
-      member&.defined_in&.to_s
+      definition = kind == :singleton ? rbs_builder.build_singleton(type_name) : rbs_builder.build_instance(type_name)
+      definition.methods[method_name.to_sym]&.defined_in&.to_s
     rescue RBS::BaseError
       nil
     end

--- a/lib/rbs_infer/signatures/rbs_parser_util.rb
+++ b/lib/rbs_infer/signatures/rbs_parser_util.rb
@@ -328,6 +328,25 @@ module RbsInfer::Signatures
       method_sig.sub(BLOCK_RETURN) { "#{Regexp.last_match[:open]}#{parenthesize_compound(type)}#{Regexp.last_match[:close]}" }
     end
 
+    # Binds `self` inside a method's block clause: `?{ (*untyped) -> untyped }`
+    # becomes `?{ (*untyped) [self: Module] -> untyped }`.
+    #
+    # Only the binding is added — not the `?`, and not the parameter list. A
+    # block the method merely STORED is one it may never call, so nothing here
+    # can make it required, and its arity stays whatever the body said
+    # (felixefelip/rbs_infer#208).
+    #
+    # A clause that already binds `self` is left alone: that binding came from a
+    # hand-written annotation, and an annotation is the authority.
+    BLOCK_SELF_BINDING = /(?<open>\??\{ \([^)]*\) )(?=->)/
+
+    def bind_block_self(method_sig, self_type)
+      return method_sig unless method_sig && usable_type?(self_type)
+      return method_sig if method_sig.include?("[self:")
+
+      method_sig.sub(BLOCK_SELF_BINDING) { "#{Regexp.last_match[:open]}[self: #{self_type}] " }
+    end
+
     # Turns the "I only forward it" block into the callee's own — required, and
     # shaped like whatever the callee declares (#149).
     #

--- a/lib/rbs_infer/signatures/steep_bridge.rb
+++ b/lib/rbs_infer/signatures/steep_bridge.rb
@@ -88,6 +88,10 @@ module RbsInfer::Signatures
       RbsInfer::Signatures::SteepBridge::BlockAnalyzer.new(steep_bridge: self).forwarded_block_requirements(source_code)
     end
 
+    def stored_block_self_types(source_code)
+      RbsInfer::Signatures::SteepBridge::BlockAnalyzer.new(steep_bridge: self).stored_block_self_types(source_code)
+    end
+
     def method_return_types(source_code)
       return_type_analyzer.method_return_types(source_code)
     end

--- a/lib/rbs_infer/signatures/steep_bridge/block_analyzer.rb
+++ b/lib/rbs_infer/signatures/steep_bridge/block_analyzer.rb
@@ -38,6 +38,54 @@ class RbsInfer::Signatures::SteepBridge
       end
     end
 
+    # Methods that STORE their block in an ivar, mapped to the `self` the block
+    # will run against when that ivar is finally handed on:
+    #
+    #   { "included" => "Module" }
+    #
+    # `included(&block)` keeps the block and `base.class_eval(&@included_block)`
+    # replays it, and `class_eval` declares `{ (self m) [self: self] -> U }` — so
+    # the block's body was written against the includer, not against the module
+    # that stored it. Nothing in the storing method says that; the callee does,
+    # and only the checker can say which callee a call resolves to
+    # (felixefelip/rbs_infer#208).
+    #
+    # Just the binding. The callee's block PARAMETERS are what it will pass, and
+    # a block may always ignore what it is passed — the arity here is the storing
+    # method's `*untyped`, honestly unknown. (It is also the shape that survives
+    # union: `mod.send(:included, self)` has a receiver typed as every includer's
+    # singleton at once, and merging their `included`s needs block parameter
+    # lists that intersect. `*untyped` intersects with `ActiveSupport::Concern`'s
+    # `()`, `(Module)` intersects with nothing, and the method drops out of the
+    # union's shape entirely.)
+    #
+    # The two halves are joined by the IVAR, not by the method: the slot is what
+    # the block lives in, and the method that stores it and the one that replays
+    # it are routinely different (`included` stores, an `append_features` replays).
+    # Keys as above: `name`, or `self.name` for singletons.
+    def stored_block_self_types(source_code)
+      typing = @steep_bridge.type_check(source_code)
+      return {} unless typing
+
+      stores = Hash.new { |hash, key| hash[key] = Set.new } # method key → ivar names it stores into
+      sites = Hash.new { |hash, key| hash[key] = [] }       # ivar name → the calls it is handed to
+      walk_stored_blocks(typing.source.node, nil, nil, false, stores, sites)
+
+      bindings = sites.transform_values do |send_nodes|
+        found = send_nodes.filter_map { |send_node| callee_block_self_type(typing, send_node) }.uniq
+        # Sites that disagree say nothing: a block cannot have been written
+        # against two different `self`s.
+        found.first if found.size == 1
+      end
+
+      result = {}
+      stores.each do |method_key, ivars|
+        answers = ivars.filter_map { |ivar| bindings[ivar] }.uniq
+        result[method_key] = answers.first if answers.size == 1
+      end
+      result
+    end
+
     private
 
     # Yields `[send_node, method_key]` for every call that receives a
@@ -72,6 +120,86 @@ class RbsInfer::Signatures::SteepBridge
       end
 
       node.children.each { |child| walk_forwarded_blocks(child, method_key, singleton, &block) }
+    end
+
+    # Both halves of the store in one walk: `@x = block` (which method fills the
+    # slot) and `foo(&@x)` (where the slot's contents go). Gathered separately
+    # and matched afterwards, because the source may write them in either order
+    # — the hand-rolled `included` stores in one branch of an `if` and replays in
+    # the other.
+    #
+    # The method key and the block's parameter name are threaded the way
+    # `walk_forwarded_blocks` threads its key: a nested `def` rebinds both, so
+    # nothing inside it is attributed to the method it sits in.
+    def walk_stored_blocks(node, method_key, block_param, singleton, stores, sites)
+      return unless node.is_a?(Parser::AST::Node)
+
+      case node.type
+      when :def
+        method_key = singleton ? "self.#{node.children[0]}" : node.children[0].to_s
+        block_param = block_param_name(node.children[1])
+      when :defs
+        method_key = "self.#{node.children[1]}"
+        block_param = block_param_name(node.children[2])
+      when :sclass
+        singleton = true
+      when :ivasgn
+        value = node.children[1]
+        if method_key && block_param && value.is_a?(Parser::AST::Node) &&
+           value.type == :lvar && value.children[0].to_s == block_param
+          stores[method_key] << node.children[0].to_s
+        end
+      when :send, :csend
+        ivar = node.children.filter_map { |child| passed_ivar(child) }.first
+        sites[ivar] << node if ivar
+      end
+
+      node.children.each { |child| walk_stored_blocks(child, method_key, block_param, singleton, stores, sites) }
+    end
+
+    # The name of the `&block` parameter in an `args` node, or nil when the
+    # method takes none — or takes an anonymous `&`, which cannot be stored.
+    def block_param_name(args)
+      return nil unless args.is_a?(Parser::AST::Node)
+
+      blockarg = args.children.find { |child| child.is_a?(Parser::AST::Node) && child.type == :blockarg }
+      blockarg&.children&.first&.to_s
+    end
+
+    # `&@x` — the ivar's name, when the argument is an ivar handed on as a block.
+    def passed_ivar(node)
+      return nil unless node.is_a?(Parser::AST::Node) && node.type == :block_pass
+
+      inner = node.children[0]
+      inner&.type == :ivar ? inner.children[0].to_s : nil
+    end
+
+    # What the callee binds `self` to inside the block it receives, as a type
+    # string, or nil when it binds nothing (or the declarations disagree).
+    def callee_block_self_type(typing, send_node)
+      call = typing.call_of(node: send_node)
+      decls = call.respond_to?(:method_decls) ? call.method_decls.to_a : []
+      return nil if decls.empty?
+
+      bindings = decls.map { |decl| block_self_binding(typing, send_node, decl.method_type.block) }.uniq
+      bindings.size == 1 ? bindings.first : nil
+    rescue StandardError
+      nil
+    end
+
+    # `class_eval` declares `[self: self]`, and `self` there is the RECEIVER —
+    # the one thing a declaration cannot spell, so it is read off the call.
+    def block_self_binding(typing, send_node, block)
+      self_type = block&.self_type or return nil
+
+      if self_type.is_a?(RBS::Types::Bases::Self)
+        receiver = send_node.children[0] or return nil
+        self_type = typing.type_of(node: receiver) rescue nil
+        return nil unless self_type
+      end
+
+      formatted = RbsInfer::Signatures::SteepBridge::TypeFormatter.format_type(self_type)
+      formatted unless formatted == "untyped" || formatted == "bot" || formatted == "void"
     end
 
     # The block the callee declares, as `[param types]`, or `:unknown` when it

--- a/spec/dummy/sig/rbs_infer/app/models/included_hook/home_made.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/included_hook/home_made.rbs
@@ -1,7 +1,7 @@
 class IncludedHook
   module HomeMade
-    @included_block: ^(*untyped) -> untyped?
+    @included_block: ^(*untyped) [self: Module] -> untyped?
 
-    def included: (?untyped base) ?{ (*untyped) -> untyped } -> nil
+    def included: (?Module? base) ?{ (*untyped) [self: Module] -> untyped } -> nil
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/included_hook/shared.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/included_hook/shared.rbs
@@ -1,6 +1,6 @@
 class IncludedHook
   module Shared
-    def self.included: (untyped base) -> untyped
+    def self.included: (Module base) -> Symbol
 
     def from_shared: () -> Integer
   end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/edit.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/edit.rbs
@@ -5,7 +5,7 @@ class ERBPostsEdit
   include PostsHelper
 
   def initialize: (post: Post & ::Post::Validated) -> void
-  def render: (?{ partial: String, locals: { post: Post & Post::Validated } } target, *untyped rest) -> nil
+  def render: (?{ partial: String, locals: { post: Post & Post::Validated } }? target, *untyped rest) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/new.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/new.rbs
@@ -5,7 +5,7 @@ class ERBPostsNew
   include PostsHelper
 
   def initialize: (post: Post) -> void
-  def render: (?{ partial: String, locals: { post: Post } } target, *untyped rest) -> nil
+  def render: (?{ partial: String, locals: { post: Post } }? target, *untyped rest) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/show.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/show.rbs
@@ -6,7 +6,7 @@ class ERBPostsShow
   include PostsHelper
 
   def initialize: (comments: Comment::ActiveRecord_Relation, post: Post & ::Post::Validated) -> void
-  def render: (?({ partial: String, locals: { comment: (Comment & Comment::Validated) } } | String) target, *{ post: Post & Post::Validated } rest) -> nil
+  def render: (?({ partial: String, locals: { comment: (Comment & Comment::Validated) } } | String)? target, *{ post: Post & Post::Validated } rest) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/dashboard_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/dashboard_controller.rbs
@@ -1,7 +1,7 @@
 class DashboardController
   @__rbs_infer__performed: true?
 
-  def render: (?Symbol target, *untyped rest) -> bool
+  def render: (?Symbol? target, *untyped rest) -> bool
 
   private
 

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/posts_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/posts_controller.rbs
@@ -1,7 +1,7 @@
 class PostsController
   @__rbs_infer__performed: true?
 
-  def render: (?Symbol target, *{ status: Symbol } rest) -> bool
+  def render: (?Symbol? target, *{ status: Symbol } rest) -> bool
 
   private
 

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/users_avatars_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/users_avatars_controller.rbs
@@ -2,7 +2,7 @@ module Users
   class AvatarsController
     @__rbs_infer__performed: true?
 
-    def render: (?Symbol target, *{ status: Symbol } rest) -> bool
+    def render: (?Symbol? target, *{ status: Symbol } rest) -> bool
 
     private
 

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/users_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/users_controller.rbs
@@ -1,7 +1,7 @@
 class UsersController
   @__rbs_infer__performed: true?
 
-  def render: (?(Symbol | String) target, *untyped rest) -> bool
+  def render: (?(Symbol | String)? target, *untyped rest) -> bool
 
   private
 

--- a/spec/expectations/steep_actionview_runtime/posts/edit.rbs
+++ b/spec/expectations/steep_actionview_runtime/posts/edit.rbs
@@ -5,7 +5,7 @@ class ERBPostsEdit
   include PostsHelper
 
   def initialize: (post: Post & ::Post::Validated) -> void
-  def render: (?{ partial: String, locals: { post: Post & Post::Validated } } target, *untyped rest) -> nil
+  def render: (?{ partial: String, locals: { post: Post & Post::Validated } }? target, *untyped rest) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/expectations/steep_actionview_runtime/posts/new.rbs
+++ b/spec/expectations/steep_actionview_runtime/posts/new.rbs
@@ -5,7 +5,7 @@ class ERBPostsNew
   include PostsHelper
 
   def initialize: (post: Post) -> void
-  def render: (?{ partial: String, locals: { post: Post } } target, *untyped rest) -> nil
+  def render: (?{ partial: String, locals: { post: Post } }? target, *untyped rest) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/expectations/steep_actionview_runtime/posts/show.rbs
+++ b/spec/expectations/steep_actionview_runtime/posts/show.rbs
@@ -6,7 +6,7 @@ class ERBPostsShow
   include PostsHelper
 
   def initialize: (comments: Comment::ActiveRecord_Relation, post: Post & ::Post::Validated) -> void
-  def render: (?({ partial: String, locals: { comment: (Comment & Comment::Validated) } } | String) target, *{ post: Post & Post::Validated } rest) -> nil
+  def render: (?({ partial: String, locals: { comment: (Comment & Comment::Validated) } } | String)? target, *{ post: Post & Post::Validated } rest) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/expectations/steep_controller_runtime/dashboard_controller.rbs
+++ b/spec/expectations/steep_controller_runtime/dashboard_controller.rbs
@@ -1,7 +1,7 @@
 class DashboardController
   @__rbs_infer__performed: true?
 
-  def render: (?Symbol target, *untyped rest) -> bool
+  def render: (?Symbol? target, *untyped rest) -> bool
 
   private
 

--- a/spec/expectations/steep_controller_runtime/posts_controller.rbs
+++ b/spec/expectations/steep_controller_runtime/posts_controller.rbs
@@ -1,7 +1,7 @@
 class PostsController
   @__rbs_infer__performed: true?
 
-  def render: (?Symbol target, *{ status: Symbol } rest) -> bool
+  def render: (?Symbol? target, *{ status: Symbol } rest) -> bool
 
   private
 

--- a/spec/expectations/steep_controller_runtime/users_avatars_controller.rbs
+++ b/spec/expectations/steep_controller_runtime/users_avatars_controller.rbs
@@ -2,7 +2,7 @@ module Users
   class AvatarsController
     @__rbs_infer__performed: true?
 
-    def render: (?Symbol target, *{ status: Symbol } rest) -> bool
+    def render: (?Symbol? target, *{ status: Symbol } rest) -> bool
 
     private
 

--- a/spec/expectations/steep_controller_runtime/users_controller.rbs
+++ b/spec/expectations/steep_controller_runtime/users_controller.rbs
@@ -1,7 +1,7 @@
 class UsersController
   @__rbs_infer__performed: true?
 
-  def render: (?(Symbol | String) target, *untyped rest) -> bool
+  def render: (?(Symbol | String)? target, *untyped rest) -> bool
 
   private
 

--- a/spec/lib/rbs_infer/analyzer_spec.rb
+++ b/spec/lib/rbs_infer/analyzer_spec.rb
@@ -1620,7 +1620,7 @@ RSpec.describe RbsInfer::Analyzer do
 
       rbs = described_class.new(target_class: "Reopened", target_file: target, source_files: Dir["app/*.rb"]).generate_rbs
 
-      expect(rbs).to include("def handle: (?Symbol target")
+      expect(rbs).to include("def handle: (?Symbol? target")
     end
 
     # The target's OWN file is already covered by IntraClassCallAnalyzer. Counting it

--- a/spec/lib/rbs_infer/inference/extend_call_site_spec.rb
+++ b/spec/lib/rbs_infer/inference/extend_call_site_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rbs_infer"
+require "tmpdir"
+require "fileutils"
+
+# A receiver reaches a module's methods two ways, and only one of them was readable.
+# `include` puts them on the instances, and `ancestry_match?` (felixefelip/rbs_infer#131)
+# already asked RBS who owns a method on an instance type. `extend` puts them on the
+# module OBJECT, whose type is `singleton(Host)` — a spelling the owner lookup digested
+# into a name no declaration answers to, so every such call site was dropped and the
+# module's parameters stayed `untyped` (felixefelip/rbs_infer#208).
+#
+# The call site that made it matter is the `Module#include` pseudo-code's
+# `mod.send(:included, self)`: `mod` is typed as the includers' singletons, and a
+# hand-rolled `included` hook sits on one of them only by `extend`.
+RSpec.describe "a call site reaching the target through extend" do
+  around do |ex|
+    Dir.mktmpdir { |dir| Dir.chdir(dir) { ex.run } }
+  end
+  before { RbsInfer::Signatures::RbsTypeLookup.reset! }
+
+  def write(path, content)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+    path
+  end
+
+  # The RBS is the previous pass's output — the state the stabilization loop reaches after
+  # one round, and the only place the `extend` is written down in a form the ancestor
+  # graph can walk.
+  def write_signatures
+    write("sig/generated/mixin.rbs", "module Mixin\n  def notify: (untyped target) -> untyped\nend\n")
+    write("sig/generated/host.rbs", "class Host\n  extend Mixin\nend\n")
+  end
+
+  it "types the parameter from a receiver typed as the extending class's singleton" do
+    target = write("app/mixin.rb", <<~RUBY)
+      module Mixin
+        def notify(target)
+          target
+        end
+      end
+    RUBY
+    write("app/host.rb", "class Host\n  extend Mixin\nend\n")
+    write("app/caller.rb", <<~RUBY)
+      class Caller
+        def run
+          klass = Host
+          klass.notify("hi")
+        end
+      end
+    RUBY
+    write_signatures
+
+    rbs = RbsInfer::Analyzer.new(target_class: "Mixin", target_file: target, source_files: Dir["app/*.rb"]).generate_rbs
+
+    expect(rbs).to include("def notify: (String target) ->")
+  end
+
+  # The receiver's type is what decides, not the method's name: `singleton(Host)` reaches
+  # `Mixin` only because `Host` extends it. A class that does not gives nothing away.
+  it "leaves the parameter untyped when the receiver's singleton does not reach the target" do
+    target = write("app/mixin.rb", <<~RUBY)
+      module Mixin
+        def notify(target)
+          target
+        end
+      end
+    RUBY
+    write("app/host.rb", "class Host\nend\n")
+    write("app/caller.rb", <<~RUBY)
+      class Caller
+        def run
+          klass = Host
+          klass.notify("hi")
+        end
+      end
+    RUBY
+    write("sig/generated/mixin.rbs", "module Mixin\n  def notify: (untyped target) -> untyped\nend\n")
+    write("sig/generated/host.rbs", "class Host\nend\n")
+
+    rbs = RbsInfer::Analyzer.new(target_class: "Mixin", target_file: target, source_files: Dir["app/*.rb"]).generate_rbs
+
+    expect(rbs).to include("def notify: (untyped target) ->")
+  end
+end

--- a/spec/lib/rbs_infer/inference/nil_default_param_spec.rb
+++ b/spec/lib/rbs_infer/inference/nil_default_param_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rbs_infer"
+require "tmpdir"
+require "fileutils"
+require_relative "../../../support/temp_file_helpers"
+
+# `def render(target = nil)` has one call site nobody writes: the default. Call sites
+# answer what a caller passes, the default answers what the method gets when nobody
+# passes anything, and taking only the first emitted `?String target` for a parameter
+# whose own declaration binds it to nil (felixefelip/rbs_infer#208).
+#
+# `initialize` already followed this rule (its nil defaults are widened alongside the
+# call-site types); every other method did not, and only stayed sound because those
+# parameters were `untyped` — which admits nil — until a call site typed them.
+RSpec.describe "a parameter defaulting to nil" do
+  include TempFileHelpers
+
+  def rbs_for(target_body, run_body)
+    with_temp_files(
+      "notifier.rb" => "class Notifier\n#{target_body}\nend\n",
+      "caller.rb" => "class Caller\n  def run\n#{run_body}\n  end\nend\n"
+    ) do |_dir, paths|
+      target_path = paths.find { |p| File.basename(p) == "notifier.rb" }
+      RbsInfer::Analyzer.new(target_file: target_path, source_files: paths).generate_rbs
+    end
+  end
+
+  it "stays nilable however non-nil every call site is" do
+    rbs = rbs_for(
+      "  def notify(message = nil)\n    message\n  end",
+      "    Notifier.new.notify(\"hi\")"
+    )
+
+    expect(rbs).to include("def notify: (?String? message) ->")
+  end
+
+  it "applies to a keyword default too" do
+    rbs = rbs_for(
+      "  def notify(message: nil)\n    message\n  end",
+      "    Notifier.new.notify(message: \"hi\")"
+    )
+
+    expect(rbs).to include("def notify: (?message: String?) ->")
+  end
+
+  # A default that is not nil says nothing about nil, and the parameter keeps exactly
+  # what the call sites gave it.
+  it "leaves a non-nil default alone" do
+    rbs = rbs_for(
+      "  def notify(message = \"\")\n    message\n  end",
+      "    Notifier.new.notify(\"hi\")"
+    )
+
+    expect(rbs).to include("def notify: (?String message) ->")
+  end
+
+  # Nothing to widen while the parameter is `untyped`: it already admits nil, and
+  # `untyped?` is not a spelling.
+  it "leaves an untyped parameter alone" do
+    rbs = rbs_for(
+      "  def notify(message = nil)\n    message\n  end",
+      "    Notifier.new"
+    )
+
+    expect(rbs).to include("def notify: (?untyped message) ->")
+  end
+end

--- a/spec/lib/rbs_infer/inference/splat_param_inference_spec.rb
+++ b/spec/lib/rbs_infer/inference/splat_param_inference_spec.rb
@@ -60,13 +60,15 @@ RSpec.describe "rest parameter inference" do
     expect(rbs).to include("def deliver: (String subject, *String bodies) ->")
   end
 
+  # `?String?`, not `?String`: the `= nil` default is a call site nobody writes, and it
+  # passes nil (felixefelip/rbs_infer#208).
   it "keeps an optional before the splat separate from it" do
     rbs = with_caller(
       "  def only_optional(first = nil, *rest)\n    [first, rest]\n  end",
       "    Notifier.new.only_optional(\"a\", 1, 2)"
     )
 
-    expect(rbs).to include("def only_optional: (?String first, *Integer rest) ->")
+    expect(rbs).to include("def only_optional: (?String? first, *Integer rest) ->")
   end
 
   # Keywords are matched by name, and the splat does not eat them: `mode:` still lands on

--- a/spec/lib/rbs_infer/inference/stored_block_self_spec.rb
+++ b/spec/lib/rbs_infer/inference/stored_block_self_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rbs_infer"
+require "tmpdir"
+require "fileutils"
+
+# A block a method KEEPS is not a block it runs. `included do … end` stores one and
+# `base.class_eval(&@included_block)` replays it later, against the includer — so the
+# body a caller writes inside that block is written against a `self` the storing method
+# never mentions. `Module#class_eval` declares it (`{ (self m) [self: self] -> U }`), and
+# without the binding in the signature the stored proc cannot be handed to `class_eval`
+# at all: `Ruby::BlockTypeMismatch` (felixefelip/rbs_infer#208).
+RSpec.describe "a block stored in an ivar" do
+  around do |ex|
+    Dir.mktmpdir { |dir| Dir.chdir(dir) { ex.run } }
+  end
+  before { RbsInfer::Signatures::RbsTypeLookup.reset! }
+
+  def write(path, content)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+    path
+  end
+
+  # The `included do … end` mechanism in one method: no argument stores the block, an
+  # argument replays it. The RBS is the previous pass's — the replay's receiver has to be
+  # typed before there is a callee to ask, which is the order the stabilization loop
+  # already converges in.
+  it "takes its self binding from the call that replays it" do
+    target = write("app/hookable.rb", <<~RUBY)
+      module Hookable
+        def hook(mod = nil, &block)
+          if mod.nil?
+            @hook_block = block
+          else
+            mod.class_eval(&@hook_block) if @hook_block
+          end
+
+          nil
+        end
+      end
+    RUBY
+    write("sig/generated/hookable.rbs", <<~RBS)
+      module Hookable
+        @hook_block: ^(*untyped) -> untyped?
+
+        def hook: (?Module? mod) ?{ (*untyped) -> untyped } -> nil
+      end
+    RBS
+
+    rbs = RbsInfer::Analyzer.new(target_class: "Hookable", target_file: target, source_files: [target]).generate_rbs
+
+    expect(rbs).to include("?{ (*untyped) [self: Module] -> untyped }")
+  end
+
+  # Store and replay are routinely written in different methods — the ivar is the slot
+  # that joins them, not the method.
+  it "joins the store and the replay through the ivar, not the method" do
+    target = write("app/hookable.rb", <<~RUBY)
+      module Hookable
+        def hook(&block)
+          @hook_block = block
+        end
+
+        def replay(mod)
+          mod.class_eval(&@hook_block) if @hook_block
+        end
+      end
+    RUBY
+    write("sig/generated/hookable.rbs", <<~RBS)
+      module Hookable
+        @hook_block: ^(*untyped) -> untyped?
+
+        def hook: () ?{ (*untyped) -> untyped } -> untyped
+        def replay: (Module mod) -> untyped
+      end
+    RBS
+
+    rbs = RbsInfer::Analyzer.new(target_class: "Hookable", target_file: target, source_files: [target]).generate_rbs
+
+    expect(rbs).to include("def hook: () ?{ (*untyped) [self: Module] -> untyped }")
+  end
+
+  # The binding comes from a callee that declares one. A method that hands the block to
+  # something with no `[self:]` in its signature has nothing to say, and says nothing —
+  # the arity stays the storing method's `*untyped` either way, because a block may
+  # always ignore what it is passed.
+  it "adds nothing when the replay's callee binds no self" do
+    target = write("app/hookable.rb", <<~RUBY)
+      module Hookable
+        def hook(items = nil, &block)
+          if items.nil?
+            @hook_block = block
+          else
+            items.each(&@hook_block) if @hook_block
+          end
+
+          nil
+        end
+      end
+    RUBY
+
+    rbs = RbsInfer::Analyzer.new(target_class: "Hookable", target_file: target, source_files: [target]).generate_rbs
+
+    expect(rbs).not_to include("[self:")
+  end
+end


### PR DESCRIPTION
Closes #208.

## The gap

`ancestry_match?` (rbs_infer#131) asks RBS who owns the method a receiver dispatches to, which is how a call site whose receiver never spells the target's name still counts. It only ever worked for an INSTANCE type: a `singleton(Foo)` spelling went through `RBS::TypeName.parse`, which digests it into a namespace of `singleton(` and a name of `Foo)` — a name no declaration answers to, so the lookup returned nil and the call site was dropped.

The call site that matters is the one the `Module#include` pseudo-code writes:

```ruby
modules.reverse_each do |mod|
  mod.send(:append_features, self)
  mod.send(:included, self)
end
```

`mod` types as the union of the includers' singletons, and a hand-rolled `included` hook sits on one of them only because that module `extend`s it — `extend` feeds nothing into the `include`-based `MixinIndex`, and the RBS ancestor graph is the only oracle for it.

`RbsDefinitionResolver#method_owner` (was `instance_method_owner`) now reads the type rather than the string, and walks the singleton chain when the type is one. `AncestorBuilder#one_singleton_ancestors` already threads `extended_modules` through, so `build_singleton` is the whole implementation.

## The two things the narrowing needed

Both were measured in the issue; the first is useless without the second.

**A `= nil` default keeps the parameter nilable.** The default is a call site nobody writes: call sites answer what a caller passes, the default answers what the method gets when nobody passes anything. `?Module base` for a body written around `base.nil?` reads as dead code, and the default itself stops type-checking. `initialize` already followed this rule; now every method does — that is what moves `render`'s `target` in the controller/view runtime sidecars.

**A block stored in an ivar gets its self binding from the replay.** `base.class_eval(&@included_block)` declares `{ (self m) [self: self] -> U }`, so the block was written against the includer. Without the binding the stored proc cannot be passed to `class_eval` at all — `Ruby::BlockTypeMismatch`, exactly the warning the issue measured as the cost of half one.

Only the binding transfers, not the parameter list: a block may always ignore an argument it does not declare, but not a `self` it was not written against. (Measured, too: declaring `(Module)` makes `included`'s method types un-mergeable across the includers' singletons — `ActiveSupport::Concern#included` declares `()` — and the method drops out of the union's shape entirely, turning `mod.send(:included, self)` into `Ruby::UnresolvedSend`. `*untyped` intersects with both.)

```rbs
class IncludedHook
  module HomeMade
    @included_block: ^(*untyped) [self: Module] -> untyped?

    def included: (?Module? base) ?{ (*untyped) [self: Module] -> untyped } -> nil
  end
end
```

`IncludedHook::Shared.included` gains the same `base` from the same resolution, and a real return type with it (`class_eval` over a `def` returns a Symbol).

## Measurements

- `steep check` on the dummy: **31 problems before, 31 after** — the narrowing costs nothing. (37 in a working tree that also has the untracked `app/models/example22.rb`; those 6 are that file's, unrelated.)
- Snapshot diff is `render`'s `target` gaining `?` in seven runtime sidecars, plus the two `included_hook` signatures.
- Whole suite green (1143 examples).

## Still open

A CONSTANT receiver (`Host.notify(…)`, where `notify` comes from `extend`) is not covered: `resolve_receiver_type` returns the bare class name for it, which is indistinguishable from an instance type at the point of the lookup. Worth its own issue rather than a guess here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)