### PR TITLE
fix: the ancestry can land on one of the target's nested modules

### DIFF
--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -241,8 +241,8 @@ module RbsInfer::Inference
               method_name
             elsif (owner_key = owner_match_key(receiver_type, method_name))
               owner_key
-            elsif ancestry_match?(receiver_type, method_name)
-              method_name
+            elsif (ancestry_key = ancestry_match_key(receiver_type, method_name))
+              ancestry_key
             end
 
           if key
@@ -516,13 +516,47 @@ module RbsInfer::Inference
     # same graph: `MixinIndex` records `include`/`prepend` and nothing else, so
     # a receiver that reaches the target by `extend` has no other oracle
     # (felixefelip/rbs_infer#208).
-    def ancestry_match?(receiver_type, method_name)
+    #
+    # Returns the `MethodKey` of the method the receiver reaches, or nil — the
+    # bare name when the ancestry lands on the target itself, the owner's key
+    # when it lands on one of the target's nested modules.
+    #
+    # That second case is the one `owner_match_key` deliberately leaves here: a
+    # `singleton(X)` receiver reaches a nested module's INSTANCE method only
+    # because X extends it, which is a fact of the ancestry and not of any name,
+    # so only the RBS can answer it. Answering it against the target alone left
+    # `Example24::Foo#bazingado` untyped — its one call site is
+    # `module_included.bazingado(self)` with `module_included` a
+    # `singleton(Example24::Baz)`, and `Baz` extends `Foo`
+    # (felixefelip/rbs_infer#229).
+    def ancestry_match_key(receiver_type, method_name)
       normalized_target = @target_class.sub(/\A::/, "")
 
-      receiver_components(receiver_type).any? do |component|
-        owner = rbs_definition_resolver.method_owner(component, method_name)
-        owner && owner.sub(/\A::/, "") == normalized_target
+      receiver_components(receiver_type).each do |component|
+        owner = rbs_definition_resolver.method_owner(component, method_name) or next
+
+        normalized_owner = owner.sub(/\A::/, "")
+        return method_name if normalized_owner == normalized_target
+
+        entry = nested_owner_entry(normalized_owner, method_name) or next
+        return RbsInfer::Inference::MethodKey.for(method_name, owner: entry[0], kind: entry[1])
       end
+
+      nil
+    end
+
+    # The target's nested owner the ancestry landed on, as `[owner, kind]`.
+    #
+    # The instance side wins a tie: reaching a nested module THROUGH the
+    # ancestry — `include` onto the instances, `extend` onto the singleton —
+    # always lands on its instance methods. Its `def self.` sits on the module's
+    # own singleton, which only a receiver naming the module reaches, and
+    # `owner_match_key` answers that one by name before this runs.
+    def nested_owner_entry(owner_name, method_name)
+      entries = @method_owners[method_name] or return nil
+
+      matching = entries.select { |owner, _| owner == owner_name }
+      matching.find { |_, kind| kind == :method } || matching.first
     end
 
     def rbs_definition_resolver

--- a/spec/dummy/sig/rbs_infer/app/models/example24.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example24.rbs
@@ -1,7 +1,7 @@
 class Example24
   module Foo
     def bazinga: (singleton(::Example24::Baz) module_included) -> nil
-    def bazingado: (untyped base_foo) -> nil
+    def bazingado: ((singleton(Example24::Bar) | singleton(Example24::BarOther)) base_foo) -> nil
   end
 
   module Baz

--- a/spec/expectations/models/example24.rbs
+++ b/spec/expectations/models/example24.rbs
@@ -1,7 +1,7 @@
 class Example24
   module Foo
     def bazinga: (singleton(::Example24::Baz) module_included) -> nil
-    def bazingado: (untyped base_foo) -> nil
+    def bazingado: ((singleton(Example24::Bar) | singleton(Example24::BarOther)) base_foo) -> nil
   end
 
   module Baz

--- a/spec/lib/rbs_infer/inference/extend_call_site_spec.rb
+++ b/spec/lib/rbs_infer/inference/extend_call_site_spec.rb
@@ -59,6 +59,98 @@ RSpec.describe "a call site reaching the target through extend" do
     expect(rbs).to include("def notify: (String target) ->")
   end
 
