### PR TITLE
fix: the `self` a module method passes on is the host that called it

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -672,7 +672,7 @@ module RbsInfer
   # e variáveis locais com mesmo nome de um attr_accessor.
 
   def method_type_resolver
-    @method_type_resolver ||= RbsInfer::Signatures::MethodTypeResolver.new(@source_files, source_index: @source_index, parse_cache: @parse_cache, file_index: @file_index, caller_file_cache: @caller_file_cache, constant_resolver: env_only_constant_resolver, mixin_index: mixin_index)
+    @method_type_resolver ||= RbsInfer::Signatures::MethodTypeResolver.new(@source_files, source_index: @source_index, parse_cache: @parse_cache, file_index: @file_index, caller_file_cache: @caller_file_cache, constant_resolver: env_only_constant_resolver, mixin_index: mixin_index, invoker_self_types: invoker_self_types)
   end
 
   # Shared by both `RbsBuilder` call-sites so a concern's file is read and
@@ -726,7 +726,8 @@ module RbsInfer
       steep_bridge: steep_bridge,
       parse_cache: @parse_cache,
       file_index: @file_index,
-      caller_file_cache: @caller_file_cache
+      caller_file_cache: @caller_file_cache,
+      invoker_self_types: invoker_self_types
     )
   end
 
@@ -736,6 +737,10 @@ module RbsInfer
 
   def mixin_index
     @corpus.mixin_index
+  end
+
+  def invoker_self_types
+    @corpus.invoker_self_types
   end
 
   # ─── Resolver quais namespaces da classe-alvo são class (não module) ──
@@ -839,6 +844,7 @@ require_relative "inference/constant_arg_type_resolver"
 require_relative "inference/self_return_type_context"
 require_relative "inference/rest_param_marker"
 require_relative "inference/method_key"
+require_relative "inference/invoker_self_types"
 require_relative "inference/send_call"
 require_relative "inference/type_merger"
 require_relative "inference/ivar_type_set"

--- a/lib/rbs_infer/inference/caller_file_analyzer.rb
+++ b/lib/rbs_infer/inference/caller_file_analyzer.rb
@@ -12,7 +12,7 @@ module RbsInfer::Inference
     # covered by `IntraClassCallAnalyzer`. Omitting it would double-count every same-file
     # self-call — the two paths resolve the receiver differently, so the parameter widens
     # into a union instead of failing loudly (required-threaded-deps).
-    def initialize(target_class:, method_type_resolver:, target_file:, mixin_index:, init_positional_params: [], target_methods: {}, steep_bridge: nil, block_methods: Set.new, method_owners: {})
+    def initialize(target_class:, method_type_resolver:, target_file:, mixin_index:, invoker_self_types:, init_positional_params: [], target_methods: {}, steep_bridge: nil, block_methods: Set.new, method_owners: {})
       @target_class = target_class
       @target_file = target_file
       @method_type_resolver = method_type_resolver
@@ -33,6 +33,11 @@ module RbsInfer::Inference
       # `untyped` while the other construction, wired, read the intersection
       # (felixefelip/rbs_infer#175).
       @mixin_index = mixin_index
+      # Which of those hosts actually CALLS the method being read, which is what
+      # turns the module's declared `self` into the one this call site has
+      # (felixefelip/rbs_infer#222). Required for the same reason as the index
+      # above: forgetting it silently widens a parameter instead of failing.
+      @invoker_self_types = invoker_self_types
       @method_call_usages = Hash.new { |h, k| h[k] = [] }
       @method_block_returns = Hash.new { |h, k| h[k] = [] }
     end
@@ -173,6 +178,7 @@ module RbsInfer::Inference
         match_bare_calls: match_bare,
         self_types_by_method: self_types_by_method,
         module_self_types: module_self_types,
+        invoker_self_types: @invoker_self_types,
         established_ivars_by_method: established_ivars_by_method,
         argument_partitions_by_method: argument_partitions_by_method,
         constant_arg_resolver: constant_arg_resolver,
@@ -228,7 +234,8 @@ module RbsInfer::Inference
         defined_class_names: NewCallCollector.collect_defined_class_names(result.value),
         # A template declares no module either, so there is no module `self` to
         # resolve here — the empty map is the answer, not a missing wire.
-        module_self_types: {}
+        module_self_types: {},
+        invoker_self_types: @invoker_self_types
       )
       result.value.accept(visitor)
 

