### PR TITLE
feat: declare which self goes with which argument, so the checker can follow

### DIFF
--- a/lib/rbs_infer/extensions/rails/module_self_type_annotator.rb
+++ b/lib/rbs_infer/extensions/rails/module_self_type_annotator.rb
@@ -52,7 +52,52 @@ module RbsInfer
           entry = { "anchor" => anchor, "annotations" => annotations(instance, module_name, hosts, is_concern) }
           defs = narrowed_defs(anchor, source, instance, invoker_self_types)
           entry["defs"] = defs if defs.any?
+          paths = declared_paths(anchor, source, instance, invoker_self_types)
+          entry["paths"] = paths if paths.any?
           entry
+        end
+
+        # `{ "bazinga" => [{ "when" => { param => type }, "self" => type }] }` —
+        # which `self` goes with which argument, call site by call site.
+        #
+        # The per-method `defs` above says what `self` may be anywhere in the
+        # method; this says which one goes with which path through it. Two
+        # parameters of one method travel together across its call sites and no
+        # RBS states that, so a call whose receiver is one of them is checked
+        # against every branch at once and demands a `self` that satisfies all
+        # of them — a type nothing is. felixefelip/steep#143 reads this and
+        # checks such a call one branch at a time instead.
+        #
+        # Written only where it says something the per-method answer does not:
+        # a method whose call sites all share one `self` is already covered.
+        def declared_paths(anchor, source, instance, invoker_self_types)
+          return {} if invoker_self_types.nil?
+
+          declared = "(#{instance})"
+          instance_methods(anchor, source).each_with_object({}) do |(name, params), acc|
+            next if params.empty?
+
+            entries = invoker_self_types.paths(method_name: name, declared: declared) or next
+            written = entries.filter_map { |args, self_type| path_entry(args, params, self_type) }
+            next unless written.size == entries.size
+
+            acc[name] = written
+          end
+        end
+
+        # One call site as the sidecar states it, or nil when it names an
+        # argument this method has no parameter for — a call passing more than
+        # the method takes cannot be what reached it.
+        def path_entry(args, params, self_type)
+          conditions = args.each_with_object({}) do |(index, type), acc|
+            name = params[index] or return nil
+            spelling = annotatable(type) or return nil
+            acc[name] = spelling
+          end
+          return nil if conditions.empty?
+
+          self_spelling = annotatable(self_type) or return nil
+          { "when" => conditions, "self" => self_spelling }
         end
 
         # `{ "bazinga" => "singleton(::Example23::Bar)" }` — the methods of this
@@ -111,13 +156,31 @@ module RbsInfer
         # `def self.` is excluded for the same reason Steep's placement skips
         # it: its `self` is the module object, which no invoker narrows.
         def instance_method_names(anchor, source)
+          instance_methods(anchor, source).map(&:first)
+        end
+
+        # `[[name, positional parameter names], ...]` for those methods. The
+        # parameters are what turns a call site's argument POSITIONS into the
+        # names the sidecar states a path in.
+        def instance_methods(anchor, source)
           node = find_scope(Prism.parse(source).value, anchor)
           body = node&.body
           return [] unless body.is_a?(Prism::StatementsNode)
 
           body.body.filter_map do |stmt|
-            stmt.name.to_s if stmt.is_a?(Prism::DefNode) && stmt.receiver.nil?
+            next unless stmt.is_a?(Prism::DefNode) && stmt.receiver.nil?
+
+            [stmt.name.to_s, positional_param_names(stmt)]
           end
+        end
+
+        def positional_param_names(node)
+          params = node.parameters or return []
+
+          names = []
+          params.requireds.each { |p| names << p.name.to_s if p.respond_to?(:name) } if params.respond_to?(:requireds)
+          params.optionals.each { |p| names << p.name.to_s if p.respond_to?(:name) } if params.respond_to?(:optionals)
+          names
         end
 
         def find_scope(node, anchor)

--- a/lib/rbs_infer/inference/invoker_self_types.rb
+++ b/lib/rbs_infer/inference/invoker_self_types.rb
@@ -86,6 +86,49 @@ module RbsInfer::Inference
       parenthesize(kept)
     end
 
