### PR TITLE
fix: a nested module is not a namespace wrapper's spare part, and `extend` is a mixin

### DIFF
--- a/lib/rbs_infer/ast/target_discovery.rb
+++ b/lib/rbs_infer/ast/target_discovery.rb
@@ -25,13 +25,16 @@ module RbsInfer::AST
   #   constant receiver. These reopen `Receiver` to mix in `Mod`; there is
   #   no class body to analyze, so the core synthesizes a reopen block.
   class TargetDiscovery < Prism::Visitor
-    attr_reader :declaration_targets, :include_targets, :declarations
+    attr_reader :include_targets, :declarations
 
     def initialize
       # Enclosing declaration names, outermost first — qualifies nested
       # targets. Blocks don't push, so it doubles as the depth counter.
       @namespace = []
-      @declaration_targets = []
+      # Source order, each `{ name:, is_module:, namespace: }`. `namespace` marks
+      # a wrapper kept only in case it turns out to be the only home a nested
+      # module has — see `declaration_targets`.
+      @targets = []
       # Every type the file declares, qualified name => is_module. Unlike
       # `declaration_targets` this keeps namespace wrappers and nested
       # modules: it answers "what kind is X?", not "what should we emit?".
@@ -59,6 +62,22 @@ module RbsInfer::AST
       super
     end
 
+    # The types to emit, in source order.
+    #
+    # A namespace wrapper hosting a nested module is in the list only when the
+    # file has a target of its own. The nested module is emitted inside its
+    # enclosing target's block and nowhere else, so with a sibling class in the
+    # file — `class C; module Foo; …; end; class Bar; end; end` — dropping the
+    # wrapper dropped `Foo` with it and the file emitted `C::Bar` alone. With no
+    # other target the file takes the single-target path, which already lands
+    # on the wrapper via
+    # `ClassNameExtractor`, and adding it here would only flatten that nesting.
+    def declaration_targets
+      real = @targets.reject { |t| t[:namespace] }
+      chosen = real.empty? ? real : @targets
+      chosen.map { |t| { name: t[:name], is_module: t[:is_module] } }
+    end
+
     private
 
     def nest(node)
@@ -79,7 +98,8 @@ module RbsInfer::AST
     end
 
     def record_declaration(node, is_module:)
-      return if namespace_wrapper?(node)
+      wrapper = namespace_wrapper?(node)
+      return if wrapper && !hosts_orphan_module?(node)
 
       name = RbsInfer::Analyzer.extract_constant_path(node.constant_path)
       return unless name && !name.empty?
@@ -96,9 +116,17 @@ module RbsInfer::AST
       # Latent while no fixture reopened a class twice in a single file; the
       # `class_eval` desugaring makes it the normal case, since it emits a `class X`
       # beside the one the file already writes.
-      return if @declaration_targets.any? { |t| t[:name] == qualified }
+      return if @targets.any? { |t| t[:name] == qualified }
 
-      @declaration_targets << { name: qualified, is_module: is_module }
+      @targets << { name: qualified, is_module: is_module, namespace: wrapper }
+    end
+
+    # A module declared directly in `node`'s body that is not itself a pure
+    # namespace — so it has members, and the owner mechanism has to write them
+    # into `node`'s block because a nested module is never a target of its own.
+    # That is what makes an otherwise droppable wrapper worth keeping.
+    def hosts_orphan_module?(node)
+      node.body.body.any? { |stmt| stmt.is_a?(Prism::ModuleNode) && !namespace_wrapper?(stmt) }
     end
 
     # A declaration whose body is nothing but other class/module declarations

--- a/lib/rbs_infer/extensions/rails/module_self_type_annotator.rb
+++ b/lib/rbs_infer/extensions/rails/module_self_type_annotator.rb
@@ -39,24 +39,31 @@ module RbsInfer
           return nil if module_name.nil? || module_name.empty?
 
           hosts = hosts_for(path, module_name, mixin_index)
-          return nil if hosts.empty?
+          extenders = mixin_index ? mixin_index.extenders_of(module_name) : []
+          return nil if hosts.empty? && extenders.empty?
 
           anchor = module_name.split("::").last
           is_concern = source.include?("extend ActiveSupport::Concern")
 
-          { "anchor" => anchor, "annotations" => annotations(module_name, hosts, is_concern) }
+          { "anchor" => anchor, "annotations" => annotations(module_name, hosts, extenders, is_concern) }
         end
 
-        # Every class a module is mixed into.
+        # Every class a module is mixed into by `include`.
         #
         # The written `include`s come first: they are what the code says, while
         # the convention below is a guess from a file path. The guess stays as
         # the fallback for what no source shows — a helper is mixed in by Rails
         # itself, and nobody writes that `include` anywhere
         # (felixefelip/rbs_infer#163).
+        #
+        # `extenders` is not consulted here on purpose: the presumption answers
+        # "which class includes this helper", and a module the sources show being
+        # EXTENDED has already been answered by the code. Falling back for it
+        # would put `ApplicationController` beside a host that is written down.
         def hosts_for(path, module_name, mixin_index)
           hosts = mixin_index ? mixin_index.hosts_of(module_name) : []
           return hosts if hosts.any?
+          return [] if mixin_index && mixin_index.extenders_of(module_name).any?
 
           Array(presumed_host_for(path, module_name))
         end
@@ -81,11 +88,26 @@ module RbsInfer
           nil
         end
 
