### PR TITLE
fix: a caller outside the declaration is calling something else, not nothing

### DIFF
--- a/lib/rbs_infer/inference/invoker_self_types.rb
+++ b/lib/rbs_infer/inference/invoker_self_types.rb
@@ -20,10 +20,22 @@ module RbsInfer::Inference
   # - the method is called on a RECEIVER somewhere (`x.bazinga`). What `self`
   #   is inside the callee is then the receiver's type, which this walk does not
   #   resolve, so the picture is no longer whole.
-  # - a bare call sits somewhere whose `self` is not one of the declared
-  #   branches — including inside the module itself, where `self` IS the union.
+  # - a bare call sits in a MODULE's instance method and the module is not one
+  #   of the declared branches. `self` there is whoever mixes THAT module in —
+  #   a name this record does not carry — so the call cannot be placed. It
+  #   covers the module's own body, where `self` is the whole union, and a
+  #   sibling concern sharing a host.
   # - nothing calls it at all. An uncalled method says nothing about its `self`;
   #   narrowing to the empty set would be inventing a fact, not reading one.
+  #
+  # The observations are gathered by method NAME across the corpus, so most of
+  # them belong to other methods that happen to share it. Those are dropped, not
+  # counted and not a reason to decline: a bare call resolves in its caller's
+  # own ancestry, and the declaration already lists every class whose ancestry
+  # carries this module (`hosts_of`/`extenders_of` resolve through module hosts
+  # to the classes). A caller outside that list is calling something else. Two
+  # namespaces with the same method names used to blank each other's narrowing
+  # (felixefelip/rbs_infer#227).
   #
   # Whole-program by construction, which is the assumption the analyzer already
   # makes everywhere else: the call sites it can see are the call sites there
@@ -45,12 +57,19 @@ module RbsInfer::Inference
 
       observed = observed_selves(method_name)
       return declared if observed.nil? || observed.empty?
-      # A `self` outside the declared union means a call site this walk placed
-      # somewhere the declaration does not admit — the two disagree, so neither
-      # is trusted to subtract from the other.
-      return declared unless observed.subset?(branches.to_set)
 
-      kept = branches.select { |branch| observed.include?(branch) }
+      declared_branches = branches.to_set
+      invokers = observed.filter_map do |self_type, module_instance|
+        next self_type if declared_branches.include?(self_type)
+        # Outside the declaration and unplaceable: `self` is a host this record
+        # cannot name, and it might be one of ours.
+        return declared if module_instance
+
+        nil
+      end.to_set
+      return declared if invokers.empty?
+
+      kept = branches.select { |branch| invokers.include?(branch) }
       return declared if kept.size == branches.size
 
       parenthesize(kept)
@@ -108,7 +127,13 @@ module RbsInfer::Inference
     end
 
     # Walks a file for bare calls to one method and records the `self` each runs
-    # under. Returns nil if any of them cannot be placed.
+    # under, as `[self type, from a module's instance method?]`. Returns nil if
+    # any of them cannot be placed at all.
+    #
+    # The flag is what tells a caller that resolves in its own ancestry — a
+    # class, or a module's own singleton — from one whose `self` is somebody
+    # else at runtime. Only the first kind can be dismissed for not appearing in
+    # a declaration.
     class SelfContextCollector < Prism::Visitor
       def self.collect(root, method_name)
         collector = new(method_name)
@@ -126,11 +151,13 @@ module RbsInfer::Inference
         # nil in a class/module body, :instance in a `def x`, :singleton in a
         # `def self.x` or under `class << self`.
         @scope = nil
+        # Whether the innermost enclosing declaration is a `module`.
+        @module_scope = false
         super()
       end
 
-      def visit_class_node(node) = with_path(node) { super }
-      def visit_module_node(node) = with_path(node) { super }
+      def visit_class_node(node) = with_path(node, module_scope: false) { super }
+      def visit_module_node(node) = with_path(node, module_scope: true) { super }
 
       def visit_singleton_class_node(node)
         outer = @scope
@@ -162,19 +189,25 @@ module RbsInfer::Inference
 
         owner = @path.join("::")
         # A body and a `def self.` both run on the class object; an instance
-        # method runs on an instance.
-        @selves << (@scope == :instance ? owner : "singleton(#{owner})")
+        # method runs on an instance. A module's INSTANCE method is the one case
+        # where that instance is not the thing named here but whoever mixes it
+        # in, which is what the flag records.
+        instance = @scope == :instance
+        @selves << [instance ? owner : "singleton(#{owner})", instance && @module_scope]
       end
 
-      def with_path(node)
+      def with_path(node, module_scope:)
         name = RbsInfer::Analyzer.extract_constant_path(node.constant_path)
         return yield if name.nil?
 
         @path.push(name)
-        outer = @scope
+        outer_scope = @scope
+        outer_module = @module_scope
         @scope = nil
+        @module_scope = module_scope
         yield
-        @scope = outer
+        @scope = outer_scope
+        @module_scope = outer_module
         @path.pop
       end
     end

