### PR TITLE
fix: hand the narrowed module `self` to the checker, per method

### DIFF
--- a/lib/rbs_infer/extensions/rails/module_self_type_annotator.rb
+++ b/lib/rbs_infer/extensions/rails/module_self_type_annotator.rb
@@ -33,9 +33,12 @@ module RbsInfer
         # @param module_name [String] the real FQN from the AST (e.g. "Search::Record::SQLite")
         # @param source [String] the file's source (for concern detection)
         # @param mixin_index [MixinIndex, nil] the `include`s written in the sources
-        # @return [Hash, nil] `{ "anchor" => leaf, "annotations" => [lines] }`, or
-        #   nil when nothing says what the module is mixed into.
-        def entry_for(path:, module_name:, source:, mixin_index: nil)
+        # @param invoker_self_types [InvokerSelfTypes, nil] narrows the module-wide
+        #   answer to the hosts that call each method; omitted, no `defs` is emitted
+        # @return [Hash, nil] `{ "anchor" => leaf, "annotations" => [lines] }` plus
+        #   `"defs" => { method => type }` where a method narrows, or nil when
+        #   nothing says what the module is mixed into.
+        def entry_for(path:, module_name:, source:, mixin_index: nil, invoker_self_types: nil)
           return nil if module_name.nil? || module_name.empty?
 
           hosts = hosts_for(path, module_name, mixin_index)
@@ -44,8 +47,63 @@ module RbsInfer
 
           anchor = module_name.split("::").last
           is_concern = source.include?("extend ActiveSupport::Concern")
+          instance = instance_type(module_name, hosts, extenders)
 
-          { "anchor" => anchor, "annotations" => annotations(module_name, hosts, extenders, is_concern) }
+          entry = { "anchor" => anchor, "annotations" => annotations(instance, module_name, hosts, is_concern) }
+          defs = narrowed_defs(anchor, source, instance, invoker_self_types)
+          entry["defs"] = defs if defs.any?
+          entry
+        end
+
+        # `{ "bazinga" => "singleton(::Example23::Bar)" }` — the methods of this
+        # module whose `self` is narrower than the module's own.
+        #
+        # The module-wide line answers "what may `self` be anywhere in here",
+        # which is the union over every host. A method only one host ever calls
+        # runs with that one, and `InvokerSelfTypes` (felixefelip/rbs_infer#222)
+        # already reads that off the call sites — it is what types the ARGUMENT
+        # such a method passes. Emitting it here is what makes the two agree:
+        # without it the body cannot pass its own `self` to a parameter typed
+        # from that very narrowing (felixefelip/rbs_infer#221).
+        #
+        # Only the methods that actually narrow, so a module whose `self` is one
+        # host, or whose methods nobody calls, writes nothing new.
+        def narrowed_defs(anchor, source, instance, invoker_self_types)
+          return {} if invoker_self_types.nil?
+
+          declared = "(#{instance})"
+          instance_method_names(anchor, source).each_with_object({}) do |name, acc|
+            narrowed = invoker_self_types.narrow(method_name: name, declared: declared)
+            acc[name] = narrowed unless narrowed == declared
+          end
+        end
+
+        # The instance methods the module named `anchor` declares directly. A
+        # `def self.` is excluded for the same reason Steep's placement skips
+        # it: its `self` is the module object, which no invoker narrows.
+        def instance_method_names(anchor, source)
+          node = find_scope(Prism.parse(source).value, anchor)
+          body = node&.body
+          return [] unless body.is_a?(Prism::StatementsNode)
+
+          body.body.filter_map do |stmt|
+            stmt.name.to_s if stmt.is_a?(Prism::DefNode) && stmt.receiver.nil?
+          end
+        end
+
+        def find_scope(node, anchor)
+          return nil unless node.is_a?(Prism::Node)
+
+          if (node.is_a?(Prism::ModuleNode) || node.is_a?(Prism::ClassNode)) &&
+             node.constant_path.respond_to?(:name) && node.constant_path.name.to_s == anchor
+            return node
+          end
+
+          node.compact_child_nodes.each do |child|
+            found = find_scope(child, anchor)
+            return found if found
+          end
+          nil
         end
 
         # Every class a module is mixed into by `include`.