--- a/lib/rbs_infer/inference/invoker_self_types.rb
+++ b/lib/rbs_infer/inference/invoker_self_types.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+module RbsInfer::Inference
+  # What `self` is inside a module's instance method, narrowed from *whatever
+  # mixes the module in* to *whoever calls this method*.
+  #
+  # `ModuleSelfTypeAnnotator` answers the first question, and it answers it
+  # right: a module extended by `Bar` and by `Baz` has, as a declaration, the
+  # self type `(singleton(Bar) | singleton(Baz))`. But an ARGUMENT is not a
+  # declaration. `Example23::Foo#bazinga` is invoked once, in `Bar`'s class
+  # body, so the `self` it hands to `module_included.bazingado(self)` is
+  # `singleton(Bar)` and nothing else — which a human reads off the source.
+  # Typing that parameter with the union made `Baz.bazingado`'s body stop
+  # checking, because `Baz` has no `log_something` (felixefelip/rbs_infer#222).
+  #
+  # The narrowing only ever REMOVES branches the declaration already listed, and
+  # it declines — returning the declaration untouched — the moment the evidence
+  # is incomplete. Three ways it can be:
+  #
+  # - the method is called on a RECEIVER somewhere (`x.bazinga`). What `self`
+  #   is inside the callee is then the receiver's type, which this walk does not
+  #   resolve, so the picture is no longer whole.
+  # - a bare call sits somewhere whose `self` is not one of the declared
+  #   branches — including inside the module itself, where `self` IS the union.
+  # - nothing calls it at all. An uncalled method says nothing about its `self`;
+  #   narrowing to the empty set would be inventing a fact, not reading one.
+  #
+  # Whole-program by construction, which is the assumption the analyzer already
+  # makes everywhere else: the call sites it can see are the call sites there
+  # are.
+  class InvokerSelfTypes
+    def initialize(source_index:, parse_cache:)
+      @source_index = source_index
+      @parse_cache = parse_cache
+      @observed = {}
+    end
+
+    # `declared` is the module's self type as the annotators state it. Returns
+    # it unchanged unless the call sites prove a narrower one.
+    def narrow(method_name:, declared:)
+      return declared if declared.nil? || method_name.nil?
+
+      branches = union_branches(declared)
+      return declared if branches.size < 2
+
+      observed = observed_selves(method_name)
+      return declared if observed.nil? || observed.empty?
+      # A `self` outside the declared union means a call site this walk placed
+      # somewhere the declaration does not admit — the two disagree, so neither
+      # is trusted to subtract from the other.
+      return declared unless observed.subset?(branches.to_set)
+
+      kept = branches.select { |branch| observed.include?(branch) }
+      return declared if kept.size == branches.size
+
+      parenthesize(kept)
+    end
+
+    private
+
+    # Same rule the annotator applies when it builds the declaration: a single
+    # part is written bare, because the parentheses exist only to keep a `|` or
+    # a `&` from binding wrong where the type lands.
+    def parenthesize(parts)
+      return parts.first if parts.size == 1 && !parts.first.include?(" & ")
+
+      "(#{parts.join(" | ")})"
+    end
+
+    # The declaration arrives parenthesized and may hold intersections
+    # (`Card & Card::Entropic`), so it is parsed rather than split on `|`.
+    def union_branches(declared)
+      type = RBS::Parser.parse_type(declared)
+      case type
+      when RBS::Types::Union then type.types.map(&:to_s)
+      else [type.to_s]
+      end
+    rescue RBS::ParsingError, RBS::BaseError
+      []
+    end
+
+    # Every `self` a call to `method_name` runs under, or nil when the evidence
+    # is incomplete. Memoized per method name: the answer is a property of the
+    # corpus, not of the module asking.
+    def observed_selves(method_name)
+      return @observed[method_name] if @observed.key?(method_name)
+
+      @observed[method_name] = compute_observed_selves(method_name)
+    end
+
+    def compute_observed_selves(method_name)
+      # `files_mentioning`, not `files_calling`/`files_with_bare_call`: those two
+      # are candidate filters that over-approximate one way and under-approximate
+      # the other, and a narrowing needs the whole picture or none of it. Whether
+      # an occurrence is a call, and whether it has a receiver, is then decided on
+      # the AST rather than on the text.
+      files = @source_index.files_mentioning(method_name)
+      return nil if files.empty?
+
+      files.each_with_object(Set.new) do |file, acc|
+        entry = @parse_cache.get(file) or return nil
+
+        found = SelfContextCollector.collect(entry.result.value, method_name)
+        return nil if found.nil?
+
+        acc.merge(found)
+      end
+    end
+
+    # Walks a file for bare calls to one method and records the `self` each runs
+    # under. Returns nil if any of them cannot be placed.
+    class SelfContextCollector < Prism::Visitor
+      def self.collect(root, method_name)
+        collector = new(method_name)
+        root.accept(collector)
+        collector.unplaceable ? nil : collector.selves
+      end
+
+      attr_reader :selves, :unplaceable
+
+      def initialize(method_name)
+        @method_name = method_name.to_sym
+        @selves = Set.new
+        @unplaceable = false
+        @path = []
+        # nil in a class/module body, :instance in a `def x`, :singleton in a
+        # `def self.x` or under `class << self`.
+        @scope = nil
+        super()
+      end
+
+      def visit_class_node(node) = with_path(node) { super }
+      def visit_module_node(node) = with_path(node) { super }
+
+      def visit_singleton_class_node(node)
+        outer = @scope
+        @scope = :singleton
+        super
+        @scope = outer
+      end
+
+      def visit_def_node(node)
+        outer = @scope
+        # `def self.x` inside a body, and any `def` already under `class << self`.
+        @scope = (node.receiver || @scope == :singleton) ? :singleton : :instance
+        super
+        @scope = outer
+      end
+
+      def visit_call_node(node)
+        record(node) if node.name == @method_name
+        super
+      end
+
+      private
+
+      def record(node)
+        # A receiver puts `self` inside the callee at the receiver's type, which
+        # is not read here.
+        return @unplaceable = true if node.receiver
+        return @unplaceable = true if @path.empty?
+
+        owner = @path.join("::")
+        # A body and a `def self.` both run on the class object; an instance
+        # method runs on an instance.
+        @selves << (@scope == :instance ? owner : "singleton(#{owner})")
+      end
+
+      def with_path(node)
+        name = RbsInfer::Analyzer.extract_constant_path(node.constant_path)
+        return yield if name.nil?
+
+        @path.push(name)
+        outer = @scope
+        @scope = nil
+        yield
+        @scope = outer
+        @path.pop
+      end
+    end
+  end
+end

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -28,7 +28,7 @@ module RbsInfer::Inference
       names
     end
 