-        def annotations(module_name, hosts, is_concern)
-          instance = "# @type instance: #{union(hosts.map { |host| "#{host} & #{module_name}" })}"
+        # An `include` and an `extend` of the same module produce `self`s of
+        # different KINDS, and both are honest members of the same union: an
+        # included module's instance method runs on an instance of the host
+        # (`Card & Card::Entropic`), an extended one's runs on the host's class
+        # object (`singleton(Bar)`) — no intersection with the module, because
+        # the RBS reopen already writes `extend ::Foo` on that singleton.
+        def annotations(module_name, hosts, extenders, is_concern)
+          instances = hosts.map { |host| "#{host} & #{module_name}" } +
+                      extenders.map { |extender| "singleton(#{extender})" }
+          instance = "# @type instance: #{union(instances)}"
           return [instance] unless is_concern
 
+          # Only the `include` hosts: the `self` of a module's SINGLETON methods
+          # when the module is extended would be `singleton(singleton(Bar))`,
+          # which RBS cannot spell. A concern is included anyway — that is what
+          # `ActiveSupport::Concern` is for — so this list is empty exactly when
+          # there is nothing to say.
           selves = hosts.map { |host| "singleton(#{host}) & singleton(#{module_name})" }
+          return [instance] if selves.empty?
+
           ["# @type self: #{union(selves)}", instance]
         end
 

--- a/lib/rbs_infer/project/mixin_index.rb
+++ b/lib/rbs_infer/project/mixin_index.rb
@@ -13,7 +13,13 @@ module RbsInfer::Project
   # module those hosts also include.
   #
   # **What `self` is inside it** — `hosts_of`, the classes that include it
-  # (felixefelip/rbs_infer#163).
+  # (felixefelip/rbs_infer#163), and `extenders_of`, the ones that `extend` it.
+  # Two methods rather than one because the answers are types of different
+  # KINDS: an `include` puts the module in the host's instance ancestry, so
+  # `self` is an instance (`Card & Card::Entropic`); an `extend` puts it in the
+  # host's SINGLETON ancestry, so `self` is the class/module object itself
+  # (`singleton(Bar)`). Folding them into one list would hand a caller a name it
+  # cannot tell apart, and the wrong one of the two is a wrong signature.
   #
   # The two match names differently, on purpose. Reachability keys on the short
   # name: a false positive only widens a search that is then filtered by what
@@ -24,11 +30,15 @@ module RbsInfer::Project
     def initialize(source_files, parse_cache: nil)
       @parse_cache = parse_cache || ParseCache.new
       @included_shorts = {}                            # file → Set[short name]
+      @extended_shorts = {}                            # file → Set[short name]
       @files_defining = Hash.new { |h, k| h[k] = [] }  # short name → [file]
       @includes_by_class = Hash.new { |h, k| h[k] = Set.new } # class FQN → Set[written name]
+      @extends_by_class = Hash.new { |h, k| h[k] = Set.new }  # class FQN → Set[written name]
       @module_declarations = Set.new                          # FQNs declared as `module`
       @hosts_by_target = {}                                   # target FQN → [host FQN]
+      @extenders_by_target = {}                               # target FQN → [extender FQN]
       @hosts_of_cache = {}                                    # target FQN → resolved hosts
+      @extenders_of_cache = {}                                # target FQN → resolved extenders
       build(source_files)
     end
 
@@ -63,6 +73,23 @@ module RbsInfer::Project
       @hosts_of_cache[unqualified(module_name)] ||= resolve_hosts(module_name, Set.new)
     end
 
+    # Classes and modules whose SINGLETON gets `module_name` — `extend Foo`, by
+    # FQN. `self` inside `Foo`'s instance methods is then the extender's class
+    # object, `singleton(Bar)`, which is why these are not merged into
+    # `hosts_of`.
+    #
+    # A module is as good an answer as a class here, and is NOT resolved through
+    # the way `hosts_of` resolves an including module: `module Baz; extend Foo`
+    # makes the object `Baz` itself the receiver of `Foo`'s methods, so `Baz` is
+    # the self, not a waypoint to one.
+    #
+    # Reached through an including module, though: when `module M` includes the
+    # target and `class C` extends `M`, `C`'s singleton carries the target too,
+    # so `singleton(C)` is one of the target's selves.
+    def extenders_of(module_name)
+      @extenders_of_cache[unqualified(module_name)] ||= resolve_extenders(module_name, Set.new)
+    end
+
     private
 
     EMPTY = Set.new.freeze
@@ -87,9 +114,31 @@ module RbsInfer::Project
                       .uniq.sort
     end
 
-    # Files whose class/module includes `short`.
+    # Same `seen`-threading as `resolve_hosts`, and the same reason: only the
+    # outermost call is memoized, so a cached entry is the complete answer.
+    def resolve_extenders(module_name, seen)
+      target = unqualified(module_name)
+      return [] unless seen.add?(target)
+
+      direct = @extenders_by_target.fetch(target, EMPTY_ARRAY)
+      # `class C; extend M; end` where `module M; include Foo; end` — C's
+      # singleton gets M, and M carries Foo, so `singleton(C)` is a self of
+      # Foo's instance methods. Only through a MODULE host: a class that
+      # includes Foo passes it to its instances, never to its singleton.
+      inherited = @hosts_by_target.fetch(target, EMPTY_ARRAY)
+                                  .select { |host| @module_declarations.include?(host) }
+                                  .flat_map { |host| resolve_extenders(host, seen) }
+
+      (direct + inherited).uniq.sort
+    end
+
+    # Files whose class/module mixes `short` in, by either route. A file that
+    # only EXTENDS the module still makes bare calls into it — `bazinga(Baz)` in
+    # a class body is a call on the class object — so reachability does not care
+    # which of the two ancestries carries it.
     def host_files(short)
-      @included_shorts.filter_map { |file, shorts| file if shorts.include?(short) }
+      @included_shorts.filter_map { |file, shorts| file if shorts.include?(short) } |
+        @extended_shorts.filter_map { |file, shorts| file if shorts.include?(short) }
     end
 
     def build(source_files)