+    # `[[{ argument index => type }, self type], ...]` — one entry per call site
+    # that this module's declaration admits, or nil when there is nothing whole
+    # to say.
+    #
+    # Same reading `narrow` does, handed over instead of collapsed: `narrow`
+    # answers "what may `self` be here", and this answers "which `self` goes
+    # with which argument", which is the part no RBS can state and which the
+    # sidecar carries to the checker (felixefelip/steep#143).
+    #
+    # nil unless every call site is placeable, every one has readable arguments,
+    # and they do not all share one `self` — where they do, the per-method
+    # answer already says everything and a path would only repeat it.
+    def paths(method_name:, declared:)
+      branches = union_branches(declared).to_set
+      return nil if branches.size < 2
+
+      observed = observed_selves(method_name)
+      return nil if observed.nil? || observed.empty?
+
+      entries = observed.filter_map do |self_type, module_instance, args|
+        # Same reading `narrow` does: a caller outside the declaration is
+        # calling a homonym and is dropped, while a module's instance method
+        # outside it cannot be placed at all and stops the answer
+        # (felixefelip/rbs_infer#227).
+        next if !branches.include?(self_type) && !module_instance
+        return nil if module_instance
+        return nil if args.empty?
+
+        [args, self_type]
+      end
+      by_argument = entries.group_by(&:first)
+      # A path is a fact only when the argument SEPARATES the call sites. Two
+      # invocations passing the same thing with a different `self` are not two
+      # paths, they are one path with two selves — and stating either would be
+      # picking one arbitrarily. Example23 is exactly that: both of its
+      # invocations pass the same constant, so its `self` stays the per-method
+      # union and nothing is written here.
+      return nil if by_argument.size < 2
+      return nil if by_argument.any? { |_, group| group.map(&:last).uniq.size > 1 }
+
+      by_argument.map { |args, group| [args, group.first.last] }
+    end
+
     private
 
     # The call sites that could have produced `given`, or all of them when the

--- a/spec/dummy/app/models/example26.rb
+++ b/spec/dummy/app/models/example26.rb
@@ -14,14 +14,18 @@
 # `def self.` — which is the second half of the same issue: one key per branch, not the
 # first that matches.
 #
-# What is RECORDED in the steep baseline is what neither the sidecar nor RBS can state.
-# rbs_infer reads the correlation and types each side by its own path; Steep checks the
-# call once, and for a union receiver it requires the argument to satisfy EVERY branch at
-# once — hence `singleton(Bar) & singleton(BarOther)`, a type nothing is. Its rule is
-# right for a fixed argument; `self` here is not fixed, it varies with the branch. Under
-# the declared surface of `bazinga` the two signatures really are contradictory, and only
-# the whole-program reading makes them true. Checking a union-receiver call per PATH is
-# what would close it — felixefelip/steep#143.
+# And the checker follows it, which took saying it somewhere RBS cannot. Checking the
+# call once, Steep merges the branches' method types and demands an argument that
+# satisfies EVERY branch — `singleton(Bar) & singleton(BarOther)`, a type nothing is.
+# That rule is right for a fixed argument, and `self` here is not fixed. So the sidecar
+# carries a `paths` entry naming which `self` goes with which argument, and
+# felixefelip/steep#143 checks such a call one branch at a time, each with its own
+# `self`. This file has no baseline entry: what used to be recorded there is now
+# verified.
+#
+# Example23 and Example24 get no `paths`, and should not: both of their invocations pass
+# the SAME constant, so the argument does not separate the call sites and the two selves
+# belong to one path rather than to two. Stating either would be picking one arbitrarily.
 class Example26
   module Foo
     def bazinga(module_included)

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -67,6 +67,14 @@ app/models/example25.rb:
       | (singleton(Example25::Baz)) | (singleton(Example25::BazOther))"
     defs:
       bazinga: singleton(Example25::Bar) | singleton(Example25::BarOther)
+    paths:
+      bazinga:
+      - when:
+          module_included: singleton(Example25::Baz)
+        self: singleton(Example25::Bar)
+      - when:
+          module_included: singleton(Example25::BazOther)
+        self: singleton(Example25::BarOther)
 app/models/example26.rb:
   modules:
   - anchor: Foo
@@ -75,6 +83,14 @@ app/models/example26.rb:
       | (singleton(Example26::Baz)) | (singleton(Example26::BazOther))"
     defs:
       bazinga: singleton(Example26::Bar) | singleton(Example26::BarOther)