--- a/spec/dummy/app/models/example24.rb
+++ b/spec/dummy/app/models/example24.rb
@@ -1,0 +1,41 @@
+# Example23's shape again, in its own namespace and with the same method names, which is
+# the whole point: `bazinga` and `bazingado` exist in both.
+#
+# The invoker-self narrowing gathers call sites by method NAME across the corpus, so this
+# file's callers show up when `Example23::Foo#bazinga` is asked about, and the other way
+# round. They used to be read as callers nobody could place, and the narrowing declined
+# for both files at once — the two namespaces blanking each other
+# (felixefelip/rbs_infer#227). A bare call resolves in its caller's own ancestry, and
+# `Example24::Bar` does not extend `Example23::Foo`, so it is calling something else.
+#
+# Deliberately thinner than Example23: no `log_something`, so nothing here depends on the
+# narrowing being USED. What it pins is that Example23's narrowing survives this file
+# existing, and that this file gets its own.
+class Example24
+  module Foo
+    def bazinga(module_included)
+      module_included.bazingado(self)
+    end
+
+    def bazingado(base_foo)
+      puts "base_foo class: #{base_foo.class}"
+    end
+  end
+
+  module Baz
+    extend Example24::Foo
+  end
+
+  class Bar
+    extend Example24::Foo
+
+    # Runs at class-body time, so `Baz` above has to be defined already.
+    bazinga(Example24::Baz)
+  end
+
+  class BarOther
+    extend Example24::Foo
+
+    bazinga(Example24::Baz)
+  end
+end

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -51,6 +51,14 @@ app/models/example23.rb:
       | (singleton(Example23::Baz))"
     defs:
       bazinga: singleton(Example23::Bar) | singleton(Example23::BarOther)
+app/models/example24.rb:
+  modules:
+  - anchor: Foo
+    annotations:
+    - "# @type instance: (singleton(Example24::Bar)) | (singleton(Example24::BarOther))
+      | (singleton(Example24::Baz))"
+    defs:
+      bazinga: singleton(Example24::Bar) | singleton(Example24::BarOther)
 app/models/example3.rb:
   modules:
   - anchor: GeneratedAttributes

--- a/spec/dummy/sig/rbs_infer/app/models/example24.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example24.rbs
@@ -1,0 +1,22 @@
+class Example24
+  module Foo
+    def bazinga: (singleton(::Example24::Baz) module_included) -> nil
+    def bazingado: (untyped base_foo) -> nil
+  end
+
+  module Baz
+    extend ::Example24::Foo
+  end
+end
+
+class Example24
+  class Bar
+    extend ::Example24::Foo
+  end
+end
+
+class Example24
+  class BarOther
+    extend ::Example24::Foo
+  end
+end

--- a/spec/expectations/models/example24.rbs
+++ b/spec/expectations/models/example24.rbs
@@ -1,0 +1,22 @@
+class Example24
+  module Foo
+    def bazinga: (singleton(::Example24::Baz) module_included) -> nil
+    def bazingado: (untyped base_foo) -> nil
+  end
+
+  module Baz
+    extend ::Example24::Foo
+  end
+end
+
+class Example24
+  class Bar
+    extend ::Example24::Foo
+  end
+end
+
+class Example24
+  class BarOther
+    extend ::Example24::Foo
+  end
+end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -603,6 +603,27 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     expect(rbs.chomp).to eq(expected_rbs(name).chomp)
   end
 