-    def initialize(target_class:, method_return_types:, local_var_types:, constant_arg_resolver:, defined_class_names:, local_var_read_types: {}, local_var_types_by_method: {}, method_type_resolver: nil, caller_class_name: nil, init_positional_params: [], target_methods: {}, match_bare_calls: false, self_types_by_method: {}, module_self_types:, established_ivars_by_method: {}, argument_partitions_by_method: {}, block_methods: Set.new, expression_types: {}, method_owners: {})
+    def initialize(target_class:, method_return_types:, local_var_types:, constant_arg_resolver:, defined_class_names:, local_var_read_types: {}, local_var_types_by_method: {}, method_type_resolver: nil, caller_class_name: nil, init_positional_params: [], target_methods: {}, match_bare_calls: false, self_types_by_method: {}, module_self_types:, invoker_self_types:, established_ivars_by_method: {}, argument_partitions_by_method: {}, block_methods: Set.new, expression_types: {}, method_owners: {})
       @target_class = target_class
       # FQNs of classes/modules defined in the file being scanned; disambiguates
       # a relative receiver from a same-simple-name class elsewhere (see
@@ -76,6 +76,7 @@ module RbsInfer::Inference
       # the parameter `untyped` while the caller-file walk beside it, wired with
       # the same map, read `(Card & Card::Stallable)` (felixefelip/rbs_infer#175).
       @module_self_types = module_self_types
+      @invoker_self_types = invoker_self_types
       # `{ "set_post" => { "@post" => "(::Post & ::Post::Validated)" } }` — ivars a
       # self-method proves populated once it has run (postconditions sidecar). Applied
       # in source order by `visit_call_node`, so only call sites AFTER the establishing
@@ -845,8 +846,18 @@ module RbsInfer::Inference
 
     # The answer for the module being visited. An unnameable one (a dynamic
     # constant path) falls back to the name the file stands for.
+    #
+    # Narrowed to the hosts that actually call THIS method. The annotators state
+    # what `self` may be across the whole module — every class that includes it,
+    # every one that extends it — and that is the right answer for a
+    # declaration. As the type of an ARGUMENT it is too wide: `Foo#bazinga` is
+    # invoked from `Bar`'s body and nowhere else, so the `self` it passes on is
+    # `singleton(Bar)`, not the union with `Baz` (felixefelip/rbs_infer#222).
     def module_self_type
-      @module_self_types[@module_name_stack.last || @caller_class_name]
+      declared = @module_self_types[@module_name_stack.last || @caller_class_name]
+      return declared if declared.nil? || @current_method.nil?
+
+      @invoker_self_types.narrow(method_name: @current_method, declared: declared)
     end
 
     # Resolves a `self.<method>` against the refined `self` type when the

--- a/lib/rbs_infer/inference/param_type_inferrer.rb
+++ b/lib/rbs_infer/inference/param_type_inferrer.rb
@@ -27,8 +27,8 @@ module RbsInfer::Inference
     # `extra_caller_sources` may legitimately be nil (not every project registers
     # one), but saying so is the caller's job.
     def initialize(target_file:, target_class:, source_files:, source_index:, method_type_resolver:, type_merger:,
-                   mixin_index:, extra_caller_sources:, steep_bridge: nil, parse_cache: nil, file_index: nil,
-                   caller_file_cache: nil)
+                   mixin_index:, invoker_self_types:, extra_caller_sources:, steep_bridge: nil, parse_cache: nil,
+                   file_index: nil, caller_file_cache: nil)
       @target_file = target_file
       @target_class = target_class
       @source_files = source_files