@@ -94,10 +152,13 @@ module RbsInfer
         # (`Card & Card::Entropic`), an extended one's runs on the host's class
         # object (`singleton(Bar)`) — no intersection with the module, because
         # the RBS reopen already writes `extend ::Foo` on that singleton.
-        def annotations(module_name, hosts, extenders, is_concern)
-          instances = hosts.map { |host| "#{host} & #{module_name}" } +
-                      extenders.map { |extender| "singleton(#{extender})" }
-          instance = "# @type instance: #{union(instances)}"
+        def instance_type(module_name, hosts, extenders)
+          union(hosts.map { |host| "#{host} & #{module_name}" } +
+                extenders.map { |extender| "singleton(#{extender})" })
+        end
+
+        def annotations(instance_type, module_name, hosts, is_concern)
+          instance = "# @type instance: #{instance_type}"
           return [instance] unless is_concern
 
           # Only the `include` hosts: the `self` of a module's SINGLETON methods

--- a/lib/rbs_infer/extensions/rails/module_self_type_generator.rb
+++ b/lib/rbs_infer/extensions/rails/module_self_type_generator.rb
@@ -95,7 +95,8 @@ module RbsInfer
         def self_types_for(rel, source, tree)
           RbsInfer::Inference::NewCallCollector.collect_defined_class_names(tree).sort.filter_map do |name|
             ModuleSelfTypeAnnotator.entry_for(path: rel, module_name: name, source: source,
-                                              mixin_index: mixin_index)
+                                              mixin_index: mixin_index,
+                                              invoker_self_types: invoker_self_types)
           end
         end
 
@@ -119,6 +120,17 @@ module RbsInfer
         # in-process annotation read one project and cannot disagree.
         def mixin_index
           @mixin_index ||= RbsInfer::Project::MixinIndex.new(source_files)
+        end
+
+        # Narrows a module method's `self` to the hosts that call it
+        # (felixefelip/rbs_infer#222), over the SAME files as the index above —
+        # this sidecar and the in-process annotation read one project and
+        # cannot disagree.
+        def invoker_self_types
+          @invoker_self_types ||= RbsInfer::Inference::InvokerSelfTypes.new(
+            source_index: RbsInfer::Project::SourceIndex.new(source_files),
+            parse_cache: RbsInfer::Project::ParseCache.new
+          )
         end
 
         # Exactly what the project tells Steep to check, `ignore`s included —

--- a/spec/dummy/app/models/example23.rb
+++ b/spec/dummy/app/models/example23.rb
@@ -12,11 +12,13 @@
 # `Baz.bazingado` is `singleton(Bar)`. With that, `base_foo.log_something` resolves and
 # the whole chain closes — both return types follow.
 #
-# What #221 is about lives here too: rbs_infer knows the `self` of `Foo`'s instance
-# methods (`ModuleSelfTypeAnnotator` injects it) while Steep does not, because the
-# annotator writes the self-type line from the `include` hosts only and nobody includes
-# `Foo`. Whether that shows up as an error depends on what the parameter ends up
-# demanding, which is why it is a separate issue from the narrowing.
+# And the same narrowing reaches the checker (felixefelip/rbs_infer#221), which it has
+# to or the two halves disagree: rbs_infer would type the call site with `singleton(Bar)`
+# while Steep still read `bazinga`'s own `self` as the union, and the body could not pass
+# its `self` to the parameter it had just typed. One line per module cannot say it —
+# `bazinga` narrows, `bazingado` does not (nobody calls it) — so the sidecar carries a
+# `defs` entry and the annotation rides `bazinga`'s signature line. This file type-checks
+# with no baseline entry; both of the ones it used to have are gone.
 class Example23
   module Foo
     def bazinga(module_included)

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -48,6 +48,8 @@ app/models/example23.rb:
   - anchor: Foo
     annotations:
     - "# @type instance: (singleton(Example23::Bar)) | (singleton(Example23::Baz))"