+    paths:
+      bazinga:
+      - when:
+          module_included: singleton(Example26::Baz)
+        self: singleton(Example26::Bar)
+      - when:
+          module_included: singleton(Example26::BazOther)
+        self: singleton(Example26::BarOther)
 app/models/example3.rb:
   modules:
   - anchor: GeneratedAttributes

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -5,7 +5,6 @@ app/models/example14.rb:15:17: [error] Type `(::Example14::User | nil)` does not
 app/models/example15.rb:25:25: [error] Type `(::Example15::User | nil)` does not have method `name`
 app/models/example21.rb:105:31: [error] Type `(::Example21::Holder | nil)` does not have method `name`
 app/models/example21.rb:96:29: [error] Type `(::Example21::Ticket | nil)` does not have method `holder`
-app/models/example26.rb:28:32: [error] Cannot pass a value of type `self` as an argument of type `(singleton(::Example26::Bar) & singleton(::Example26::BarOther))`
 app/models/example3.rb:123:11: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:64:13: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:65:26: [error] Type `(::Example3::User | nil)` does not have method `name`

--- a/spec/lib/rbs_infer/extensions/rails/module_self_type_annotator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/module_self_type_annotator_spec.rb
@@ -60,10 +60,13 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeAnnotator do
 
       # Narrows `stamp` and declines on anything else, which is what
       # `InvokerSelfTypes` does for a method nobody calls.
-      def narrower_answering(answers)
+      def narrower_answering(answers, paths: {})
         double(:invoker_self_types).tap do |narrower|
           allow(narrower).to receive(:narrow) do |method_name:, declared:|
             answers.fetch(method_name, declared)
+          end
+          allow(narrower).to receive(:paths) do |method_name:, declared:|
+            paths[method_name]
           end
         end
       end
@@ -79,7 +82,7 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeAnnotator do
       end
 
       it "records only the methods whose self is narrower than the module's" do
-        entry = entry_with(narrower_answering("stamp" => "singleton(Wrap::Bar)"))
+        entry = entry_with(narrower_answering({ "stamp" => "singleton(Wrap::Bar)" }))
 
         expect(entry["annotations"])
           .to eq(["# @type instance: (singleton(Wrap::Bar)) | (singleton(Wrap::Baz))"])
@@ -94,14 +97,58 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeAnnotator do
       # Two invoking hosts is what first produces a union here.
       it "writes the union in the one spelling an annotation accepts" do
         entry = entry_with(
-          narrower_answering("stamp" => "(singleton(Wrap::Bar) | singleton(Wrap::Other))")
+          narrower_answering({ "stamp" => "(singleton(Wrap::Bar) | singleton(Wrap::Other))" })
         )
 
         expect(entry["defs"]).to eq("stamp" => "singleton(Wrap::Bar) | singleton(Wrap::Other)")
       end
 
       it "omits a self type RBS cannot read at all" do
-        expect(entry_with(narrower_answering("stamp" => "not a type ("))).not_to have_key("defs")
+        expect(entry_with(narrower_answering({ "stamp" => "not a type (" }))).not_to have_key("defs")
+      end
+
+      # felixefelip/steep#143. The per-method answer says what `self` may be
+      # anywhere in the method; this says which one goes with which argument, so
+      # a call whose receiver is that argument can be checked one branch at a
+      # time instead of against all of them at once.
+      it "states which self goes with which argument" do
+        narrower = narrower_answering(
+          {},
+          paths: {
+            "stamp" => [
+              [{ 0 => "singleton(Wrap::Baz)" }, "singleton(Wrap::Bar)"],
+              [{ 0 => "singleton(Wrap::Other)" }, "singleton(Wrap::OtherHost)"]
+            ]
+          }
+        )
+
+        expect(entry_with(narrower)["paths"]).to eq(
+          "stamp" => [
+            { "when" => { "value" => "singleton(Wrap::Baz)" }, "self" => "singleton(Wrap::Bar)" },
+            { "when" => { "value" => "singleton(Wrap::Other)" }, "self" => "singleton(Wrap::OtherHost)" }
+          ]
+        )
+      end
+
+      it "omits the key when there is nothing to say" do
+        expect(entry_with(narrower_answering({}))).not_to have_key("paths")
+      end
+
+      # An argument position the method has no parameter for cannot be what
+      # reached it, so the whole method is left without paths rather than with
+      # a partial one.
+      it "omits the method when an argument names no parameter" do
+        narrower = narrower_answering(
+          {},
+          paths: {
+            "stamp" => [
+              [{ 0 => "singleton(Wrap::Baz)" }, "singleton(Wrap::Bar)"],
+              [{ 3 => "singleton(Wrap::Other)" }, "singleton(Wrap::OtherHost)"]
+            ]
+          }
+        )
+
+        expect(entry_with(narrower)).not_to have_key("paths")
       end
 
       it "omits the key entirely when nothing narrows" do
