### PR TITLE
Widen a nil default in the entry that holds it

### DIFF
--- a/lib/rbs_infer/inference/method_key.rb
+++ b/lib/rbs_infer/inference/method_key.rb
@@ -50,6 +50,24 @@ module RbsInfer
         bare.merge(qualified)
       end
 
+      # The entries that HOLD this method's parameter types, in `lookup`'s order
+      # of precedence: the bare one first, the qualified one last.
+      #
+      # `lookup` answers a question — and when both entries exist it answers it
+      # by MERGING them into a new hash. Writing into what it returns writes
+      # into that copy, which is then dropped: the nil-default widening did
+      # exactly this, so a parameter typed from an owner-matched call site kept
+      # the type it had and the `= nil` in its own signature stopped being a
+      # legal argument (felixefelip/rbs_infer#235). A write has to reach the
+      # entry the value lives in, and which entry that is varies per parameter —
+      # `base_foo` under the qualified key, `message` under the bare one.
+      def self.tables(table, name, owner:, kind:)
+        key = self.for(name, owner: owner, kind: kind)
+        keys = key == name.to_s ? [name.to_s] : [name.to_s, key]
+
+        keys.filter_map { |k| table[k] }
+      end
+
       # `member.owner` is relative to the target (`"Baz"`); the table is keyed
       # by the full path.
       def self.qualify_owner(target_class, owner)

--- a/lib/rbs_infer/inference/param_type_inferrer.rb
+++ b/lib/rbs_infer/inference/param_type_inferrer.rb
@@ -344,17 +344,24 @@ module RbsInfer::Inference
         next unless [:method, :class_method].include?(member.kind)
         next if member.param_nil_defaults.nil? || member.param_nil_defaults.empty?
 
-        types = RbsInfer::Inference::MethodKey.lookup(
+        # Written through `tables`, not `lookup`: the parameters of one method
+        # can be spread across the bare and the qualified entry, and only the
+        # entry a parameter lives in can be widened (felixefelip/rbs_infer#235).
+        tables = RbsInfer::Inference::MethodKey.tables(
           inferred,
           member.name,
           owner: RbsInfer::Inference::MethodKey.qualify_owner(@target_class, member.owner),
           kind: member.kind
-        ) or next
-        member.param_nil_defaults.each do |param_name|
-          current = types[param_name]
-          next if current.nil? || current == "untyped"
+        )
+        next if tables.empty?
 
-          types[param_name] = RbsInfer::Signatures::RbsParserUtil.nilablize(current)
+        member.param_nil_defaults.each do |param_name|
+          tables.each do |types|
+            current = types[param_name]
+            next if current.nil? || current == "untyped"
+
+            types[param_name] = RbsInfer::Signatures::RbsParserUtil.nilablize(current)
+          end
         end
       end
     end

--- a/spec/dummy/app/models/example27.rb
+++ b/spec/dummy/app/models/example27.rb
@@ -1,3 +1,13 @@
+# Example26's shape with the two parameters given `= nil` / `: nil` defaults, which is
+# where the nil-default widening met the per-owner parameter table for the first time.
+#
+# `bazingado`'s two parameters arrive by different routes — `base_foo` from
+# `module_included.bazingado(self)`, filed under the owner the receiver reaches
+# (`Example27::Foo#bazingado`), and `message` from the bare call in `Baz`'s body, filed
+# under the plain name. Reading the two entries merges them; the widening WROTE through
+# that merge, into a copy that was dropped, so both parameters kept a type their own
+# default is not (felixefelip/rbs_infer#235). A method with a single entry — every flat
+# case, and `initialize` — was mutated in place and never showed it.
 class Example27
   module Foo
     def bazinga(module_included)

--- a/spec/dummy/sig/rbs_infer/app/models/example27.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example27.rbs
@@ -1,7 +1,7 @@
 class Example27
   module Foo
     def bazinga: (singleton(::Example27::Baz) module_included) -> nil
-    def bazingado: (?singleton(Example27::Bar) base_foo, ?message: String) -> nil
+    def bazingado: (?singleton(Example27::Bar)? base_foo, ?message: String?) -> nil
   end
 
   module Baz

--- a/spec/lib/rbs_infer/inference/nil_default_param_spec.rb
+++ b/spec/lib/rbs_infer/inference/nil_default_param_spec.rb
@@ -66,4 +66,71 @@ RSpec.describe "a parameter defaulting to nil" do
 
     expect(rbs).to include("def notify: (?untyped message) ->")
   end