+  # The same reach, one level in: the module is NESTED under the target, so it is not a
+  # target of its own (felixefelip/rbs_infer#22) and the ancestry lands on a name the
+  # enclosing target does not answer to. Compared against the target alone — which is all
+  # this matcher used to do — the call site was dropped and the parameter stayed `untyped`
+  # (felixefelip/rbs_infer#229).
+  it "types a nested module's method reached by extend from a sibling" do
+    target = write("app/wrap.rb", <<~RUBY)
+      class Wrap
+        module Mixin
+          def notify(value)
+            value
+          end
+        end
+
+        module Host
+          extend Wrap::Mixin
+        end
+      end
+    RUBY
+    write("app/caller.rb", <<~RUBY)
+      class Caller
+        def run
+          klass = Wrap::Host
+          klass.notify("hi")
+        end
+      end
+    RUBY
+    write("sig/generated/wrap.rbs", <<~RBS)
+      class Wrap
+        module Mixin
+          def notify: (untyped value) -> untyped
+        end
+
+        module Host
+          extend ::Wrap::Mixin
+        end
+      end
+    RBS
+
+    rbs = RbsInfer::Analyzer.new(target_class: "Wrap", target_file: target, source_files: Dir["app/*.rb"]).generate_rbs
+
+    expect(rbs).to include("def notify: (String value) ->")
+  end
+
+  # And a `def self.` of the same name on the extender SHADOWS it, so the call site
+  # belongs to that one and the module's own stays untouched.
+  it "leaves the module alone when the extender shadows the method" do
+    target = write("app/wrap.rb", <<~RUBY)
+      class Wrap
+        module Mixin
+          def notify(value)
+            value
+          end
+        end
+
+        module Host
+          extend Wrap::Mixin
+
+          def self.notify(value)
+            value
+          end
+        end
+      end
+    RUBY
+    write("app/caller.rb", <<~RUBY)
+      class Caller
+        def run
+          klass = Wrap::Host
+          klass.notify("hi")
+        end
+      end
+    RUBY
+    write("sig/generated/wrap.rbs", <<~RBS)
+      class Wrap
+        module Mixin
+          def notify: (untyped value) -> untyped
+        end
+
+        module Host
+          extend ::Wrap::Mixin
+
+          def self.notify: (untyped value) -> untyped
+        end
+      end
+    RBS
+
+    rbs = RbsInfer::Analyzer.new(target_class: "Wrap", target_file: target, source_files: Dir["app/*.rb"]).generate_rbs
+
+    expect(rbs).to include("def self.notify: (String value) ->")
+    expect(rbs).to include("def notify: (untyped value) ->")
+  end
+
   # The receiver's type is what decides, not the method's name: `singleton(Host)` reaches
   # `Mixin` only because `Host` extends it. A class that does not gives nothing away.
   it "leaves the parameter untyped when the receiver's singleton does not reach the target" do


### PR DESCRIPTION
Closes #229. Found by you, asking why `Example24::Foo#bazingado` came out `untyped`.

## Two `untyped`s, one of them wrong

`example23.rb` and `example24.rb` sit side by side and both print `def bazingado: (untyped base_foo)` on `Foo`. Only one of them is right.

In example23, `Baz` declares `def self.bazingado`, which **shadows** `Foo`'s: the call site belongs to `Baz.bazingado`, that is where the type lands, and `Foo#bazingado` staying `untyped` is correct. In example24 there is no shadow — `Baz` only extends `Foo` — so `module_included.bazingado(self)` reaches `Foo#bazingado`, and the `self` it passes has been narrowed to `(singleton(Bar) | singleton(BarOther))` since #222. That one should have been typed.

## Cause

The three matchers, and what RBS answers for each receiver:

| receiver | `method_owner` |
|---|---|
| `singleton(::Example23::Baz).bazingado` | `::Example23::Baz` |
| `singleton(::Example24::Baz).bazingado` | `::Example24::Foo` |

- `match_class?` compares against the target `Example24`. No match.
- `owner_match_key` unwraps `singleton()` and requires `kind == :class_method`, **on purpose** — its own comment says a `singleton(X)` reaches a module's instance method only because X extends it, "which `ancestry_match?` answers off the RBS".
- `ancestry_match?` asks RBS, gets the right owner (`::Example24::Foo`), and then compares it **against the target alone**. `Example24::Foo` ≠ `Example24`, so the call site is dropped.

#215 taught `owner_match?` about the target's nested modules and left `ancestry_match?` behind — the one matcher the other two delegate this exact case to.

## Fix

`ancestry_match?` becomes `ancestry_match_key` and returns a `MethodKey`: the bare name when the ancestry lands on the target itself (the Active Record case, `user.filters.from_params`, unchanged), the owner's key when it lands on one of the target's nested modules.

The instance side wins a tie on kind: reaching a nested module THROUGH the ancestry — `include` onto the instances, `extend` onto the singleton — always lands on its instance methods. Its `def self.` lives on the module's own singleton, which only a receiver naming the module reaches, and `owner_match_key` answers that one by name first.

## Effect

```diff
 class Example24
   module Foo
     def bazinga: (singleton(::Example24::Baz) module_included) -> nil
-    def bazingado: (untyped base_foo) -> nil
+    def bazingado: ((singleton(Example24::Bar) | singleton(Example24::BarOther)) base_foo) -> nil
   end
 end
```

One file in the whole dummy. example23 does not move: `Foo#bazingado` stays `untyped` because it is shadowed, and `Baz.bazingado` keeps the type.

## Verification

- `bundle exec rspec` (full suite) — 1186 examples, 0 failures.
- Two new examples in `extend_call_site_spec.rb`, the pair rather than the case alone: a nested module reached by `extend` from a sibling gets its parameter typed, and an extender that declares a `def self.` of the same name keeps it for itself. The first fails without this change; the second passes either way, which is what makes it worth having.
- `steep check` on the dummy: no new baseline entry. That matters here — the parameter stopped being `untyped`, so it is now actually checked.
