### PR TITLE
fix: a nested module is not a namespace wrapper's spare part

### DIFF
--- a/lib/rbs_infer/ast/target_discovery.rb
+++ b/lib/rbs_infer/ast/target_discovery.rb
@@ -25,13 +25,16 @@ module RbsInfer::AST
   #   constant receiver. These reopen `Receiver` to mix in `Mod`; there is
   #   no class body to analyze, so the core synthesizes a reopen block.
   class TargetDiscovery < Prism::Visitor
-    attr_reader :declaration_targets, :include_targets, :declarations
+    attr_reader :include_targets, :declarations
 
     def initialize
       # Enclosing declaration names, outermost first — qualifies nested
       # targets. Blocks don't push, so it doubles as the depth counter.
       @namespace = []
-      @declaration_targets = []
+      # Source order, each `{ name:, is_module:, namespace: }`. `namespace` marks
+      # a wrapper kept only in case it turns out to be the only home a nested
+      # module has — see `declaration_targets`.
+      @targets = []
       # Every type the file declares, qualified name => is_module. Unlike
       # `declaration_targets` this keeps namespace wrappers and nested
       # modules: it answers "what kind is X?", not "what should we emit?".
@@ -59,6 +62,22 @@ module RbsInfer::AST
       super
     end
 
+    # The types to emit, in source order.
+    #
+    # A namespace wrapper hosting a nested module is in the list only when the
+    # file has a target of its own. The nested module is emitted inside its
+    # enclosing target's block and nowhere else, so with a sibling class in the
+    # file — `class C; module Foo; …; end; class Bar; end; end` — dropping the
+    # wrapper dropped `Foo` with it and the file emitted `C::Bar` alone. With no
+    # other target the file takes the single-target path, which already lands
+    # on the wrapper via
+    # `ClassNameExtractor`, and adding it here would only flatten that nesting.
+    def declaration_targets
+      real = @targets.reject { |t| t[:namespace] }
+      chosen = real.empty? ? real : @targets
+      chosen.map { |t| { name: t[:name], is_module: t[:is_module] } }
+    end
+
     private
 
     def nest(node)
@@ -79,7 +98,8 @@ module RbsInfer::AST
     end
 
     def record_declaration(node, is_module:)
-      return if namespace_wrapper?(node)
+      wrapper = namespace_wrapper?(node)
+      return if wrapper && !hosts_orphan_module?(node)
 
       name = RbsInfer::Analyzer.extract_constant_path(node.constant_path)
       return unless name && !name.empty?
@@ -96,9 +116,17 @@ module RbsInfer::AST
       # Latent while no fixture reopened a class twice in a single file; the
       # `class_eval` desugaring makes it the normal case, since it emits a `class X`
       # beside the one the file already writes.
-      return if @declaration_targets.any? { |t| t[:name] == qualified }
+      return if @targets.any? { |t| t[:name] == qualified }
 
-      @declaration_targets << { name: qualified, is_module: is_module }
+      @targets << { name: qualified, is_module: is_module, namespace: wrapper }
+    end
+
+    # A module declared directly in `node`'s body that is not itself a pure
+    # namespace — so it has members, and the owner mechanism has to write them
+    # into `node`'s block because a nested module is never a target of its own.
+    # That is what makes an otherwise droppable wrapper worth keeping.
+    def hosts_orphan_module?(node)
+      node.body.body.any? { |stmt| stmt.is_a?(Prism::ModuleNode) && !namespace_wrapper?(stmt) }
     end
 
     # A declaration whose body is nothing but other class/module declarations