@@ -113,13 +162,26 @@ module RbsInfer::Project
           next
         end
 
-        written = include_written_names(entry.result.value)
+        mixins = MixinWriter.collect(entry.result.value)
+        written = mixins.includes.values.reduce(Set.new, :|)
+        extended = mixins.extends.values.reduce(Set.new, :|)
+
         @module_declarations << class_name if extractor.is_module
+        @module_declarations.merge(mixins.module_declarations)
         @files_defining[class_name.split("::").last] << file
+        # Reachability keys on the FILE, so the union over its declarations is
+        # the right granularity: a bare call anywhere in the file can reach
+        # anything anything in it mixes in.
         @included_shorts[file] = written.map { |name| name.split("::").last }.to_set
+        @extended_shorts[file] = extended.map { |name| name.split("::").last }.to_set
+        # Self-types cannot use that union — they key on the DECLARATION that
+        # wrote the mixin. Attributing a file's every `include` to its headline
+        # class made `class Example23; module Baz; extend Foo; end; end` answer
+        # `Example23` for "who extends Foo", a class that extends nothing.
         # Merged rather than assigned: a class reopened across files carries the
         # includes of all of them.
-        @includes_by_class[class_name].merge(written)
+        mixins.includes.each { |owner, names| @includes_by_class[owner].merge(names) }
+        mixins.extends.each { |owner, names| @extends_by_class[owner].merge(names) }
       end
 
       # A template's bare calls reach whatever its OWNER includes: `post_status_badge(post)`
@@ -133,7 +195,8 @@ module RbsInfer::Project
         @included_shorts[file] = inherited unless inherited.empty?
       end
 
-      index_hosts_by_target
+      @hosts_by_target = index_by_target(@includes_by_class)
+      @extenders_by_target = index_by_target(@extends_by_class)
     end
 
     # The reverse of `@includes_by_class`, built once.
@@ -147,16 +210,18 @@ module RbsInfer::Project
     # `hosts_of` into a hash lookup, and (measured on Fizzy) takes the mixin
     # resolution from ~36% of a run's wall time, plus the GC churn of the strings
     # it allocated, down to noise.
-    def index_hosts_by_target
-      @includes_by_class.each do |host, written|
+    def index_by_target(mixins_by_class)
+      by_target = {}
+      mixins_by_class.each do |host, written|
         prefixes = nestings(host)
         written.each do |name|
           targets_for(name, prefixes).each do |target|
-            hosts = (@hosts_by_target[target] ||= [])
+            hosts = (by_target[target] ||= [])
             hosts << host unless hosts.include?(host)
           end
         end
       end
+      by_target
     end
 
     # The candidates a written name can mean, innermost nesting first — and,
@@ -195,19 +260,93 @@ module RbsInfer::Project
       name.to_s.sub(/\A::/, "")
     end
 
-    # Names as WRITTEN in the arguments of `include A, B::C` / `prepend A`.
-    def include_written_names(root)
-      names = Set.new
-      RbsInfer::Analyzer.find_all_nodes(root) do |n|
-        n.is_a?(Prism::CallNode) && n.receiver.nil? &&
-          (n.name == :include || n.name == :prepend) && n.arguments
-      end.each do |call|
-        call.arguments.arguments.each do |arg|
+    # Every mixin a file writes, attributed to the class or module that
+    # lexically encloses it, and split by which ancestry it lands in.
+    #
+    # The split is not the method name alone: `include` inside `class << self`
+    # puts the module on the singleton, which is what `extend` means, so it is
+    # recorded as one. That equivalence is Ruby's, not a convention — the two
+    # spellings produce the same ancestors.
+    class MixinWriter < Prism::Visitor
+      INCLUDE_CALLS = %i[include prepend].freeze
+      # `extend self` records nothing: its argument is not a constant, so
+      # `extract_constant_path` returns nil — and that is the right answer, since
+      # a module extending ITSELF names no other host.
+      EXTEND_CALLS = %i[extend].freeze
+
+      attr_reader :includes, :extends, :module_declarations
+
+      def self.collect(root)
+        new.tap { |writer| root.accept(writer) }
+      end
+
+      def initialize
+        @stack = []
+        @singleton_depth = 0
+        @includes = Hash.new { |h, k| h[k] = Set.new }
+        @extends = Hash.new { |h, k| h[k] = Set.new }
+        @module_declarations = Set.new
+        super()
+      end
+
+      def visit_class_node(node)
+        with_scope(node) { super }
+      end
+
+      def visit_module_node(node)
+        with_scope(node) { |fqn| @module_declarations << fqn if fqn; super }
+      end
+
+      def visit_singleton_class_node(node)
+        @singleton_depth += 1
+        super
+      ensure
+        @singleton_depth -= 1
+      end
+
+      def visit_call_node(node)
+        record(node) if node.receiver.nil? && node.arguments
+        super
+      end
+
+      private
+
+      # A mixin written at the top level of a file belongs to no declaration and
+      # is dropped — `Array.include Foo` has an explicit receiver and never
+      # reaches here, and a bare `include Foo` at top level mixes into Object,
+      # which is not a self any signature of ours would name.
+      def record(node)
+        owner = @stack.last or return
+
+        bucket =
+          if EXTEND_CALLS.include?(node.name) then @extends
+          elsif INCLUDE_CALLS.include?(node.name) then @singleton_depth.positive? ? @extends : @includes
+          end
+        return unless bucket
+
+        node.arguments.arguments.each do |arg|
           name = RbsInfer::Analyzer.extract_constant_path(arg)
-          names << name if name
+          bucket[owner] << name if name
         end
       end