+  # The same shape in a second namespace, with the same method names. The
+  # invoker-self narrowing gathers call sites by NAME across the corpus, so each of these
+  # two files shows up in the other's observations; read as unplaceable callers, they
+  # blanked each other's narrowing (felixefelip/rbs_infer#227). Both snapshots are pinned
+  # so the poisoning cannot come back from either side.
+  it "example24" do
+    name = "models/example24"
+    rbs = RbsInfer::Analyzer.new(
+      target_file: "app/models/example24.rb",
+      source_files: source_files
+    ).generate_rbs
+
+    if ENV["UPDATE_EXPECTATIONS"]
+      path = expectations_dir.join("#{name}.rbs")
+      path.dirname.mkpath
+      path.write(rbs)
+    end
+
+    expect(rbs.chomp).to eq(expected_rbs(name).chomp)
+  end
+
   it "example20" do
     name = "models/example20"
     rbs = RbsInfer::Analyzer.new(

--- a/spec/lib/rbs_infer/inference/invoker_self_types_spec.rb
+++ b/spec/lib/rbs_infer/inference/invoker_self_types_spec.rb
@@ -102,14 +102,64 @@ RSpec.describe RbsInfer::Inference::InvokerSelfTypes do
     expect(narrower.narrow(method_name: "stamp", declared: declared)).to eq(declared)
   end
 
-  # Including a bare call whose `self` is the module itself: there `self` IS the
-  # union, so the union is the answer.
-  it "declines when a bare call sits outside every declared branch" do
+  # The observations are gathered by method NAME across the corpus, so most of
+  # them belong to other methods. A class resolves a bare call in its own
+  # ancestry, and the declaration already lists every class whose ancestry
+  # carries this module — so one that is not listed is calling something else.
+  # Two namespaces with the same method names used to blank each other's
+  # narrowing (felixefelip/rbs_infer#227).
+  it "ignores a bare call from a class the declaration does not list" do
     write_two_extenders
     write("app/elsewhere.rb", <<~RUBY)
       class Elsewhere
         def run
           stamp(3)
+        end
+      end
+    RUBY
+
+    expect(narrower.narrow(method_name: "stamp", declared: declared))
+      .to eq("singleton(Wrap::Bar)")
+  end
+
+  # A MODULE's instance method is the one caller that cannot be dismissed that
+  # way: `self` there is whoever mixes THAT module in, a name this record does
+  # not carry, and it might be one of ours — a sibling concern sharing a host.
+  it "declines when a bare call sits in a module's instance method" do
+    write_two_extenders
+    write("app/sibling.rb", <<~RUBY)
+      module Sibling
+        def run
+          stamp(3)
+        end
+      end
+    RUBY
+
+    expect(narrower.narrow(method_name: "stamp", declared: declared)).to eq(declared)
+  end
+
+  # Including the module's own body, where `self` is the whole union.
+  it "declines when the module itself calls the method" do
+    write("app/wrap.rb", <<~RUBY)
+      class Wrap
+        module Foo
+          def stamp(value)
+            value
+          end
+
+          def relay(value)
+            stamp(value)
+          end
+        end
+
+        module Baz
+          extend Wrap::Foo
+        end
+
+        class Bar
+          extend Wrap::Foo
+
+          stamp(1)
         end
       end
     RUBY


### PR DESCRIPTION
Closes #227. Found by you, when you added `example24.rb`.

## What happened

`example24.rb` repeats `example23.rb`'s shape in another namespace, with **the same method names**. That alone was enough to regress `example23.rbs`:

```diff
 class Example23
   module Baz
-    def self.bazingado: ((singleton(Example23::Bar) | singleton(Example23::BarOther)) base_foo) -> String
+    def self.bazingado: ((singleton(Example23::Bar) | singleton(Example23::BarOther) | singleton(Example23::Baz)) base_foo) -> untyped
   end
 end
```

and the `defs` key vanished from the sidecar — for both files.

`observed_selves` is memoized by method NAME over the whole corpus, with no notion of which module is asking:

```
observed("bazinga") = [singleton(Example23::Bar), singleton(Example23::BarOther),
                       singleton(Example24::Bar), singleton(Example24::BarOther)]
```

and `narrow` required the observed set to be a SUBSET of the declared branches: a `self` from outside meant a call site the walk could not place, so nothing was subtracted. Each namespace puts the other's callers outside its own union, and the guard fired both ways.

## The guard was wrong, not merely strict

The declared union is not an arbitrary list: it is precisely the set of selves whose **ancestry carries the module** — `hosts_of`/`extenders_of` resolve transitively through module hosts down to classes. And a bare call resolves in its caller's own ancestry.

So a class that is not in the union **cannot** be calling this method; it is calling a homonym. Dropping it is sound — and that is what was missing.

The one caller that cannot be dropped that way is a MODULE's instance method: its `self` at runtime is whoever mixes THAT module in, a name this record does not carry, and it might be one of ours — a sibling concern sharing a host. That covers the module's own body too, where `self` is the whole union. The collector now marks those observations, and they still decline.

A call on a receiver anywhere still declines, as before.

| observation | before | now |
|---|---|---|
| a declared branch | invoker | invoker |
| a class outside the union | **declines everything** | dropped |
| a module instance method outside the union | declines everything | declines everything |
| the module's own body | declines everything | declines everything |
| a call on a receiver | declines everything | declines everything |

## The fixture

`example24.rb` stays, and joins the integration suite next to example23 — so the poisoning cannot come back from either side. I trimmed the comments it inherited from example23 about a `log_something` it does not have, and it is deliberately thinner: nothing in it depends on the narrowing being USED, only on it existing.

Each file now narrows its own:

```yaml
app/models/example23.rb:
    defs:
      bazinga: singleton(Example23::Bar) | singleton(Example23::BarOther)
app/models/example24.rb:
    defs:
      bazinga: singleton(Example24::Bar) | singleton(Example24::BarOther)
```

and `example23.rbs` is byte-for-byte what it was.

## Verification

- `bundle exec rspec` (full suite) — 1184 examples, 0 failures.
- `spec/lib/rbs_infer/inference/invoker_self_types_spec.rb` — 9 examples. One of them I had to **rewrite**: `"declines when a bare call sits outside every declared branch"` pinned exactly the behaviour this PR corrects (its `Elsewhere` is today's `Example24::Bar`). Three took its place, one per row of the table above.
- `steep check` on the dummy: no new baseline entry; `example24.rb` checks clean too.