@@ -36,6 +36,7 @@ module RbsInfer::Inference
       @method_type_resolver = method_type_resolver
       @type_merger = type_merger
       @mixin_index = mixin_index
+      @invoker_self_types = invoker_self_types
       @extra_caller_sources = extra_caller_sources
       @steep_bridge = steep_bridge
       @parse_cache = parse_cache || RbsInfer::Project::ParseCache.new
@@ -169,7 +170,8 @@ module RbsInfer::Inference
         # — the ones worth collecting call-site blocks for.
         block_methods: members.select { |m| BlockSignatureResolver.untyped_block_return?(m) }.map(&:name).to_set,
         method_owners: nested_method_owners(members),
-        mixin_index: @mixin_index
+        mixin_index: @mixin_index,
+        invoker_self_types: @invoker_self_types
       )
 
       caller_files(target_methods, is_module: is_module) do |file, force_bare|
@@ -235,7 +237,8 @@ module RbsInfer::Inference
         init_positional_params: init_positional_params(parsed_target),
         target_methods: target_method_params(parsed_target),
         steep_bridge: @steep_bridge,
-        mixin_index: @mixin_index
+        mixin_index: @mixin_index,
+        invoker_self_types: @invoker_self_types
       )
       @source_index.files_referencing(@target_class).flat_map { |file| analyzer.analyze(file) }
     end

--- a/lib/rbs_infer/project/corpus.rb
+++ b/lib/rbs_infer/project/corpus.rb
@@ -3,6 +3,7 @@ require_relative "source_index"
 require_relative "file_index"
 require_relative "caller_file_cache"
 require_relative "mixin_index"
+require_relative "../inference/invoker_self_types"
 
 module RbsInfer::Project
   # Everything about a project that a target class cannot change.
@@ -64,6 +65,17 @@ module RbsInfer::Project
     # should not pay for the walk, and `Analyzer` already treated it that way.
     def mixin_index
       @mixin_index ||= MixinIndex.new(@source_files, parse_cache: @parse_cache)
+    end
+
+    # Lazy for the same reason, and asked by little: only a module method with
+    # more than one possible `self` ever narrows, and the answer is memoized per
+    # method name for the whole run (felixefelip/rbs_infer#222). It sits here
+    # rather than in `Analyzer` so the memo, like the four indexes above,
+    # survives from one target to the next.
+    def invoker_self_types
+      @invoker_self_types ||= RbsInfer::Inference::InvokerSelfTypes.new(
+        source_index: @source_index, parse_cache: @parse_cache
+      )
     end
   end
 end

--- a/lib/rbs_infer/project/source_index.rb
+++ b/lib/rbs_infer/project/source_index.rb
@@ -57,6 +57,7 @@ module RbsInfer::Project
       @index = Hash.new { |h, k| h[k] = [] }
       @call_index = Hash.new { |h, k| h[k] = [] }
       @bare_call_index = {}
+      @mention_index = {}
       source_files.each do |file|
         begin
           content = File.read(file)
@@ -135,6 +136,33 @@ module RbsInfer::Project
     def files_with_bare_call(method_name)
       @bare_call_index[method_name] ||= begin
         pattern = BARE_CALL_AT.call(method_name)
+        @source_files.select do |file|
+          content = File.read(file)
+          content.match?(pattern)
+        rescue Errno::ENOENT, Errno::EACCES
+          false
+        end.freeze
+      end
+    end
+
+    # Files whose text contains `method_name` as a word, in any position.
+    #
+    # A superset of the three above, and the only one of the four safe to read
+    # as "these are ALL the files that could call it". The other three are
+    # CANDIDATE filters, tuned to over-approximate cheaply for a search that a
+    # later resolution step filters: `files_calling` matches `.name` across a
+    # newline, so a comment ending in a full stop above a bare call registers as
+    # a receiver call; `files_with_bare_call` only matches at the start of a
+    # line, so `x = name(1)` does not register at all. Over-approximating is
+    # harmless when the answer is "look here too" and wrong when the answer is
+    # "there is nothing anywhere else", which is what a narrowing needs
+    # (felixefelip/rbs_infer#222).
+    #
+    # Scanned on demand and memoized, for the reason `files_with_bare_call`
+    # gives: an index over every identifier in the corpus is what it avoids.
+    def files_mentioning(method_name)
+      @mention_index[method_name] ||= begin
+        pattern = /\b#{Regexp.escape(method_name)}\b/
         @source_files.select do |file|
           content = File.read(file)
           content.match?(pattern)

--- a/lib/rbs_infer/signatures/method_type_resolver.rb
+++ b/lib/rbs_infer/signatures/method_type_resolver.rb
@@ -22,11 +22,15 @@ module RbsInfer::Signatures
     # parameter it feeds goes untyped with it, and the class's contracts stop
     # being inferrable. Passed in rather than built here, because building one is
     # a full sweep of the project's files and the Analyzer already has it.