-      names
+
+      # `class A::B` inside `module A` is `A::A::B` nowhere — a compact path is
+      # already absolute enough to stand on its own, so a name that carries its
+      # own namespace is not re-prefixed.
+      def with_scope(node)
+        name = RbsInfer::Analyzer.extract_constant_path(node.constant_path)
+        fqn =
+          if name.nil? then nil
+          elsif @stack.empty? || name.include?("::") then name
+          else "#{@stack.last}::#{name}"
+          end
+
+        @stack.push(fqn) if fqn
+        yield fqn
+      ensure
+        @stack.pop if fqn
+      end
     end
+    private_constant :MixinWriter
   end
 end

--- a/spec/dummy/app/models/example22.rb
+++ b/spec/dummy/app/models/example22.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# A nested module SIDE BY SIDE with a nested class, in a body that declares
+# nothing else. That combination is what used to lose `Foo` entirely.
+#
+# `TargetDiscovery` drops a declaration whose body is only other declarations —
+# a pure namespace has no members of its own, and each nested class is emitted
+# as a target in its own right. A nested MODULE is not: it is excluded from the
+# targets on purpose, because the `owner` mechanism writes it inside its
+# enclosing target's block. So dropping `Example22` dropped the only block
+# `Foo` could ever be written into, and the file emitted `Example22::Bar`
+# alone.
+#
+# It takes both halves to show it: without `Bar` nothing in the file is a
+# target, and the single-target path lands on `Example22` anyway; with a member
+# of its own `Example22` stops being a namespace and stays a target. Neither
+# spelling reaches the case.
+#
+# The bodies are the `extend` shape on purpose — `Bar.bazingado`'s `super`
+# resolves through `extend Example22::Foo` into the module, which only works
+# while `Foo` is emitted.
+class Example22
+  module Foo
+    def bazinga(module_included)
+      module_included.bazingado(self)
+    end
+
+    def bazingado(base_foo)
+      base_foo.log_something("bazingado")
+    end
+  end
+
+  class Bar
+    extend Example22::Foo
+
+    def self.bazingado(base_foo)
+      super
+
+      base_foo.log_something("bazingado bar")
+    end
+
+    def self.log_something(message)
+      puts message
+    end
+  end
+end

--- a/spec/dummy/app/models/example23.rb
+++ b/spec/dummy/app/models/example23.rb
@@ -10,7 +10,7 @@ class Example23
   end
 
   module Baz
-	  extend Example23::Foo
+    extend Example23::Foo
 
     def self.bazingado(base_foo)
       base_foo.log_something("bazingado")
@@ -31,4 +31,3 @@ class Example23
     bazinga(Example23::Baz)
   end
 end
-

--- a/spec/dummy/app/models/example23.rb
+++ b/spec/dummy/app/models/example23.rb
@@ -9,6 +9,14 @@ class Example23
     end
   end
 
+  module Baz
+	  extend Example23::Foo
+
+    def bazingado(base_foo)
+      base_foo.log_something("bazingado")
+    end
+  end
+
   class Bar
     extend Example23::Foo
 
@@ -20,12 +28,5 @@ class Example23
       message
     end
   end
-
-  module Baz
-	  extend Example23::Foo
-
-    def bazingado(base_foo)
-      base_foo.log_something("bazingado")
-    end
-  end
 end
+

--- a/spec/dummy/app/models/example23.rb
+++ b/spec/dummy/app/models/example23.rb
@@ -16,6 +16,8 @@ class Example23
 
     def self.log_something(message)
       puts message
+
+      message
     end
   end
 

--- a/spec/dummy/app/models/example23.rb
+++ b/spec/dummy/app/models/example23.rb
@@ -20,13 +20,15 @@ class Example23
   class Bar
     extend Example23::Foo
 
-    bazinga(Example23::Baz)
-
     def self.log_something(message)
       puts message
 
       message
     end
+
+    # Runs at class-body time, so everything it reaches has to be defined
+    # already: `Baz` above, and `log_something` right here.
+    bazinga(Example23::Baz)
   end
 end
 

--- a/spec/dummy/app/models/example23.rb
+++ b/spec/dummy/app/models/example23.rb
@@ -5,7 +5,7 @@ class Example23
     end
 
     def bazingado(base_foo)
-      base_foo.log_something("bazingado")
+      puts "base_foo class: #{base_foo.class}"
     end
   end
 

--- a/spec/dummy/app/models/example23.rb
+++ b/spec/dummy/app/models/example23.rb
@@ -1,0 +1,29 @@
+class Example23
+  module Foo
+    def bazinga(module_included)
+      module_included.bazingado(self)
+    end
+
+    def bazingado(base_foo)
+      base_foo.log_something("bazingado")
+    end
+  end
+
+  class Bar
+    extend Example23::Foo
+
+    bazinga(Example23::Baz)
+
+    def self.log_something(message)
+      puts message
+    end
+  end
+
+  module Baz
+	  extend Example23::Foo
+
+    def bazingado(base_foo)
+      base_foo.log_something("bazingado")
+    end
+  end
+end

--- a/spec/dummy/app/models/example23.rb
+++ b/spec/dummy/app/models/example23.rb
@@ -12,7 +12,7 @@ class Example23
   module Baz
 	  extend Example23::Foo
 
-    def bazingado(base_foo)
+    def self.bazingado(base_foo)
       base_foo.log_something("bazingado")
     end
   end

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -33,6 +33,31 @@ app/models/eventable.rb:
     annotations:
     - "# @type self: singleton(Widget) & singleton(Eventable)"
     - "# @type instance: Widget & Eventable"