--- a/spec/dummy/app/models/example22.rb
+++ b/spec/dummy/app/models/example22.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# A nested module SIDE BY SIDE with a nested class, in a body that declares
+# nothing else. That combination is what used to lose `Foo` entirely.
+#
+# `TargetDiscovery` drops a declaration whose body is only other declarations —
+# a pure namespace has no members of its own, and each nested class is emitted
+# as a target in its own right. A nested MODULE is not: it is excluded from the
+# targets on purpose, because the `owner` mechanism writes it inside its
+# enclosing target's block. So dropping `Example22` dropped the only block
+# `Foo` could ever be written into, and the file emitted `Example22::Bar`
+# alone.
+#
+# It takes both halves to show it: without `Bar` nothing in the file is a
+# target, and the single-target path lands on `Example22` anyway; with a member
+# of its own `Example22` stops being a namespace and stays a target. Neither
+# spelling reaches the case.
+#
+# The bodies are the `extend` shape on purpose — `Bar.bazingado`'s `super`
+# resolves through `extend Example22::Foo` into the module, which only works
+# while `Foo` is emitted.
+class Example22
+  module Foo
+    def bazinga(module_included)
+      module_included.bazingado(self)
+    end
+
+    def bazingado(base_foo)
+      base_foo.log_something("bazingado")
+    end
+  end
+
+  class Bar
+    extend Example22::Foo
+
+    def self.bazingado(base_foo)
+      super
+
+      base_foo.log_something("bazingado bar")
+    end
+
+    def self.log_something(message)
+      puts message
+    end
+  end
+end

--- a/spec/dummy/sig/rbs_infer/app/models/example22.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example22.rbs
@@ -1,0 +1,15 @@
+class Example22
+  module Foo
+    def bazinga: (untyped module_included) -> untyped
+    def bazingado: (untyped base_foo) -> untyped
+  end
+end
+
+class Example22
+  class Bar
+    extend ::Example22::Foo
+
+    def self.bazingado: (untyped base_foo) -> untyped
+    def self.log_something: (untyped message) -> nil
+  end
+end

--- a/spec/expectations/models/example22.rbs
+++ b/spec/expectations/models/example22.rbs
@@ -1,0 +1,15 @@
+class Example22
+  module Foo
+    def bazinga: (untyped module_included) -> untyped
+    def bazingado: (untyped base_foo) -> untyped
+  end
+end
+
+class Example22
+  class Bar
+    extend ::Example22::Foo
+
+    def self.bazingado: (untyped base_foo) -> untyped
+    def self.log_something: (untyped message) -> nil
+  end
+end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -555,6 +555,28 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     expect(rbs.chomp).to eq(expected_rbs(name).chomp)
   end
 
+  # A nested module beside a nested class, in a body that declares nothing else.
+  # `TargetDiscovery` dropped `Example22` as a pure namespace, and with it the
+  # only block `Foo` is ever written into — the file emitted `Example22::Bar`
+  # alone, so `Bar.bazingado`'s `super` had no `extend`ed module to reach.
+  # Neither half shows it on its own: drop `Bar` and nothing in the file is a
+  # target, so the single-target path lands on `Example22` anyway.
+  it "example22" do
+    name = "models/example22"
+    rbs = RbsInfer::Analyzer.new(
+      target_file: "app/models/example22.rb",
+      source_files: source_files
+    ).generate_rbs
+
+    if ENV["UPDATE_EXPECTATIONS"]
+      path = expectations_dir.join("#{name}.rbs")
+      path.dirname.mkpath
+      path.write(rbs)
+    end
+
+    expect(rbs.chomp).to eq(expected_rbs(name).chomp)
+  end
+
   it "example20" do
     name = "models/example20"
     rbs = RbsInfer::Analyzer.new(

--- a/spec/lib/rbs_infer/ast/target_discovery_spec.rb
+++ b/spec/lib/rbs_infer/ast/target_discovery_spec.rb
@@ -186,6 +186,71 @@ RSpec.describe RbsInfer::AST::TargetDiscovery do
     ])
   end
 