+
+  # A method inside a nested module has its parameters filed under TWO keys: an
+  # owner-matched call site qualifies (`Wrap::Alpha#stamp`), and every other kind
+  # of evidence stays under the bare name. Reading the two MERGES them into a new
+  # hash, and the widening was written into that copy — dropped with it. Both
+  # parameters below default to nil, both got a type, and neither widened
+  # (felixefelip/rbs_infer#235).
+  #
+  # Which is why the flat cases above never showed it: a method with only one
+  # entry is looked up and mutated in place.
+  describe "on a method whose types are split across a qualified and a bare key" do
+    around do |ex|
+      Dir.mktmpdir { |dir| Dir.chdir(dir) { ex.run } }
+    end
+    before { RbsInfer::Signatures::RbsTypeLookup.reset! }
+
+    def write(path, content)
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, content)
+      path
+    end
+
+    it "widens the parameter in each key that holds one" do
+      # `message` comes from the bare call in `Beta`'s body, `value` from the
+      # call whose receiver names `Beta` — which reaches `Alpha#stamp` through
+      # the extend, so it is filed under the owner.
+      target = write("app/wrap.rb", <<~RUBY)
+        class Wrap
+          module Alpha
+            def stamp(value = nil, message: nil)
+              [value, message]
+            end
+          end
+
+          module Beta
+            extend Wrap::Alpha
+
+            stamp(message: "hi")
+          end
+        end
+      RUBY
+      write("app/caller.rb", <<~RUBY)
+        class Caller
+          def run
+            klass = Wrap::Beta
+            klass.stamp("hi")
+          end
+        end
+      RUBY
+      # The previous pass's output, which is what types the caller's local.
+      write("sig/generated/wrap.rbs", <<~RBS)
+        class Wrap
+          module Alpha
+            def stamp: (?untyped value, ?message: untyped) -> untyped
+          end
+
+          module Beta
+            extend ::Wrap::Alpha
+          end
+        end
+      RBS
+
+      rbs = RbsInfer::Analyzer.new(target_class: "Wrap", target_file: target, source_files: Dir["app/*.rb"]).generate_rbs
+
+      expect(rbs).to include("def stamp: (?String? value, ?message: String?) ->")
+    end
+  end
 end


### PR DESCRIPTION
Closes #235.

`example27.rb` — example26's shape with the two parameters declared `= nil` / `: nil` — makes `steep check` report against the fixture:

```
Cannot assign a value of type `nil` to an expression of type `singleton(::Example27::Bar)`
  nil <: singleton(::Example27::Bar)

Cannot assign a value of type `nil` to an expression of type `::String`
  nil <: ::String
```

Both parameters bind `nil` in their own declaration, and neither emitted type admitted one:

```rbs
def bazingado: (?singleton(Example27::Bar) base_foo, ?message: String) -> nil
```

## What was wrong

The widening from #208 is there and fires — it wrote into a copy.

`MethodKey.lookup` answers *what was inferred for this method*, and a method inside a nested module has that answer split across two entries: an owner-matched call site files under `Example27::Foo#bazingado`, every other kind of evidence under the bare `bazingado`. When both exist, `lookup` merges them into a **new** hash, which is the right answer to the question it was asked. `nilablize_nil_defaults` then widened the parameters in that hash and returned, dropping it.

The two parameters of `bazingado` happen to sit one in each entry — `base_foo` from `module_included.bazingado(self)`, `message` from the bare call in `Baz`'s body — so neither widened. Not the two independently: once the method has both keys, *every* nil default of that method stops widening, including the one filed bare.

Which is why nothing showed it before. A method with a single entry is looked up and mutated in place, and only a nested module produces both keys (#215) — so `initialize` and every flat method kept working.

## The fix

Separate the read from the write. `lookup` keeps merging. A `MethodKey.tables` companion returns the entries that actually **hold** the values, in the same order of precedence, and the widening applies to the entry each parameter lives in.

```ruby
def self.tables(table, name, owner:, kind:)
  key = self.for(name, owner: owner, kind: kind)
  keys = key == name.to_s ? [name.to_s] : [name.to_s, key]

  keys.filter_map { |k| table[k] }
end
```

`nilablize_nil_defaults` is the only writer through `lookup`; the other three consumers (`RbsBuilder`, `TypeMerger`, `ReturnTypeResolver`) read and are untouched.

## Result

```rbs
def bazingado: (?singleton(Example27::Bar)? base_foo, ?message: String?) -> nil
```

`example27.rb` type-checks clean, with no baseline entry. `spec/dummy/sig/rbs_infer/app/models/example27.rbs` is the only generated file that moves.

## Coverage

`spec/lib/rbs_infer/inference/nil_default_param_spec.rb` gains the case its siblings could not reach: a method whose parameters are split across the qualified and the bare key. It fails on `main` with both parameters non-nilable, which is the fixture's error reproduced at unit size.