+app/models/example13.rb:
+  modules:
+  - anchor: GeneratedAttributes
+    annotations:
+    - "# @type instance: Example13::Registry & Example13::Registry::GeneratedAttributes"
+app/models/example22.rb:
+  modules:
+  - anchor: Foo
+    annotations:
+    - "# @type instance: singleton(Example22::Bar)"
+app/models/example23.rb:
+  modules:
+  - anchor: Foo
+    annotations:
+    - "# @type instance: (singleton(Example23::Bar)) | (singleton(Example23::Baz))"
+app/models/example3.rb:
+  modules:
+  - anchor: GeneratedAttributes
+    annotations:
+    - "# @type instance: Example3::Foo & Example3::Foo::GeneratedAttributes"
+app/models/included_hook/home_made.rb:
+  modules:
+  - anchor: HomeMade
+    annotations:
+    - "# @type instance: singleton(IncludedHook::Homespun)"
 app/models/included_hook/shared.rb:
   modules:
   - anchor: Shared
@@ -124,3 +149,8 @@ sig/generated/steep_current_runtime/current.rb:
   - anchor: GeneratedAttributeMethods
     annotations:
     - "# @type instance: Current & Current::GeneratedAttributeMethods"
+sig/generated/steep_devise_runtime/devise_scoped_helpers.rb:
+  modules:
+  - anchor: DeviseScopedHelpers
+    annotations:
+    - "# @type instance: ActionController::Base & DeviseScopedHelpers"

--- a/spec/dummy/sig/rbs_infer/app/models/example22.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example22.rbs
@@ -1,0 +1,15 @@
+class Example22
+  module Foo
+    def bazinga: (untyped module_included) -> untyped
+    def bazingado: (untyped base_foo) -> untyped
+  end
+end
+
+class Example22
+  class Bar
+    extend ::Example22::Foo
+
+    def self.bazingado: (untyped base_foo) -> untyped
+    def self.log_something: (untyped message) -> nil
+  end
+end

--- a/spec/dummy/sig/rbs_infer/app/models/example23.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example23.rbs
@@ -1,11 +1,11 @@
 class Example23
   module Foo
-    def bazinga: (singleton(::Example23::Baz) module_included) -> untyped
-    def bazingado: (untyped base_foo) -> untyped
+    def bazinga: (singleton(::Example23::Baz) module_included) -> nil
+    def bazingado: (untyped base_foo) -> nil
   end
   module Baz
     extend ::Example23::Foo
-    def bazingado: (untyped base_foo) -> untyped
+    def bazingado: (untyped base_foo) -> nil
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example23.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example23.rbs
@@ -1,0 +1,18 @@
+class Example23
+  module Foo
+    def bazinga: (singleton(::Example23::Baz) module_included) -> untyped
+    def bazingado: (untyped base_foo) -> untyped
+  end
+  module Baz
+    extend ::Example23::Foo
+    def bazingado: (untyped base_foo) -> untyped
+  end
+end
+
+class Example23
+  class Bar
+    extend ::Example23::Foo
+
+    def self.log_something: (untyped message) -> nil
+  end
+end

--- a/spec/dummy/sig/rbs_infer/app/models/example23.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example23.rbs
@@ -1,11 +1,11 @@
 class Example23
   module Foo
-    def bazinga: (singleton(::Example23::Baz) module_included) -> nil
+    def bazinga: (singleton(::Example23::Baz) module_included) -> untyped
     def bazingado: (untyped base_foo) -> nil
   end
   module Baz
     extend ::Example23::Foo
-    def bazingado: (untyped base_foo) -> nil
+    def self.bazingado: (untyped base_foo) -> untyped
   end
 end
 

--- a/spec/expectations/models/example22.rbs
+++ b/spec/expectations/models/example22.rbs
@@ -1,0 +1,15 @@
+class Example22
+  module Foo
+    def bazinga: (untyped module_included) -> untyped
+    def bazingado: (untyped base_foo) -> untyped
+  end
+end
+
+class Example22
+  class Bar
+    extend ::Example22::Foo
+
+    def self.bazingado: (untyped base_foo) -> untyped
+    def self.log_something: (untyped message) -> nil
+  end
+end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -5,11 +5,11 @@ app/models/example14.rb:15:17: [error] Type `(::Example14::User | nil)` does not
 app/models/example15.rb:25:25: [error] Type `(::Example15::User | nil)` does not have method `name`
 app/models/example21.rb:105:31: [error] Type `(::Example21::Holder | nil)` does not have method `name`
 app/models/example21.rb:96:29: [error] Type `(::Example21::Ticket | nil)` does not have method `holder`
-app/models/example3.rb:122:11: [error] Type `(::Example3::User | nil)` does not have method `name`
-app/models/example3.rb:63:13: [error] Type `(::Example3::User | nil)` does not have method `name`
-app/models/example3.rb:64:26: [error] Type `(::Example3::User | nil)` does not have method `name`
-app/models/example3.rb:65:26: [error] Type `(::String | nil)` does not have method `upcase`
-app/models/example3.rb:66:13: [error] Type `(::String | nil)` does not have method `upcase`
+app/models/example3.rb:123:11: [error] Type `(::Example3::User | nil)` does not have method `name`
+app/models/example3.rb:64:13: [error] Type `(::Example3::User | nil)` does not have method `name`
+app/models/example3.rb:65:26: [error] Type `(::Example3::User | nil)` does not have method `name`
+app/models/example3.rb:66:26: [error] Type `(::String | nil)` does not have method `upcase`
+app/models/example3.rb:67:13: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:14:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:22:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:27:23: [error] Type `(::String | nil)` does not have method `upcase`

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -555,6 +555,28 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     expect(rbs.chomp).to eq(expected_rbs(name).chomp)
   end
 
