### PR TITLE
fix: a nested module is formatted like the class around it

### DIFF
--- a/lib/rbs_infer/signatures/rbs_builder.rb
+++ b/lib/rbs_infer/signatures/rbs_builder.rb
@@ -276,38 +276,47 @@ module RbsInfer::Signatures
 
       owned.group_by(&:owner).each do |owner, mod_members|
         inner_indent = member_indent + "  "
+        # Sibling modules are member blocks like any other, so they are
+        # blank-separated the same way `add_group` separates the groups of a
+        # class body — without this two `module X ... end` touch.
+        lines << "" unless lines.empty?
         lines << "#{member_indent}module #{owner}"
 
-        mod_members.select { |m| m.kind == :constant }.each do |const|
-          lines << "#{inner_indent}#{const.signature}"
-        end
-        mod_members.select { |m| m.kind == :prepend }.each do |pre|
-          lines << "#{inner_indent}prepend #{qualify(pre.name)}"
-        end
-        mod_members.select { |m| m.kind == :include }.each do |inc|
-          lines << "#{inner_indent}include #{qualify(inc.name)}"
-        end
-        mod_members.select { |m| m.kind == :extend }.each do |ext|
-          lines << "#{inner_indent}extend #{qualify(ext.name)}"
-        end
-        mod_members.select { |m| m.kind == :class_method }.each do |m|
+        # The body goes through the SAME grouping the top-level body uses
+        # (`add_group`), so a nested module reads like the class around it: the
+        # mixins separated from the singletons, the singletons from the instance
+        # members. Emitting the lines flat made a nested module the one place in
+        # the file where everything touched.
+        body_start = lines.size
+
+        add_group(lines, body_start, mod_members.select { |m| m.kind == :constant }.map do |const|
+          "#{inner_indent}#{const.signature}"
+        end)
+
+        mixins = mod_members.select { |m| m.kind == :prepend }.map { |pre| "#{inner_indent}prepend #{qualify(pre.name)}" } +
+                 mod_members.select { |m| m.kind == :include }.map { |inc| "#{inner_indent}include #{qualify(inc.name)}" } +
+                 mod_members.select { |m| m.kind == :extend }.map { |ext| "#{inner_indent}extend #{qualify(ext.name)}" }
+        add_group(lines, body_start, mixins)
+
+        class_level = mod_members.select { |m| m.kind == :class_method }.map do |m|
           # The same substitution the top-level singletons get. Omitting it left
           # a nested module's `def self.x` carrying the raw structural signature
           # even once its call sites had been read (felixefelip/rbs_infer#159).
           sig = m.signature
           sig = apply_inferred_param_types(sig, method_param_types[m.name]) if method_param_types[m.name]
-          lines << "#{inner_indent}def self.#{RbsInfer::Signatures::RbsParserUtil.parenthesize_return_type(sig)}"
+          "#{inner_indent}def self.#{RbsInfer::Signatures::RbsParserUtil.parenthesize_return_type(sig)}"
         end
-        mod_members.select { |m| m.kind == :singleton_alias }.each do |a|
-          lines << "#{inner_indent}alias self.#{a.name} self.#{a.old_name}"
+        class_level += mod_members.select { |m| m.kind == :singleton_alias }.map do |a|
+          "#{inner_indent}alias self.#{a.name} self.#{a.old_name}"
         end
-        mod_members.select { |m| m.kind == :alias }.each do |a|
-          lines << "#{inner_indent}alias #{a.name} #{a.old_name}"
+        class_level += mod_members.select { |m| m.kind == :alias }.map do |a|
+          "#{inner_indent}alias #{a.name} #{a.old_name}"
         end
-        mod_members.each do |m|
-          line = render_value_member(m, inner_indent, {}, attr_types, method_param_types, Set.new)
-          lines << line if line
-        end
+        add_group(lines, body_start, class_level)
+
+        add_group(lines, body_start, mod_members.filter_map do |m|
+          render_value_member(m, inner_indent, {}, attr_types, method_param_types, Set.new)
+        end)
 
         lines << "#{member_indent}end"
       end

