### PR TITLE
fix: write the self type in the one spelling an annotation accepts

### DIFF
--- a/lib/rbs_infer/extensions/rails/module_self_type_annotator.rb
+++ b/lib/rbs_infer/extensions/rails/module_self_type_annotator.rb
@@ -74,8 +74,37 @@ module RbsInfer
           declared = "(#{instance})"
           instance_method_names(anchor, source).each_with_object({}) do |name, acc|
             narrowed = invoker_self_types.narrow(method_name: name, declared: declared)
-            acc[name] = narrowed unless narrowed == declared
+            next if narrowed == declared
+
+            spelling = annotatable(narrowed) or next
+            acc[name] = spelling
           end
+        end
+
+        # The one spelling of a type that Steep will accept in an annotation.
+        #
+        # `AnnotationParser#parse_type` re-reads the parsed node's own location
+        # and demands it be byte-for-byte the string it was given. RBS drops a
+        # redundant outer parenthesis from that location — `(A | B)` parses to a
+        # union whose source is `A | B` — so a type RBS reads happily is a
+        # syntax error in an annotation, reported against the ANNOTATED FILE.
+        # `InvokerSelfTypes` wraps its answer because everywhere else that
+        # answer lands is a type position where a bare `|` or `&` would bind
+        # wrong; here it must not be wrapped, so ask RBS for the canonical form
+        # rather than trying to spell it.
+        #
+        # nil unless RBS reads the WHOLE string. `parse_type` stops at the first
+        # complete type and ignores the rest — `"not a type ("` comes back as
+        # `not` — which is the very thing Steep's check catches, one file too
+        # late. The input is either the canonical form or that form wrapped
+        # once, because that is all `InvokerSelfTypes` produces; anything else
+        # is a malformed narrowing and does not belong in a file Steep parses.
+        def annotatable(type)
+          canonical = RBS::Parser.parse_type(type).to_s
+          stripped = type.strip
+          canonical if stripped == canonical || stripped == "(#{canonical})"
+        rescue RBS::ParsingError, RBS::BaseError
+          nil
         end
 
         # The instance methods the module named `anchor` declares directly. A

--- a/spec/dummy/app/models/example23.rb
+++ b/spec/dummy/app/models/example23.rb
@@ -6,16 +6,22 @@
 # read first typed them both.
 #
 # It is also where the `self` a module method passes on gets narrowed
-# (felixefelip/rbs_infer#222). `Foo`'s declared `self` is the union over its extenders,
-# which is right as a declaration and too wide as an ARGUMENT: `bazinga` is invoked once,
-# by `bazinga(Example23::Baz)` in `Bar`'s class body, so the `self` it hands to
-# `Baz.bazingado` is `singleton(Bar)`. With that, `base_foo.log_something` resolves and
-# the whole chain closes — both return types follow.
+# (felixefelip/rbs_infer#222). `Foo`'s declared `self` is the union over all three
+# extenders, which is right as a declaration and too wide as an ARGUMENT: `bazinga` is
+# called from `Bar` and from `BarOther`, and from nowhere else, so the `self` it hands to
+# `Baz.bazingado` is those two and not `Baz` — which is what lets
+# `base_foo.log_something` resolve, closing the chain down to both return types.
+#
+# TWO callers rather than one, deliberately. With a single one the narrowing is a lone
+# `singleton(Bar)`, and a union is where the spelling starts to matter: `(A | B)` is a
+# type RBS reads happily and an annotation Steep refuses, because its parser re-reads the
+# parsed node's own location and RBS drops the outer parenthesis from it. One caller kept
+# that hidden (felixefelip/rbs_infer#225).
 #
 # And the same narrowing reaches the checker (felixefelip/rbs_infer#221), which it has
-# to or the two halves disagree: rbs_infer would type the call site with `singleton(Bar)`
-# while Steep still read `bazinga`'s own `self` as the union, and the body could not pass
-# its `self` to the parameter it had just typed. One line per module cannot say it —
+# to or the two halves disagree: rbs_infer would type the call site narrowly while Steep
+# still read `bazinga`'s own `self` as the full union, and the body could not pass its
+# `self` to the parameter it had just typed. One line per module cannot say it —
 # `bazinga` narrows, `bazingado` does not (nobody calls it) — so the sidecar carries a
 # `defs` entry and the annotation rides `bazinga`'s signature line. This file type-checks
 # with no baseline entry; both of the ones it used to have are gone.