+  # A nested module beside a nested class, in a body that declares nothing else.
+  # `TargetDiscovery` dropped `Example22` as a pure namespace, and with it the
+  # only block `Foo` is ever written into — the file emitted `Example22::Bar`
+  # alone, so `Bar.bazingado`'s `super` had no `extend`ed module to reach.
+  # Neither half shows it on its own: drop `Bar` and nothing in the file is a
+  # target, so the single-target path lands on `Example22` anyway.
+  it "example22" do
+    name = "models/example22"
+    rbs = RbsInfer::Analyzer.new(
+      target_file: "app/models/example22.rb",
+      source_files: source_files
+    ).generate_rbs
+
+    if ENV["UPDATE_EXPECTATIONS"]
+      path = expectations_dir.join("#{name}.rbs")
+      path.dirname.mkpath
+      path.write(rbs)
+    end
+
+    expect(rbs.chomp).to eq(expected_rbs(name).chomp)
+  end
+
   it "example20" do
     name = "models/example20"
     rbs = RbsInfer::Analyzer.new(

--- a/spec/lib/rbs_infer/ast/target_discovery_spec.rb
+++ b/spec/lib/rbs_infer/ast/target_discovery_spec.rb
@@ -186,6 +186,71 @@ RSpec.describe RbsInfer::AST::TargetDiscovery do
     ])
   end
 
+  # A nested module is emitted inside its enclosing target's block and nowhere
+  # else, so a wrapper hosting one is the only home it has. Dropping the
+  # wrapper because "it has no members of its own" dropped `Foo` with it, and
+  # the file emitted `Example22::Bar` alone.
+  it "keeps a namespace wrapper that is a nested module's only home" do
+    d = discover(<<~RUBY)
+      class Example22
+        module Foo
+          def bazinga; end
+        end
+
+        class Bar
+          def self.log_something; end
+        end
+      end
+    RUBY
+
+    expect(d.declaration_targets).to eq([
+      { name: "Example22", is_module: false },
+      { name: "Example22::Bar", is_module: false },
+    ])
+  end
+
+  # The other half of the same rule: with no target of its own the file takes
+  # the single-target path, which lands on the wrapper through
+  # `ClassNameExtractor` anyway. Adding it here would flatten that nesting —
+  # `module ActionController; module HttpAuthentication; module Token` emits
+  # nested only while the outer two stay out of the targets.
+  it "still skips a wrapper whose nested module is the file's only content" do
+    d = discover(<<~RUBY)
+      module ActionController
+        module HttpAuthentication
+          module Token
+            def authenticate; end
+          end
+        end
+      end
+    RUBY
+
+    expect(d.declaration_targets).to be_empty
+  end
+
+  # A module that is itself a pure namespace has no members needing a block, so
+  # it does not hold its wrapper alive.
+  it "skips a wrapper whose nested module only wraps classes" do
+    d = discover(<<~RUBY)
+      class Holder
+        module Wrapping
+          class Inner
+            def name; end
+          end
+        end
+
+        class Bar
+          def title; end
+        end
+      end
+    RUBY
+
+    expect(d.declaration_targets).to eq([
+      { name: "Holder::Wrapping::Inner", is_module: false },
+      { name: "Holder::Bar", is_module: false },
+    ])
+  end
+
   # `declarations` answers "what kind is X?" for every type the file declares —
   # wrappers and nested modules included, unlike `declaration_targets`. The
   # analyzer renders a nested target's namespace from it; resolving that kind

--- a/spec/lib/rbs_infer/extensions/rails/class_methods_implements_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/class_methods_implements_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RbsInfer::Extensions::Rails::ClassMethodsImplements do
   def blocks(source, path: "app/models/post/taggable.rb", module_name: "Post::Taggable", hosts: ["Post"])
     described_class.blocks_for(
       path: path, module_name: module_name, source: source,
-      mixin_index: instance_double(RbsInfer::Project::MixinIndex, hosts_of: hosts)
+      mixin_index: instance_double(RbsInfer::Project::MixinIndex, hosts_of: hosts, extenders_of: [])
     )
   end
 
@@ -86,7 +86,7 @@ RSpec.describe RbsInfer::Extensions::Rails::ClassMethodsImplements do
     def entry(source, path: "app/models/post/taggable.rb", module_name: "Post::Taggable", hosts: ["Post"])
       described_class.self_type_entry(
         path: path, module_name: module_name, source: source,
-        mixin_index: instance_double(RbsInfer::Project::MixinIndex, hosts_of: hosts)
+        mixin_index: instance_double(RbsInfer::Project::MixinIndex, hosts_of: hosts, extenders_of: [])
       )
     end
 

--- a/spec/lib/rbs_infer/extensions/rails/module_self_type_annotator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/module_self_type_annotator_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeAnnotator do
   # A model concern's host comes from the `include` that names it, so these pass
   # an index (felixefelip/rbs_infer#163). The conventions below cover only what
   # no source shows.
-  def index_answering(hosts)
-    instance_double(RbsInfer::Project::MixinIndex, hosts_of: hosts)
+  def index_answering(hosts, extenders: [])
+    instance_double(RbsInfer::Project::MixinIndex, hosts_of: hosts, extenders_of: extenders)
   end
 
   describe ".entry_for" do
@@ -89,8 +89,8 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeAnnotator do
   # path; the `include`s written in the sources are what the code says, so they
   # answer first and the guess is left for what no source shows.
   describe "with a mixin index" do
-    def index_answering(hosts)
-      instance_double(RbsInfer::Project::MixinIndex, hosts_of: hosts)
+    def index_answering(hosts, extenders: [])
+      instance_double(RbsInfer::Project::MixinIndex, hosts_of: hosts, extenders_of: extenders)
     end
 
     it "prefers the written include over the path convention" do
@@ -148,6 +148,62 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeAnnotator do
       )
 
       expect(entry["annotations"]).to eq(["# @type instance: Card & Trashable"])