+  # A nested module is emitted inside its enclosing target's block and nowhere
+  # else, so a wrapper hosting one is the only home it has. Dropping the
+  # wrapper because "it has no members of its own" dropped `Foo` with it, and
+  # the file emitted `Example22::Bar` alone.
+  it "keeps a namespace wrapper that is a nested module's only home" do
+    d = discover(<<~RUBY)
+      class Example22
+        module Foo
+          def bazinga; end
+        end
+
+        class Bar
+          def self.log_something; end
+        end
+      end
+    RUBY
+
+    expect(d.declaration_targets).to eq([
+      { name: "Example22", is_module: false },
+      { name: "Example22::Bar", is_module: false },
+    ])
+  end
+
+  # The other half of the same rule: with no target of its own the file takes
+  # the single-target path, which lands on the wrapper through
+  # `ClassNameExtractor` anyway. Adding it here would flatten that nesting —
+  # `module ActionController; module HttpAuthentication; module Token` emits
+  # nested only while the outer two stay out of the targets.
+  it "still skips a wrapper whose nested module is the file's only content" do
+    d = discover(<<~RUBY)
+      module ActionController
+        module HttpAuthentication
+          module Token
+            def authenticate; end
+          end
+        end
+      end
+    RUBY
+
+    expect(d.declaration_targets).to be_empty
+  end
+
+  # A module that is itself a pure namespace has no members needing a block, so
+  # it does not hold its wrapper alive.
+  it "skips a wrapper whose nested module only wraps classes" do
+    d = discover(<<~RUBY)
+      class Holder
+        module Wrapping
+          class Inner
+            def name; end
+          end
+        end
+
+        class Bar
+          def title; end
+        end
+      end
+    RUBY
+
+    expect(d.declaration_targets).to eq([
+      { name: "Holder::Wrapping::Inner", is_module: false },
+      { name: "Holder::Bar", is_module: false },
+    ])
+  end
+
   # `declarations` answers "what kind is X?" for every type the file declares —
   # wrappers and nested modules included, unlike `declaration_targets`. The
   # analyzer renders a nested target's namespace from it; resolving that kind


### PR DESCRIPTION
`class C; module Foo; …; end; class Bar; end; end` emitted `C::Bar` and nothing else. `Foo` was dropped without a diagnostic — not typed `untyped`, not emitted empty: absent, so every call into it resolved against nothing.

## The two rules that cross

`TargetDiscovery` decides which types a file emits, and both halves of the answer are deliberate:

1. **a nested MODULE is not a target** (#22) — the `owner` mechanism writes it *inside* its enclosing target's block;
2. **a declaration whose body is only other declarations is a pure namespace** and is not a target either, because "it has no members of its own to emit".

Rule 2 assumes every declaration in that body has a home elsewhere. True of a nested class, which the counterpart to rule 1 promotes to a target of its own; false of a nested module, whose only home is the block rule 2 just deleted.

## Why no fixture had it

It takes both halves. Drop the class and nothing in the file is a target, so the analyzer takes the single-target path, which lands on the wrapper through `ClassNameExtractor` and emits the module in place. Give the wrapper a member of its own and it stops being a namespace. Only the mix — a module with members beside a class, and nothing else — loses it.

## The fix

A wrapper hosting a module with members stays a target, but **only when the file has a target of its own**.

That condition is not decoration. With no other target the file already takes the single-target path, and adding the wrapper there *flattens* the nesting it produces — `module ActionController; module HttpAuthentication; module Token` is the controller-runtime transcription, and it emits nested only while the outer two stay out of the targets. (A first, broader cut without this condition turned that snapshot into `module ActionController; module HttpAuthentication::Token::ControllerMethods`.) A nested module that is itself a pure namespace does not hold its wrapper alive either — it has no members to place.

`declaration_targets` becomes a reader over the recorded list, so the decision is made once the whole file is known rather than at the moment the wrapper is visited — which is before the file has said whether anything else is a target.

## Fixture

`example22`, in the `extend` shape: `Bar.bazingado`'s `super` reaches `Foo` through `extend Example22::Foo`, which only resolves while `Foo` is emitted.

```rbs
class Example22
  module Foo
    def bazinga: (untyped module_included) -> untyped
    def bazingado: (untyped base_foo) -> untyped
  end
end

class Example22
  class Bar
    extend ::Example22::Foo

    def self.bazingado: (untyped base_foo) -> untyped
    def self.log_something: (untyped message) -> nil
  end
end
```

Plus three unit specs: the broken case, and the two shapes that must keep being dropped (the pure-nesting wrapper, and a wrapper whose nested module only wraps classes).

## Verification

- Full suite: **1152 examples, 0 failures**, including `steep_dummy_spec` (baseline + contracts), which is what proves the `super` resolves with `Foo` emitted.
- A full `make rbs_infer` over the dummy touched **only** the new `example22.rbs` — no other snapshot moved, so there was no fixed point to chase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)