@@ -39,6 +45,20 @@ class Example23
   end
 
   class Bar
+    extend Example23::Foo
+
+    def self.log_something(message)
+      puts message
+
+      message
+    end
+
+    # Runs at class-body time, so everything it reaches has to be defined
+    # already: `Baz` above, and `log_something` right here.
+    bazinga(Example23::Baz)
+  end
+
+  class BarOther
     extend Example23::Foo
 
     def self.log_something(message)

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -47,9 +47,10 @@ app/models/example23.rb:
   modules:
   - anchor: Foo
     annotations:
-    - "# @type instance: (singleton(Example23::Bar)) | (singleton(Example23::Baz))"
+    - "# @type instance: (singleton(Example23::Bar)) | (singleton(Example23::BarOther))
+      | (singleton(Example23::Baz))"
     defs:
-      bazinga: singleton(Example23::Bar)
+      bazinga: singleton(Example23::Bar) | singleton(Example23::BarOther)
 app/models/example3.rb:
   modules:
   - anchor: GeneratedAttributes

--- a/spec/dummy/sig/rbs_infer/app/models/example23.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example23.rbs
@@ -7,12 +7,20 @@ class Example23
   module Baz
     extend ::Example23::Foo
 
-    def self.bazingado: (singleton(Example23::Bar) base_foo) -> String
+    def self.bazingado: ((singleton(Example23::Bar) | singleton(Example23::BarOther)) base_foo) -> String
   end
 end
 
 class Example23
   class Bar
+    extend ::Example23::Foo
+
+    def self.log_something: (String message) -> String
+  end
+end
+
+class Example23
+  class BarOther
     extend ::Example23::Foo
 
     def self.log_something: (String message) -> String

--- a/spec/expectations/models/example23.rbs
+++ b/spec/expectations/models/example23.rbs
@@ -7,12 +7,20 @@ class Example23
   module Baz
     extend ::Example23::Foo
 
-    def self.bazingado: (singleton(Example23::Bar) base_foo) -> String
+    def self.bazingado: ((singleton(Example23::Bar) | singleton(Example23::BarOther)) base_foo) -> String
   end
 end
 
 class Example23
   class Bar
+    extend ::Example23::Foo
+
+    def self.log_something: (String message) -> String
+  end
+end
+
+class Example23
+  class BarOther
     extend ::Example23::Foo
 
     def self.log_something: (String message) -> String

--- a/spec/lib/rbs_infer/extensions/rails/module_self_type_annotator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/module_self_type_annotator_spec.rb
@@ -86,6 +86,24 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeAnnotator do
         expect(entry["defs"]).to eq("stamp" => "singleton(Wrap::Bar)")
       end
 
+      # felixefelip/steep#141's placement feeds this straight into
+      # `AnnotationParser`, which re-reads the parsed node's own location and
+      # demands it be byte-for-byte the string given. RBS drops a redundant
+      # outer parenthesis from that location, so `(A | B)` — which RBS itself
+      # reads happily — is `Ruby::AnnotationSyntaxError` in the ANNOTATED file.
+      # Two invoking hosts is what first produces a union here.
+      it "writes the union in the one spelling an annotation accepts" do
+        entry = entry_with(
+          narrower_answering("stamp" => "(singleton(Wrap::Bar) | singleton(Wrap::Other))")
+        )
+
+        expect(entry["defs"]).to eq("stamp" => "singleton(Wrap::Bar) | singleton(Wrap::Other)")
+      end
+
+      it "omits a self type RBS cannot read at all" do
+        expect(entry_with(narrower_answering("stamp" => "not a type ("))).not_to have_key("defs")
+      end
+
       it "omits the key entirely when nothing narrows" do
         expect(entry_with(narrower_answering({}))).not_to have_key("defs")
       end