+    defs:
+      bazinga: singleton(Example23::Bar)
 app/models/example3.rb:
   modules:
   - anchor: GeneratedAttributes

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -5,7 +5,6 @@ app/models/example14.rb:15:17: [error] Type `(::Example14::User | nil)` does not
 app/models/example15.rb:25:25: [error] Type `(::Example15::User | nil)` does not have method `name`
 app/models/example21.rb:105:31: [error] Type `(::Example21::Holder | nil)` does not have method `name`
 app/models/example21.rb:96:29: [error] Type `(::Example21::Ticket | nil)` does not have method `holder`
-app/models/example23.rb:23:32: [error] Cannot pass a value of type `self` as an argument of type `singleton(::Example23::Bar)`
 app/models/example3.rb:123:11: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:64:13: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:65:26: [error] Type `(::Example3::User | nil)` does not have method `name`

--- a/spec/lib/rbs_infer/extensions/rails/module_self_type_annotator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/module_self_type_annotator_spec.rb
@@ -39,6 +39,79 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeAnnotator do
       expect(entry["annotations"]).to eq(["# @type instance: Post & Post::Taggable"])
     end
 
+    # felixefelip/rbs_infer#221. One annotation per module cannot answer a
+    # question whose answer varies by method, and it has to: the same narrowing
+    # types the ARGUMENT such a method passes, so the body has to see it too or
+    # the two disagree.
+    describe "per-def self (defs)" do
+      TWO_EXTENDERS = <<~RUBY
+        class Wrap
+          module Foo
+            def stamp(value)
+              value
+            end
+
+            def other(value)
+              value
+            end
+          end
+        end
+      RUBY
+
+      # Narrows `stamp` and declines on anything else, which is what
+      # `InvokerSelfTypes` does for a method nobody calls.
+      def narrower_answering(answers)
+        double(:invoker_self_types).tap do |narrower|
+          allow(narrower).to receive(:narrow) do |method_name:, declared:|
+            answers.fetch(method_name, declared)
+          end
+        end
+      end
+
+      def entry_with(narrower)
+        described_class.entry_for(
+          path: "app/models/wrap.rb",
+          module_name: "Wrap::Foo",
+          source: TWO_EXTENDERS,
+          mixin_index: index_answering([], extenders: ["Wrap::Bar", "Wrap::Baz"]),
+          invoker_self_types: narrower
+        )
+      end
+
+      it "records only the methods whose self is narrower than the module's" do
+        entry = entry_with(narrower_answering("stamp" => "singleton(Wrap::Bar)"))
+
+        expect(entry["annotations"])
+          .to eq(["# @type instance: (singleton(Wrap::Bar)) | (singleton(Wrap::Baz))"])
+        expect(entry["defs"]).to eq("stamp" => "singleton(Wrap::Bar)")
+      end
+
+      it "omits the key entirely when nothing narrows" do
+        expect(entry_with(narrower_answering({}))).not_to have_key("defs")
+      end
+
+      # The plugin path (`self_type_entries`) has no narrower to pass, and the
+      # in-process pipeline does its own narrowing at read time anyway.
+      it "omits the key when no narrower is given" do
+        expect(entry_with(nil)).not_to have_key("defs")
+      end
+
+      # `def self.x`'s self is the module object — no invoker narrows it, and
+      # Steep's placement skips it for the same reason.
+      it "does not ask about a singleton method" do
+        narrower = narrower_answering("stamp" => "singleton(Wrap::Bar)")
+        entry = described_class.entry_for(
+          path: "app/models/wrap.rb",
+          module_name: "Wrap::Foo",
+          source: "class Wrap\n  module Foo\n    def self.stamp(v)\n      v\n    end\n  end\nend\n",
+          mixin_index: index_answering([], extenders: ["Wrap::Bar", "Wrap::Baz"]),
+          invoker_self_types: narrower
+        )
+
+        expect(entry).not_to have_key("defs")
+      end
+    end
+
     # There is no convention for a model concern any more: its host is always
     # written down, and guessing it from the namespace only ever spoke where the
     # guess was wrong — `Test::Filtrable` got `Test`, a directory, and the