+    end
+
+    # An extended module's instance method runs on the extender's CLASS OBJECT,
+    # so its `self` is `singleton(Bar)` — no intersection with the module, since
+    # the RBS reopen already writes `extend ::Foo` onto that singleton.
+    it "answers with the extender's singleton when the module is extended" do
+      entry = described_class.entry_for(
+        path: "app/models/example23.rb",
+        module_name: "Example23::Foo",
+        source: PLAIN_SRC,
+        mixin_index: index_answering([], extenders: ["Example23::Bar"])
+      )
+
+      expect(entry["annotations"]).to eq(["# @type instance: singleton(Example23::Bar)"])
+    end
+
+    # Both routes are honest members of one union: `self` is an instance of an
+    # includer or the class object of an extender, one at a time.
+    it "unions include hosts with extenders" do
+      entry = described_class.entry_for(
+        path: "app/models/foo.rb",
+        module_name: "Foo",
+        source: PLAIN_SRC,
+        mixin_index: index_answering(["Card"], extenders: %w[Bar Baz])
+      )
+
+      expect(entry["annotations"])
+        .to eq(["# @type instance: (Card & Foo) | (singleton(Bar)) | (singleton(Baz))"])
+    end
+
+    # The convention answers "which class includes this helper". A module the
+    # sources show being EXTENDED has already been answered by the code, so the
+    # guess must not be added beside it.
+    it "does not fall back to the convention for an extended module" do
+      entry = described_class.entry_for(
+        path: "app/helpers/posts_helper.rb",
+        module_name: "PostsHelper",
+        source: PLAIN_SRC,
+        mixin_index: index_answering([], extenders: ["ERBPostsIndex"])
+      )
+
+      expect(entry["annotations"]).to eq(["# @type instance: singleton(ERBPostsIndex)"])
+    end
+
+    # A concern is INCLUDED — that is what `ActiveSupport::Concern` is for — and
+    # the `self` of a module's singleton methods when the module is extended
+    # would be `singleton(singleton(Bar))`, which RBS cannot spell.
+    it "omits the singleton annotation when only extenders answer" do
+      entry = described_class.entry_for(
+        path: "app/models/foo.rb",
+        module_name: "Foo",
+        source: CONCERN_SRC,
+        mixin_index: index_answering([], extenders: ["Bar"])
+      )
+
+      expect(entry["annotations"]).to eq(["# @type instance: singleton(Bar)"])
     end
 
     it "falls back to the convention when nobody includes the module" do

--- a/spec/lib/rbs_infer/project/mixin_index_spec.rb
+++ b/spec/lib/rbs_infer/project/mixin_index_spec.rb
@@ -257,5 +257,136 @@ RSpec.describe RbsInfer::Project::MixinIndex do
       expect(index.hosts_of("A")).to contain_exactly("Widget")
       expect(index.hosts_of("B")).to contain_exactly("Widget")
     end
+
+    # The include belongs to the declaration that WROTE it, not to the file's
+    # headline class. Attributing a whole file to `extractor.class_name` made a
+    # nested module's host come out as the outer namespace — for
+    # `class Example3; class Foo; module GeneratedAttributes` it answered
+    # `Example3`, which includes nothing.
+    it "attributes an include to the declaration that writes it, not the file" do
+      file = write_file("example3.rb", <<~RUBY)
+        class Example3
+          class Foo
+            module GeneratedAttributes
+            end
+
+            include GeneratedAttributes
+          end
+        end
+      RUBY
+
+      index = described_class.new([file])
+
+      expect(index.hosts_of("Example3::Foo::GeneratedAttributes")).to contain_exactly("Example3::Foo")
+    end
+  end
+
+  describe "#extenders_of" do
+    it "answers with the class whose singleton gets the module" do
+      file = write_file("bar.rb", "class Bar\n  extend Foo\nend\n")
+      foo = write_file("foo.rb", "module Foo\nend\n")
+
+      index = described_class.new([file, foo])
+
+      expect(index.extenders_of("Foo")).to contain_exactly("Bar")
+      # `extend` is not an `include`: the module never reaches Bar's instances.
+      expect(index.hosts_of("Foo")).to be_empty
+    end
+
+    # A module is as good an answer as a class, and is NOT resolved through the
+    # way an INCLUDING module is: `module Baz; extend Foo` makes the object
+    # `Baz` itself the receiver of Foo's methods, so Baz is the self.
+    it "keeps a module that extends the target as the answer" do
+      baz = write_file("baz.rb", "module Baz\n  extend Foo\nend\n")
+      foo = write_file("foo.rb", "module Foo\nend\n")
+
+      index = described_class.new([baz, foo])
+
+      expect(index.extenders_of("Foo")).to contain_exactly("Baz")
+    end
+
+    it "answers with every extender, not the first" do
+      file = write_file("example23.rb", <<~RUBY)
+        class Example23
+          module Foo
+          end
+
+          module Baz
+            extend Example23::Foo
+          end
+
+          class Bar
+            extend Example23::Foo
+          end
+        end
+      RUBY
+
+      index = described_class.new([file])
+
+      expect(index.extenders_of("Example23::Foo"))
+        .to contain_exactly("Example23::Bar", "Example23::Baz")
+    end
+
+    # `include` inside `class << self` puts the module on the singleton, which
+    # is what `extend` means — the two spellings produce the same ancestors.
+    it "reads an include inside `class << self` as an extend" do
+      file = write_file("bar.rb", <<~RUBY)
+        class Bar
+          class << self
+            include Foo
+          end
+        end
+      RUBY
+      foo = write_file("foo.rb", "module Foo\nend\n")
+
+      index = described_class.new([file, foo])
+
+      expect(index.extenders_of("Foo")).to contain_exactly("Bar")
+      expect(index.hosts_of("Foo")).to be_empty
+    end
+
+    # `class C; extend M; end` where `module M; include Foo; end` — C's
+    # singleton gets M, and M carries Foo.
+    it "reaches the target through a module the extender extends" do
+      c = write_file("c.rb", "class C\n  extend M\nend\n")
+      m = write_file("m.rb", "module M\n  include Foo\nend\n")
+      foo = write_file("foo.rb", "module Foo\nend\n")
+
+      index = described_class.new([c, m, foo])
+
+      expect(index.extenders_of("Foo")).to contain_exactly("C")
+    end
+
+    # A class that INCLUDES the target passes it to its instances, never to its
+    # singleton — so it is a host, not an extender.
+    it "does not read an including class as an extender" do
+      card = write_file("card.rb", "class Card\n  include Foo\nend\n")
+      foo = write_file("foo.rb", "module Foo\nend\n")
+
+      index = described_class.new([card, foo])
+
+      expect(index.extenders_of("Foo")).to be_empty
+      expect(index.hosts_of("Foo")).to contain_exactly("Card")
+    end
+
+    # `extend self` names no other host, and its argument is not a constant.
+    it "records nothing for `extend self`" do
+      file = write_file("foo.rb", "module Foo\n  extend self\nend\n")
+
+      index = described_class.new([file])
+
+      expect(index.extenders_of("Foo")).to be_empty
+    end
+
+    # A file that only EXTENDS the module still makes bare calls into it —
+    # `bazinga(Baz)` in a class body is a call on the class object.
+    it "makes an extending file reach the module" do
+      bar = write_file("bar.rb", "class Bar\n  extend Foo\n  bazinga(Baz)\nend\n")
+      foo = write_file("foo.rb", "module Foo\n  def bazinga(m) = nil\nend\n")
+
+      index = described_class.new([bar, foo])
+
+      expect(index.files_reaching("Foo")).to include(bar)
+    end
   end
 end