### PR DESCRIPTION
Fecha #225. Par de felixefelip/steep#142 — este PR conserta a grafia, o do fork conserta o que a grafia corrigida destapou. Nenhum dos dois fecha o ficheiro sozinho.

Encontrado por você, ao pôr um **segundo invocador** de `bazinga` no `example23.rb`. É tudo o que era preciso: com um só, o estreitamento nunca forma uma união, e é na união que os dois bugs moram.

## 1. A grafia (aqui)

`InvokerSelfTypes` devolve a união entre parênteses, de propósito — em todo o outro sítio onde essa resposta cai é posição de tipo, onde um `|` ou `&` solto liga errado.

Numa anotação não pode. `Steep::AnnotationParser#parse_type` relê a `location` do nó parseado e exige que seja byte a byte a string recebida:

```ruby
unless (type.location || raise).source == string.strip
  raise SyntaxError.new(..., message: "Failed to parse a type in annotation")
end
```

E o RBS descarta o parêntese externo redundante dessa location:

| string | `location.source` | passa? |
|---|---|---|
| `(singleton(A) \| singleton(B))` | `singleton(A) \| singleton(B)` | não |
| `(singleton(A)) \| (singleton(B))` | igual à string | sim |
| `(A & B)` | `A & B` | não |
| `singleton(A)` | igual à string | sim |

Um tipo que o RBS lê sem se queixar é erro de sintaxe numa anotação — e reportado **contra a fixture**, não contra o sidecar que o produziu:

```
app/models/example23.rb:24:48: [error] Ruby::AnnotationSyntaxError
  Type annotation has a syntax error: Failed to parse a type in annotation
```

O annotator passa a pedir a forma canónica ao RBS (`parse_type(t).to_s`) em vez de tentar soletrá-la. Com um cuidado a mais: `parse_type` para no primeiro tipo completo e ignora o resto — `"not a type ("` volta como `not` —, que é exatamente o que o check do Steep apanha um ficheiro tarde demais. Portanto a canónica só é usada se der conta da string inteira, ou dela envolvida uma vez, que é tudo o que o `InvokerSelfTypes` produz.

## 2. O que isso destapou (felixefelip/steep#142)

Colocada e parseada a anotação, o `steep check` reportou outra coisa — um tipo a não ser subtipo de si mesmo:

```
self <: (singleton(Bar) | singleton(Other))
  self <: singleton(Bar)                                  ← parte a união antes de expandir self
    (singleton(Bar) | singleton(Other)) <: singleton(Bar) → falha
```

Detalhes e conserto no PR do fork. Reproduzido em 20 linhas fora do dummy.

## A fixture

O `BarOther` fica. Vale um caso: com um invocador só, o estreitamento é um `singleton(Bar)` isolado e nenhum dos dois bugs aparece. O cabeçalho do ficheiro diz porquê.

```diff
 class Example23
   module Baz
-    def self.bazingado: (singleton(Example23::Bar) base_foo) -> String
+    def self.bazingado: ((singleton(Example23::Bar) | singleton(Example23::BarOther)) base_foo) -> String
   end
 end
+
+class Example23
+  class BarOther
+    extend ::Example23::Foo
+
+    def self.log_something: (String message) -> String
+  end
+end
```

E no sidecar, `bazinga: singleton(Example23::Bar) | singleton(Example23::BarOther)` — canónico, sem parênteses externos.

## Verificação

- `bundle exec rspec spec/lib` — 1073 exemplos, 0 falhas (2 novos: a união escrita na grafia que uma anotação aceita, e um self type que o RBS não lê inteiro sendo descartado).
- `bundle exec rspec spec/integration/rails_dummy_spec.rb` — 82 exemplos, 0 falhas.
- `steep check` no dummy: o `example23.rb` fecha **sem entrada nenhuma** no baseline, que fica byte a byte como estava.
- Do lado do fork: `rake test` completa — 1845 runs, 7704 assertions, 0 falhas.

## Ordem de merge

felixefelip/steep#142 primeiro. Sem ele este PR troca um erro por outro no mesmo ficheiro. O dummy resolve o steep por path, então o snapshot aqui já foi medido com os dois aplicados.