### PR DESCRIPTION
Fecha #221. Par de felixefelip/steep#141 — este PR decide *o quê*, o do fork faz a *colocação*; nenhum dos dois serve sozinho.

## O problema

O #222 estreitou o `self` que um método de módulo passa adiante para o host que o chama, e tipou com isso o parâmetro que o recebe. A outra metade desse mesmo facto nunca saiu do rbs_infer: o Steep continuou a ler o `self` do próprio `Foo#bazinga` como a união sobre os extensores de `Foo`, então o corpo não conseguia passar o seu `self` a um parâmetro que aquele mesmo estreitamento acabara de tipar.

```
Cannot pass a value of type `self` as an argument of type `singleton(::Example23::Bar)`
  self <: singleton(::Example23::Bar)
    (singleton(::Example23::Bar) | singleton(::Example23::Baz)) <: singleton(::Example23::Bar)
```

A segunda linha é o diagnóstico, e corrige o que a #221 dizia originalmente: o Steep **vê** o self do módulo — o `# @type instance:` do sidecar chega lá e funciona. O que ele não tem é a versão por método. O sidecar é ancorado no **módulo**, e a resposta varia: `bazinga` estreita para `singleton(Bar)`, o vizinho `bazingado` não estreita de todo (ninguém o chama). Uma linha não diz as duas coisas.

## O que muda

`ModuleSelfTypeAnnotator` pergunta ao `InvokerSelfTypes` (#222) por cada método de **instância** do módulo e emite os que estreitam:

```yaml
app/models/example23.rb:
  modules:
  - anchor: Foo
    annotations:
    - "# @type instance: (singleton(Example23::Bar)) | (singleton(Example23::Baz))"
    defs:
      bazinga: singleton(Example23::Bar)
```

felixefelip/steep#141 lê a chave `defs` e põe `# @type self:` na linha da assinatura de cada método nomeado, pegando carona numa linha existente — sem acrescentar linha, sem deslocar número nenhum. É a mesma divisão que o sidecar já tinha para `modules` e `blocks`: o gerador conhece extensores e call-sites, o Steep coloca o comentário no sítio certo e não aprende nada sobre Rails.

Escreve-se **só o que estreita**, então um módulo com um host só, ou cujos métodos ninguém chama, não gera nada novo — no dummy inteiro é uma entrada. Um `def self.` fica de fora dos dois lados: o `self` dele é o objeto-módulo, que a linha do módulo já cobre e que nenhum invocador estreita.

O caminho de plugin (`self_type_entries`, usado pela injeção in-process) não passa narrower e não escreve `defs`: o pipeline estreita em tempo de leitura e não precisa da anotação.

De caminho, `annotations` foi partido em `instance_type` + `annotations`, para o tipo cru estar disponível sem o round-trip por regex sobre a linha que ele mesmo acabou de montar.

## Efeito

```diff
-app/models/example23.rb:23:32: [error] Cannot pass a value of type `self` as an argument of type `singleton(::Example23::Bar)`
```

`spec/expectations/steep_baseline.txt` volta exatamente ao conteúdo que tinha antes do #220: o `example23.rb` deixa de contribuir erro nenhum, depois de ter carregado dois. Nenhuma outra entrada mexe.

## Verificação

- `bundle exec rspec` (suíte completa) — 1179 exemplos, 0 falhas. Os 4 novos estão no `module_self_type_annotator_spec.rb`: só os métodos que estreitam entram, a chave não aparece quando nada estreita, nem quando não há narrower, e um `def self.` não é sequer perguntado.
- `steep check` no dummy: a entrada acima sai do baseline e nenhuma entra.
- Do lado do fork: `test/source/module_self_types_test.rb` 26 runs / 0 falhas, `test/source_test.rb` 40 runs / 0 falhas.

## Ordem de merge

felixefelip/steep#141 primeiro — sem ele o `defs` é escrito e ignorado (inerte, não quebra nada). O dummy resolve o steep por path, então o snapshot deste PR já foi medido com os dois aplicados.