@@ -117,7 +164,7 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeAnnotator do
       # `def self.x`'s self is the module object — no invoker narrows it, and
       # Steep's placement skips it for the same reason.
       it "does not ask about a singleton method" do
-        narrower = narrower_answering("stamp" => "singleton(Wrap::Bar)")
+        narrower = narrower_answering({ "stamp" => "singleton(Wrap::Bar)" })
         entry = described_class.entry_for(
           path: "app/models/wrap.rb",
           module_name: "Wrap::Foo",


### PR DESCRIPTION
Closes #233. Paired with felixefelip/steep#144, which reads what this writes — neither closes the case alone.

## The gap this fills

#232 taught the pipeline to read the correlation: two parameters of one method travel together across its call sites, and `InvokerSelfTypes` records the tuple (self, argument types) per invocation to keep them together. The types it emits are right, and the checker could not follow them:

```
Cannot pass a value of type `self` as an argument of type
  `(singleton(::Example26::Bar) & singleton(::Example26::BarOther))`
```

For a union receiver Steep merges the branches' method types, so the argument must satisfy every branch at once. That is right for a **fixed** argument, and `self` there is not fixed — it is whichever host made the call, correlated with the branch. The entry has been in the baseline since #232.

The reading was already there. What was missing was saying it somewhere Steep can read.

## What changes

`InvokerSelfTypes#paths` hands the per-invocation tuples over instead of collapsing them, filtered exactly as `narrow` filters them (a caller outside the declaration is dropped; a module's instance method outside it declines). The annotator turns argument POSITIONS into the parameter names the sidecar states a path in:

```yaml
app/models/example26.rb:
  modules:
  - anchor: Foo
    annotations: ["# @type instance: ..."]
    defs:
      bazinga: singleton(Example26::Bar) | singleton(Example26::BarOther)
    paths:
      bazinga:
      - when: { module_included: "singleton(Example26::Baz)" }
        self: "singleton(Example26::Bar)"
      - when: { module_included: "singleton(Example26::BazOther)" }
        self: "singleton(Example26::BarOther)"
```

## When it stays quiet

Only where the argument **separates** the call sites. Two invocations passing the same thing with a different `self` are not two paths — they are one path with two selves, and stating either would be picking one arbitrarily.

The first version of this did exactly that, and the dummy caught it: example23 came out with two entries whose `when` was identical and whose `self` was not. Steep would have taken the first and narrowed on nothing. Now the arguments must be pairwise distinct and map to one `self` each.

| fixture | invocations pass | `paths` |
|---|---|---|
| example23, example24 | the same constant twice | none |
| example25, example26 | different constants | one per call site |

Nothing is written where the per-method `defs` already says everything, either — a method whose call sites all share one `self`.

## Effect

`app/models/example26.rb` loses its baseline entry and checks clean. `spec/expectations/steep_baseline.txt` returns **byte-for-byte** to what it was before #232: what used to be recorded there is now verified.

The fixture's header says so, including why example23 and example24 get no paths — that is the part someone will otherwise read as a bug.

## Verification

- `bundle exec rspec` (full suite) — 1194 examples, 0 failures.
- Three new examples in `module_self_type_annotator_spec.rb`: the paths as stated, nothing when there is nothing to say, and nothing for the whole method when an argument names no parameter of it.
- `steep check` on the dummy, with felixefelip/steep#144 applied: the entry is gone and no other moves.
- Fork side: `rake test` — 1850 runs, 7718 assertions, 0 failures.

## Merge order

felixefelip/steep#144 first. Without it the `paths` key is written and ignored — inert, nothing breaks. The dummy resolves steep by path, so the snapshot here was measured with both applied.