### PR DESCRIPTION
Two defects that only show together, which is why the same fixture drives both: a nested module reached by `extend`.

## 1. A nested module dropped by its namespace wrapper

`class C; module Foo; …; end; class Bar; end; end` emitted `C::Bar` and nothing else. `Foo` was absent — not `untyped`, not empty — so every call into it resolved against nothing.

Two `TargetDiscovery` rules crossing: a nested module is deliberately not a target (the `owner` mechanism writes it inside the enclosing block, #22), and a declaration whose body is only other declarations is a pure namespace and not a target either. Rule 2 assumes every declaration in that body has a home elsewhere — true of a nested class, which gets promoted; false of a nested module, whose only home is the block rule 2 just deleted.

`declaration_targets` becomes a reader over the recorded list, so the decision is made once the whole file is known rather than when the wrapper is visited.

## 2. `MixinIndex` never saw `extend`

`include_written_names` matched `:include` and `:prepend`, so `hosts_of` answered `[]` for any module reached by `extend`. That empty answer travels: `SelfTypeAnnotators` injects nothing, `NewCallCollector#current_self_type` falls back to `"untyped"`, and a module's instance-method `self` passed as an argument types the callee's parameter `untyped` — not for want of a call site (the site is matched), but because the argument had no type.

**`extenders_of` is a separate question from `hosts_of`, on purpose.** An `include` puts the module in the host's instance ancestry, so `self` is an instance (`Card & Card::Entropic`); an `extend` puts it in the *singleton* ancestry, so `self` is the class object (`singleton(Bar)`). One list would hand callers a name they cannot tell apart, and the wrong one of the two is a wrong signature. The annotator unions them: `(Card & Foo) | (singleton(Bar))`.

It covers what Ruby covers, no more:

- `include` inside `class << self` counts as an extend — same ancestors, so the method name alone cannot decide;
- a *module* that extends the target is the answer, not a waypoint (`module Baz; extend Foo` makes the object `Baz` the receiver) — unlike an *including* module, which `hosts_of` resolves through;
- `class C; extend M` where `module M; include Foo` reaches `C`;
- `extend self` records nothing — its argument is not a constant, and a module extending itself names no other host.

**Lexical attribution is what makes it work.** Mixins were credited to the file's headline class, which for `class Example23; module Baz; extend Foo` answered `Example23` — a class that extends nothing. Attribution is now to the declaration that wrote the mixin. That also settles includes the file-level credit had been losing (`class Example3; class Foo; module GeneratedAttributes` now gets `Example3::Foo`), which is where the `.steep_module_self_types.yml` entries beyond the `extend` ones come from.

`files_reaching` keeps the file-level union — `bazinga(Baz)` in a class body is a bare call on the class object and does reach the module.

## Measured

`Example23::Baz` as target:

```
def self.bazingado: ((singleton(Example23::Bar) | singleton(Example23::Baz)) base_foo) -> untyped
```

against `(untyped base_foo)` before. The union is over both extenders of `Foo` — the trade-off `union` already documents for includes.

## Also here

`example23.rb` did not load: `bazinga(Example23::Baz)` runs at class-body time and reached `Bar.log_something`, written below it. The analyzer reads the file rather than loading it, so nothing flagged it — but the dummy's rake tasks do load it, and `rbs_rails:all` aborting took 83 of 91 integration examples with it.

## Verification

- `bundle exec rspec spec/lib` — 1058 examples, 0 failures
- `bundle exec rspec spec/integration` — 91 examples, 0 failures
- Steep baseline refreshed: the same five `example3.rb` errors, shifted one line by the annotation now injected above them

## Still open

`TargetDiscovery` promotes `["Example23", "Example23::Bar"]`, so `Foo` and `Baz` are typed against the wrapper's target and `match_class?` compares `singleton(Example23::Baz)` against `Example23`. The type resolves when `Example23::Baz` is the target; only the multi-target path loses it. `spec/dummy/sig/rbs_infer/app/models/example23.rbs` stays `untyped` for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)