-    def initialize(source_files, constant_resolver:, mixin_index:, source_index: nil, parse_cache: nil, file_index: nil, caller_file_cache: nil)
+    # invoker_self_types: required for the same reason and on the same path — it
+    # is what narrows that module `self` from every host to the ones that call
+    # the method being read (felixefelip/rbs_infer#222).
+    def initialize(source_files, constant_resolver:, mixin_index:, invoker_self_types:, source_index: nil, parse_cache: nil, file_index: nil, caller_file_cache: nil)
       @source_files = source_files
       @source_index = source_index
       @constant_resolver = constant_resolver
       @mixin_index = mixin_index
+      @invoker_self_types = invoker_self_types
       @parse_cache = parse_cache || RbsInfer::Project::ParseCache.new
       @file_index = file_index || RbsInfer::Project::FileIndex.new(source_files)
       @caller_file_cache = caller_file_cache || RbsInfer::Project::CallerFileCache.new(@parse_cache)
@@ -295,7 +299,8 @@ module RbsInfer::Signatures
           # type via the loaded RBS env, not a bare name (#46, #56).
           constant_arg_resolver: @constant_resolver,
           defined_class_names: defined_names,
-          module_self_types: module_self_types_for(file, entry, defined_names)
+          module_self_types: module_self_types_for(file, entry, defined_names),
+          invoker_self_types: @invoker_self_types
         )
         entry.result.value.accept(visitor)
         all_usages.concat(visitor.usages)
@@ -511,7 +516,8 @@ module RbsInfer::Signatures
           # type via the loaded RBS env, not a bare name (#46, #56).
           constant_arg_resolver: @constant_resolver,
           defined_class_names: defined_names,
-          module_self_types: module_self_types_for(file, entry, defined_names)
+          module_self_types: module_self_types_for(file, entry, defined_names),
+          invoker_self_types: @invoker_self_types
         )
         entry.result.value.accept(visitor)
 

--- a/spec/dummy/app/models/example23.rb
+++ b/spec/dummy/app/models/example23.rb
@@ -5,17 +5,18 @@
 # the inferred-parameter table used to key them by name alone, so whichever call site was
 # read first typed them both.
 #
-# Two errors this file produces are RECORDED in the steep baseline, and both come from
-# the same place — `self` inside a module method extended by more than one host:
+# It is also where the `self` a module method passes on gets narrowed
+# (felixefelip/rbs_infer#222). `Foo`'s declared `self` is the union over its extenders,
+# which is right as a declaration and too wide as an ARGUMENT: `bazinga` is invoked once,
+# by `bazinga(Example23::Baz)` in `Bar`'s class body, so the `self` it hands to
+# `Baz.bazingado` is `singleton(Bar)`. With that, `base_foo.log_something` resolves and
+# the whole chain closes — both return types follow.
 #
-#   1. `base_foo.log_something` inside `Baz.bazingado`. That parameter is the union over
-#      `Foo`'s extenders, and `Baz` has no `log_something`. The only invocation passes
-#      `Bar` — `bazinga(Example23::Baz)` runs in `Bar`'s class body — so a human reads
-#      `singleton(Bar)` where the tooling reads the union. Narrowing it means correlating
-#      the host that invoked `bazinga` with the `self` inside it.
-#   2. `module_included.bazingado(self)` inside `Foo#bazinga`. rbs_infer types that `self`
-#      as the union (`ModuleSelfTypeAnnotator` injects it); Steep does not, because its
-#      module-self convention is built from `include` and nobody includes `Foo`.
+# What #221 is about lives here too: rbs_infer knows the `self` of `Foo`'s instance
+# methods (`ModuleSelfTypeAnnotator` injects it) while Steep does not, because the
+# annotator writes the self-type line from the `include` hosts only and nobody includes
+# `Foo`. Whether that shows up as an error depends on what the parameter ends up
+# demanding, which is why it is a separate issue from the narrowing.
 class Example23
   module Foo
     def bazinga(module_included)

--- a/spec/dummy/sig/rbs_infer/app/models/example23.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example23.rbs
@@ -1,13 +1,13 @@
 class Example23
   module Foo
-    def bazinga: (singleton(::Example23::Baz) module_included) -> untyped
+    def bazinga: (singleton(::Example23::Baz) module_included) -> String
     def bazingado: (untyped base_foo) -> nil
   end
 
   module Baz
     extend ::Example23::Foo
 
-    def self.bazingado: ((singleton(Example23::Bar) | singleton(Example23::Baz)) base_foo) -> untyped
+    def self.bazingado: (singleton(Example23::Bar) base_foo) -> String
   end
 end
 

--- a/spec/expectations/models/example23.rbs
+++ b/spec/expectations/models/example23.rbs
@@ -1,13 +1,13 @@
 class Example23
   module Foo
-    def bazinga: (singleton(::Example23::Baz) module_included) -> untyped
+    def bazinga: (singleton(::Example23::Baz) module_included) -> String
     def bazingado: (untyped base_foo) -> nil
   end
 
   module Baz
     extend ::Example23::Foo
 