--- a/spec/expectations/models/included_hook.rbs
+++ b/spec/expectations/models/included_hook.rbs
@@ -1,21 +1,28 @@
 class IncludedHook
   module Hookable
     def self.included: (untyped base) -> untyped
+
     def from_hook: () -> String
     def slot: () -> untyped
   end
+
   module Sugared
     extend ActiveSupport::Concern
+
     def from_sugar: () -> String
     def badge: () -> untyped
   end
+
   module Homespun
     extend ::IncludedHook::HomeMade
+
     def from_homespun: () -> String
     def stamp: () -> untyped
   end
+
   module Arbitrary
     def self.foo_included: (untyped base) -> untyped
+
     def from_arbitrary: () -> String
   end
 

--- a/spec/expectations/steep_controller_runtime/action_controller/metal/http_authentication.rbs
+++ b/spec/expectations/steep_controller_runtime/action_controller/metal/http_authentication.rbs
@@ -5,6 +5,7 @@ module ActionController
       def authenticate_with_http_token: () { (String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?) -> untyped } -> untyped
       def request_http_token_authentication: (?String realm, ?untyped message) -> bool
     end
+
     module Token
       def authenticate: ((ActionController::Base & ActionController::HttpAuthentication::Token::ControllerMethods) controller) { (String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?) -> untyped } -> untyped
       def authentication_request: ((ActionController::Base & ActionController::HttpAuthentication::Token::ControllerMethods) controller, String realm, ?untyped message) -> bool


### PR DESCRIPTION
Um módulo aninhado era o único lugar de um arquivo gerado onde nada era separado por linha em branco.

`RbsBuilder#build` monta o corpo por grupos, e `add_group` põe uma linha em branco entre grupos que de fato emitem. `emit_parsed_nested_modules` não usava nada disso: empurrava `lines <<` direto. Daí dois sintomas, visíveis lado a lado no mesmo arquivo — `class Bar`, que passa pelo caminho de topo, tem a linha em branco depois do seu `extend`; `module Baz`, ao lado, não tem:

```rbs
class Example23
  module Foo
    def bazinga: (singleton(::Example23::Baz) module_included) -> untyped
    def bazingado: (untyped base_foo) -> nil
  end
  module Baz
    extend ::Example23::Foo
    def self.bazingado: (untyped base_foo) -> untyped
  end
end
```

Agora:

```rbs
class Example23
  module Foo
    def bazinga: (singleton(::Example23::Baz) module_included) -> untyped
    def bazingado: (untyped base_foo) -> nil
  end

  module Baz
    extend ::Example23::Foo

    def self.bazingado: (untyped base_foo) -> untyped
  end
end
```

O corpo do módulo passa pelo mesmo `add_group` do corpo da classe (constantes / mixins / singletons+aliases / membros de instância), e módulos irmãos são separados como qualquer outro bloco de membro. A ORDEM de emissão não muda — só onde entram as linhas em branco.

## Snapshots

Só dois arquivos se movem, e só ganhando linha em branco:

- `spec/expectations/models/included_hook.rbs` (+7 — quatro módulos irmãos, três deles com mixin e métodos)
- `spec/expectations/steep_controller_runtime/action_controller/metal/http_authentication.rbs` (+1 — dois módulos irmãos)

Os demais módulos aninhados do dummy são de grupo único, então saem idênticos.

## Verificação

- `bundle exec rspec spec/lib` — 1058 exemplos, 0 falhas
- `bundle exec rspec spec/integration` — 91 exemplos, 0 falhas (rodada de novo depois do `UPDATE_EXPECTATIONS=1`, com os snapshots já regravados)

## Fora de escopo

O outro incômodo de forma do mesmo arquivo — `class Bar` sair num `class Example23` REABERTO em vez de ficar no bloco que já está aberto — é #217. É a concatenação de blocos em `Analyzer#generate_multi_target_rbs`, vale para todo arquivo multi-alvo (`example19.rbs` abre `class Example19` três vezes) e mexe em quase todo snapshot do repo, então quer PR só dele.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