-    def self.bazingado: ((singleton(Example23::Bar) | singleton(Example23::Baz)) base_foo) -> untyped
+    def self.bazingado: (singleton(Example23::Bar) base_foo) -> String
   end
 end
 

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -5,8 +5,7 @@ app/models/example14.rb:15:17: [error] Type `(::Example14::User | nil)` does not
 app/models/example15.rb:25:25: [error] Type `(::Example15::User | nil)` does not have method `name`
 app/models/example21.rb:105:31: [error] Type `(::Example21::Holder | nil)` does not have method `name`
 app/models/example21.rb:96:29: [error] Type `(::Example21::Ticket | nil)` does not have method `holder`
-app/models/example23.rb:22:32: [error] Cannot pass a value of type `self` as an argument of type `(singleton(::Example23::Bar) | singleton(::Example23::Baz))`
-app/models/example23.rb:35:15: [error] Type `(singleton(::Example23::Bar) | singleton(::Example23::Baz))` does not have method `log_something`
+app/models/example23.rb:23:32: [error] Cannot pass a value of type `self` as an argument of type `singleton(::Example23::Bar)`
 app/models/example3.rb:123:11: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:64:13: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:65:26: [error] Type `(::Example3::User | nil)` does not have method `name`

--- a/spec/lib/rbs_infer/inference/caller_file_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/inference/caller_file_analyzer_spec.rb
@@ -12,7 +12,11 @@ RSpec.describe RbsInfer::Inference::CallerFileAnalyzer do
       target_class: "Foo",
       method_type_resolver: nil,
       target_file: "app/models/foo.rb",
-      mixin_index: RbsInfer::Project::MixinIndex.new([])
+      mixin_index: RbsInfer::Project::MixinIndex.new([]),
+      invoker_self_types: RbsInfer::Inference::InvokerSelfTypes.new(
+        source_index: RbsInfer::Project::SourceIndex.new([]),
+        parse_cache: RbsInfer::Project::ParseCache.new
+      )
     )
   end
 

--- a/spec/lib/rbs_infer/inference/invoker_self_types_spec.rb
+++ b/spec/lib/rbs_infer/inference/invoker_self_types_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rbs_infer"
+require "tmpdir"
+require "fileutils"
+
+# The declared self type of a module is every host it has; the self type at a
+# CALL SITE is the host that made the call. Handing a parameter the first where
+# the second is readable states a fact the code does not
+# (felixefelip/rbs_infer#222).
+RSpec.describe RbsInfer::Inference::InvokerSelfTypes do
+  around do |ex|
+    Dir.mktmpdir { |dir| Dir.chdir(dir) { ex.run } }
+  end
+
+  def write(path, content)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+    path
+  end
+
+  def narrower(files = Dir["app/**/*.rb"])
+    described_class.new(
+      source_index: RbsInfer::Project::SourceIndex.new(files),
+      parse_cache: RbsInfer::Project::ParseCache.new
+    )
+  end
+
+  # `Bar` and `Baz` both extend the module; only `Bar` calls `stamp`.
+  def write_two_extenders(baz_body: "")
+    write("app/wrap.rb", <<~RUBY)
+      class Wrap
+        module Foo
+          def stamp(value)
+            value
+          end
+        end
+
+        module Baz
+          extend Wrap::Foo
+      #{baz_body}
+        end
+
+        class Bar
+          extend Wrap::Foo
+
+          stamp(1)
+        end
+      end
+    RUBY
+  end
+
+  let(:declared) { "((singleton(Wrap::Bar)) | (singleton(Wrap::Baz)))" }
+
+  it "keeps only the branch that calls the method" do
+    write_two_extenders
+
+    expect(narrower.narrow(method_name: "stamp", declared: declared))
+      .to eq("singleton(Wrap::Bar)")
+  end
+
+  it "leaves the declaration alone when every branch calls it" do
+    write("app/wrap.rb", <<~RUBY)
+      class Wrap
+        module Foo
+          def stamp(value)
+            value
+          end
+        end
+
+        module Baz
+          extend Wrap::Foo
+
+          stamp(2)
+        end
+
+        class Bar
+          extend Wrap::Foo
+
+          stamp(1)
+        end
+      end
+    RUBY
+
+    expect(narrower.narrow(method_name: "stamp", declared: declared)).to eq(declared)
+  end
+
+  # What `self` is inside the callee is then the receiver's type, which this
+  # walk does not resolve — so the picture is no longer whole and nothing is
+  # subtracted.
+  it "declines when the method is called on a receiver anywhere" do
+    write_two_extenders
+    write("app/elsewhere.rb", <<~RUBY)
+      class Elsewhere
+        def run(target)
+          target.stamp(3)
+        end
+      end
+    RUBY
+
+    expect(narrower.narrow(method_name: "stamp", declared: declared)).to eq(declared)
+  end
+
+  # Including a bare call whose `self` is the module itself: there `self` IS the
+  # union, so the union is the answer.
+  it "declines when a bare call sits outside every declared branch" do
+    write_two_extenders
+    write("app/elsewhere.rb", <<~RUBY)
+      class Elsewhere
+        def run
+          stamp(3)
+        end
+      end
+    RUBY
+
+    expect(narrower.narrow(method_name: "stamp", declared: declared)).to eq(declared)
+  end
+
+  # An uncalled method says nothing about its `self`. Narrowing to the empty set
+  # would be inventing a fact rather than reading one.
+  it "declines when nothing calls the method" do
+    write("app/wrap.rb", <<~RUBY)
+      class Wrap
+        module Foo
+          def stamp(value)
+            value
+          end
+        end
+      end
+    RUBY
+
+    expect(narrower.narrow(method_name: "stamp", declared: declared)).to eq(declared)
+  end
+
+  # A single host has nothing to subtract, and the walk is skipped entirely.
+  it "leaves a one-branch declaration alone" do
+    write_two_extenders
+
+    expect(narrower.narrow(method_name: "stamp", declared: "(Card & Card::Entropic)"))
+      .to eq("(Card & Card::Entropic)")
+  end
+
+  # A call written at the start of a line is what `files_with_bare_call` matches;
+  # this one is not, and missing it would have narrowed `Baz` away wrongly.
+  it "sees a bare call that is not at the start of a line" do
+    write_two_extenders(baz_body: "    x = stamp(2)")
+
+    expect(narrower.narrow(method_name: "stamp", declared: declared)).to eq(declared)
+  end
+end

--- a/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
@@ -28,12 +28,24 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
     found
   end
 
-  # Test-only builder. `module_self_types:` is REQUIRED in production (a caller
-  # that forgets it types every `self` inside a concern `untyped` — see
-  # docs/engineering/required-threaded-deps.md), and hardly an example here is
-  # about that map; the ones that are pass their own.
+  # Test-only builder. `module_self_types:` and `invoker_self_types:` are both
+  # REQUIRED in production (a caller that forgets the first types every `self`
+  # inside a concern `untyped`; one that forgets the second cannot narrow it —
+  # see docs/engineering/required-threaded-deps.md), and hardly an example here
+  # is about either; the ones that are pass their own.
+  #
+  # The narrower is the real one over an empty corpus rather than a stub: with
+  # no files to read it finds no call sites and declines, which is exactly "do
+  # not narrow" — and it stays honest if the class changes.
   def build_collector(**kwargs)
-    described_class.new(module_self_types: {}, **kwargs)
+    described_class.new(module_self_types: {}, invoker_self_types: null_invoker_self_types, **kwargs)
+  end
+
+  def null_invoker_self_types
+    @null_invoker_self_types ||= RbsInfer::Inference::InvokerSelfTypes.new(
+      source_index: RbsInfer::Project::SourceIndex.new([]),
+      parse_cache: RbsInfer::Project::ParseCache.new
+    )
   end
 
   def collect_usages(source, target_class:, method_return_types: {}, local_var_types: {})
@@ -163,7 +175,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
 
     with_temp_files(files) do |dir, paths|
       Dir.chdir(dir) do
-        resolver = RbsInfer::Signatures::MethodTypeResolver.new(paths, constant_resolver: fake_constant_resolver, mixin_index: RbsInfer::Project::MixinIndex.new(paths))
+        resolver = RbsInfer::Signatures::MethodTypeResolver.new(paths, constant_resolver: fake_constant_resolver, mixin_index: RbsInfer::Project::MixinIndex.new(paths), invoker_self_types: null_invoker_self_types)
         source = File.read(paths.last)
         result = Prism.parse(source)
         visitor = build_collector(
@@ -594,7 +606,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
 
       with_temp_files(files) do |dir, paths|
         Dir.chdir(dir) do
-          resolver = RbsInfer::Signatures::MethodTypeResolver.new(paths, constant_resolver: fake_constant_resolver, mixin_index: RbsInfer::Project::MixinIndex.new(paths))
+          resolver = RbsInfer::Signatures::MethodTypeResolver.new(paths, constant_resolver: fake_constant_resolver, mixin_index: RbsInfer::Project::MixinIndex.new(paths), invoker_self_types: null_invoker_self_types)
           source = File.read(File.join(dir, "caller.rb"))
           result = Prism.parse(source)
           visitor = build_collector(

--- a/spec/lib/rbs_infer/signatures/method_type_resolver_spec.rb
+++ b/spec/lib/rbs_infer/signatures/method_type_resolver_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     described_class.new(
       source_files,
       mixin_index: RbsInfer::Project::MixinIndex.new(source_files),
+      invoker_self_types: RbsInfer::Inference::InvokerSelfTypes.new(
+        source_index: RbsInfer::Project::SourceIndex.new(source_files),
+        parse_cache: RbsInfer::Project::ParseCache.new
+      ),
       **kwargs
     )
   end


### PR DESCRIPTION
Fecha #222.

O self-type de um módulo responde *"que `self` este método pode ter?"* — todo host que o inclui, todo que o estende. É a resposta certa para uma **declaração** e larga demais para um **argumento**. Em `Example23`, `Foo#bazinga` é invocado uma vez, no corpo de `Bar`, então o `self` que ele passa adiante é `singleton(Bar)`; tipar o parâmetro com a união fazia o corpo de `Baz.bazingado` parar de checar, porque `Baz` não tem `log_something`.

## O que muda

`RbsInfer::Inference::InvokerSelfTypes` (novo): dado um nome de método e o self-type declarado, devolve o declarado a menos que os call-sites provem um mais estreito. Só **remove** ramos que a declaração já listava, e recusa — devolvendo o declarado intacto — assim que a prova está incompleta:

- o método é chamado sobre um **receiver** em algum lado (`x.bazinga`) — aí o `self` do callee é o tipo do receiver, que este walk não resolve;
- uma chamada nua está num `self` que não é nenhum dos ramos declarados — incluindo dentro do próprio módulo, onde `self` **é** a união;
- ninguém chama o método — um método não chamado não diz nada sobre o seu `self`, e estreitar para o conjunto vazio seria inventar um facto.

Ancorado em `NewCallCollector#module_self_type`, que já sabe o módulo e o método correntes. Vive no `Corpus`, ao lado dos outros índices, para o memo por nome de método sobreviver de um alvo para o seguinte.

### `SourceIndex#files_mentioning`

Os três índices existentes são filtros de **candidatos**, afinados para sobre-aproximar barato numa busca que um passo posterior filtra — e nenhum serve para responder *"não há mais nada em lado nenhum"*, que é o que um estreitamento precisa:

- `files_calling` casa `.nome` atravessando newline, então um comentário terminado em ponto por cima de uma chamada nua conta como chamada com receiver. Foi exatamente o que aconteceu aqui na primeira tentativa;
- `files_with_bare_call` só casa no início de linha, então `x = nome(1)` não conta de todo — e perder essa chamada teria estreitado um ramo indevidamente.

`files_mentioning` é o superset por palavra; se a ocorrência é uma chamada, e se tem receiver, decide-se no AST. Varrido on demand e memoizado, pela mesma razão que `files_with_bare_call` documenta.

## Efeito

```diff
 class Example23
   module Foo
-    def bazinga: (singleton(::Example23::Baz) module_included) -> untyped
+    def bazinga: (singleton(::Example23::Baz) module_included) -> String
     def bazingado: (untyped base_foo) -> nil
   end

   module Baz
     extend ::Example23::Foo

-    def self.bazingado: ((singleton(Example23::Bar) | singleton(Example23::Baz)) base_foo) -> untyped
+    def self.bazingado: (singleton(Example23::Bar) base_foo) -> String
   end
 end
```

Os return types vêm de borda: com `base_foo` estreitado, `base_foo.log_something(...)` resolve (`-> String`), e `module_included.bazingado(self)` atrás dele também. A cadeia inteira fecha.

No baseline do Steep, a entrada do `log_something` **sai**:

```diff
-app/models/example23.rb:22:32: [error] Cannot pass a value of type `self` as an argument of type `(singleton(::Example23::Bar) | singleton(::Example23::Baz))`
-app/models/example23.rb:35:15: [error] Type `(singleton(::Example23::Bar) | singleton(::Example23::Baz))` does not have method `log_something`
+app/models/example23.rb:23:32: [error] Cannot pass a value of type `self` as an argument of type `singleton(::Example23::Bar)`
```

A que fica é a #221 — o Steep não vê o `self` de um módulo só estendido — com o tipo e a linha atualizados. É independente deste estreitamento: dispararia qualquer que fosse o tipo do parâmetro.

## Fiação

`invoker_self_types` é **obrigatório** em `NewCallCollector`, `CallerFileAnalyzer`, `ParamTypeInferrer` e `MethodTypeResolver`, ao lado do `mixin_index` que já era: esquecê-lo não parte nada, só devolve um parâmetro largo demais sem diagnóstico — o caso silent-wrong de `docs/engineering/required-threaded-deps.md`. Os specs unitários que constroem esses objetos ganharam o default de teste no builder, que é o narrower **real** sobre um corpus vazio: sem ficheiros não encontra call-sites e recusa, que é exatamente "não estreites", e continua honesto se a classe mudar.

## Verificação

- `bundle exec rspec` (suíte completa) — 1175 exemplos, 0 falhas. Os 7 novos estão em `invoker_self_types_spec.rb`: o caso que estreita, o que não estreita porque todos chamam, e as quatro recusas — receiver, `self` fora da união, ninguém chama, um ramo só — mais a chamada nua fora do início da linha, que é a que `files_with_bare_call` perderia).
- `make rbs_infer` iterado até ponto fixo; expectation e `sig/` versionado no mesmo texto.
