### PR TITLE
Pick an overload by the call's argument types

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -634,7 +634,7 @@ module RbsInfer
       target_class = info.target.split("_").map(&:capitalize).join
 
       info.methods.each do |method_name|
-        return_type = method_type_resolver.resolve(target_class, method_name) || "untyped"
+        return_type = method_type_resolver.resolve(target_class, method_name, arg_types: nil) || "untyped"
         return_type = RbsInfer::Signatures::RbsParserUtil.nilablize(return_type) if info.allow_nil
 
         generated_name = case info.prefix

--- a/lib/rbs_infer/inference/attr_type_inferrer.rb
+++ b/lib/rbs_infer/inference/attr_type_inferrer.rb
@@ -119,7 +119,7 @@ module RbsInfer::Inference
         # self.x = param.method → resolve the param's type, then the method's
         param_type = init_arg_types[expr_info[:param_name]]
         param_type = nil if param_type.nil? || param_type == "untyped"
-        @method_type_resolver.resolve(param_type, expr_info[:method_name]) if param_type
+        @method_type_resolver.resolve(param_type, expr_info[:method_name], arg_types: nil) if param_type
       when :call
         # self.x = something.method → resolve it through RBS
         if expr_info[:class_name] && expr_info[:method_name] && @method_type_resolver

--- a/lib/rbs_infer/inference/intra_class_call_analyzer.rb
+++ b/lib/rbs_infer/inference/intra_class_call_analyzer.rb
@@ -242,7 +242,7 @@ module RbsInfer::Inference
         elsif node.receiver.is_a?(Prism::LocalVariableReadNode)
           var_type = @local_var_types[node.receiver.name.to_s]
           if var_type && @method_type_resolver
-            @method_type_resolver.resolve(var_type, node.name.to_s) || "untyped"
+            @method_type_resolver.resolve(var_type, node.name.to_s, arg_types: nil) || "untyped"
           else
             "untyped"
           end

--- a/lib/rbs_infer/inference/new_call_collector.rb
+++ b/lib/rbs_infer/inference/new_call_collector.rb
@@ -965,7 +965,7 @@ module RbsInfer::Inference
       refined = @current_method && @self_types_by_method[@current_method]
       return nil if refined.nil? || refined.empty?
 
-      resolved = @method_type_resolver.resolve(refined, method_name)
+      resolved = @method_type_resolver.resolve(refined, method_name, arg_types: nil)
       resolved if resolved && resolved != "untyped"
     end
 
@@ -987,7 +987,7 @@ module RbsInfer::Inference
       receiver_type = resolve_receiver_type(node.receiver)
       return nil unless receiver_type && receiver_type != "untyped"
 
-      resolved = @method_type_resolver.resolve(receiver_type, node.name.to_s)
+      resolved = @method_type_resolver.resolve(receiver_type, node.name.to_s, arg_types: nil)
       # `a&.b` with a nilable receiver: the nil flows into the result (on
       # a plain call the resolve is optimistic — `a.b` raises on nil).
       if resolved && node.safe_navigation? && receiver_type.end_with?("?")

--- a/lib/rbs_infer/inference/param_type_inferrer.rb
+++ b/lib/rbs_infer/inference/param_type_inferrer.rb
@@ -539,7 +539,7 @@ module RbsInfer::Inference
           # receiver.method → tentar resolver
           receiver_type = resolve_arg_value_type(node.receiver, local_var_types, method_return_types)
           if receiver_type && receiver_type != "untyped"
-            @method_type_resolver.resolve(receiver_type, node.name.to_s) || "untyped"
+            @method_type_resolver.resolve(receiver_type, node.name.to_s, arg_types: nil) || "untyped"
           else
             "untyped"
           end
@@ -631,7 +631,7 @@ module RbsInfer::Inference
             else
               receiver_type = resolve_arg_value_type(assign.value.receiver, local_var_types, method_return_types)
               if receiver_type && receiver_type != "untyped"
-                resolved = @method_type_resolver.resolve(receiver_type, assign.value.name.to_s)
+                resolved = @method_type_resolver.resolve(receiver_type, assign.value.name.to_s, arg_types: nil)
                 local_var_types[var_name] = resolved if resolved && resolved != "untyped"
               end
             end

--- a/lib/rbs_infer/inference/type_merger.rb
+++ b/lib/rbs_infer/inference/type_merger.rb
@@ -491,11 +491,14 @@ module RbsInfer::Inference
           block_body_type = infer_block_body_type(call_node.block, self_ctx) if call_node.block
           constant_receiver = call_node.receiver.is_a?(Prism::ConstantReadNode) || call_node.receiver.is_a?(Prism::ConstantPathNode)
           # Use singleton lookup for constant receivers (class method calls like ActiveRecord::Base.transaction)
+          arg_types = argument_types(call_node, self_ctx, method_type_resolver, local_types: local_types)
           resolved = if constant_receiver
                        method_type_resolver.resolve_class_method(receiver_type, call_node.name.to_s, block_body_type: block_body_type) ||
-                         method_type_resolver.resolve(receiver_type, call_node.name.to_s, block_body_type: block_body_type)
+                         method_type_resolver.resolve(receiver_type, call_node.name.to_s, block_body_type: block_body_type,
+                                                                                          arg_types: arg_types)
                      else
-                       method_type_resolver.resolve(receiver_type, call_node.name.to_s, block_body_type: block_body_type)
+                       method_type_resolver.resolve(receiver_type, call_node.name.to_s, block_body_type: block_body_type,
+                                                                                        arg_types: arg_types)
                      end
           resolved = receiver_type if resolved == "self"
           resolved = local_self_return(self_ctx, receiver_type, call_node.name.to_s, constant_receiver) if resolved.nil? || resolved == "untyped"
@@ -514,6 +517,43 @@ module RbsInfer::Inference
       # (felixefelip/rbs_infer#35).
       result = "self" if result && @target_class && result == @target_class && self_ctx.own_kind != :class_method
       result
+    end
+
+    # The call's POSITIONAL argument types, or nil when the list is not one this
+    # can answer whole. An overload is only picked when every argument is known,
+    # so a partial answer is worth nothing — and `nil` is the difference between
+    # "the arguments say this overload" and "say nothing", which is what keeps
+    # the selection sound.
+    #
+    # Splats, block-passes, keywords and forwarding all decline: they describe
+    # an argument list this array cannot stand for.
+    def argument_types(call_node, self_ctx, method_type_resolver, local_types: {})
+      arguments = call_node.arguments&.arguments
+      return nil if arguments.nil? || arguments.empty?
+      return nil unless arguments.all? { |argument| positional_argument?(argument) }
+
+      types = arguments.map do |argument|
+        argument_type(argument, self_ctx, method_type_resolver, local_types: local_types)
+      end
+      types.any?(&:nil?) ? nil : types
+    end
+
+    # A CONSTANT in argument position is the class OBJECT — `singleton(Foo)` —
+    # which is the opposite of what `resolve_receiver_type` answers for it: as a
+    # RECEIVER a constant names the class whose singleton is being called, so it
+    # returns the bare `Foo`. Handing that to the selection would match an
+    # overload taking an INSTANCE. Decline instead; a wrong type here is exactly
+    # the failure this whole path exists to remove.
+    def argument_type(node, self_ctx, method_type_resolver, local_types: {})
+      return nil if node.is_a?(Prism::ConstantReadNode) || node.is_a?(Prism::ConstantPathNode)
+
+      infer_literal_type(node) ||
+        resolve_receiver_type(node, self_ctx, method_type_resolver, local_types: local_types)
+    end
+
+    def positional_argument?(node)
+      !(node.is_a?(Prism::SplatNode) || node.is_a?(Prism::BlockArgumentNode) ||
+        node.is_a?(Prism::KeywordHashNode) || node.is_a?(Prism::ForwardingArgumentsNode))
     end
 
     def resolve_receiver_type(node, self_ctx, method_type_resolver, local_types: {})

--- a/lib/rbs_infer/inference/type_merger.rb
+++ b/lib/rbs_infer/inference/type_merger.rb
@@ -572,7 +572,7 @@ module RbsInfer::Inference
         else
           parent_type = resolve_receiver_type(node.receiver, self_ctx, method_type_resolver, local_types: local_types)
           if parent_type && parent_type != "untyped"
-            resolved = method_type_resolver.resolve(parent_type, node.name.to_s)
+            resolved = method_type_resolver.resolve(parent_type, node.name.to_s, arg_types: nil)
             # "self" means the method returns the same type as the receiver
             resolved = parent_type if resolved == "self"
             if resolved.nil? || resolved == "untyped"

--- a/lib/rbs_infer/signatures/method_type_resolver.rb
+++ b/lib/rbs_infer/signatures/method_type_resolver.rb
@@ -69,7 +69,7 @@ module RbsInfer::Signatures
       end || name
     end
 
-    def resolve(class_name, method_name, block_body_type: nil)
+    def resolve(class_name, method_name, block_body_type: nil, arg_types: nil)
       return nil unless class_name && class_name != "untyped"
 
       # Nilable receiver (`User?`): the call has TWO branches and both are real
@@ -89,7 +89,8 @@ module RbsInfer::Signatures
       # false when the association is nil, which Steep then rejects with
       # "Cannot allow method body have type `(true | false)` … declared as `true`".
       if class_name.end_with?("?")
-        return resolve_nilable(class_name.delete_suffix("?"), method_name, block_body_type: block_body_type)
+        return resolve_nilable(class_name.delete_suffix("?"), method_name, block_body_type: block_body_type,
+                               arg_types: arg_types)
       end
 
       # Intersection types (e.g. `(OrderImport & OrderImport::Validated)` from
@@ -99,7 +100,7 @@ module RbsInfer::Signatures
       # which gives precedence to later components in the intersection.
       if (components = parse_intersection(class_name))
         components.reverse_each do |component|
-          result = resolve(component, method_name, block_body_type: block_body_type)
+          result = resolve(component, method_name, block_body_type: block_body_type, arg_types: arg_types)
           return result if result && result != "untyped"
         end
         return nil
@@ -111,14 +112,16 @@ module RbsInfer::Signatures
       # components agree on the return type; divergence → nil (ambiguous,
       # better untyped than a guess) — felixefelip/rbs_infer#19.
       if (components = parse_union(class_name))
-        results = components.map { |c| resolve(c, method_name, block_body_type: block_body_type) }
+        results = components.map { |c| resolve(c, method_name, block_body_type: block_body_type, arg_types: arg_types) }
         return nil if results.any?(&:nil?)
         return results.first if results.uniq.length == 1
         return nil
       end
 
       # Tentar via RBS DefinitionBuilder primeiro (resolve genéricos corretamente)
-      rbs_result = @rbs_definition_resolver.resolve_via_rbs_builder(:instance, class_name, method_name, block_body_type: block_body_type)
+      rbs_result = @rbs_definition_resolver.resolve_via_rbs_builder(:instance, class_name, method_name,
+                                                                    block_body_type: block_body_type,
+                                                                    arg_types: arg_types)
       return rbs_result if rbs_result && rbs_result != "untyped"
 
       # Fallback: source + regex-based resolution
@@ -128,8 +131,8 @@ module RbsInfer::Signatures
 
     # The two branches of a call on a nilable receiver, unioned. See `resolve`
     # for why the nil branch is not optional.
-    private def resolve_nilable(base, method_name, block_body_type:)
-      base_result = resolve(base, method_name, block_body_type: block_body_type)
+    private def resolve_nilable(base, method_name, block_body_type:, arg_types: nil)
+      base_result = resolve(base, method_name, block_body_type: block_body_type, arg_types: arg_types)
       return base_result if base_result.nil? || base_result == "untyped"
 
       nil_result = nil_branch(method_name, block_body_type)

--- a/lib/rbs_infer/signatures/method_type_resolver.rb
+++ b/lib/rbs_infer/signatures/method_type_resolver.rb
@@ -69,7 +69,7 @@ module RbsInfer::Signatures
       end || name
     end
 
-    def resolve(class_name, method_name, block_body_type: nil, arg_types: nil)
+    def resolve(class_name, method_name, arg_types:, block_body_type: nil)
       return nil unless class_name && class_name != "untyped"
 
       # Nilable receiver (`User?`): the call has TWO branches and both are real
@@ -131,11 +131,11 @@ module RbsInfer::Signatures
 
     # The two branches of a call on a nilable receiver, unioned. See `resolve`
     # for why the nil branch is not optional.
-    private def resolve_nilable(base, method_name, block_body_type:, arg_types: nil)
+    private def resolve_nilable(base, method_name, arg_types:, block_body_type:)
       base_result = resolve(base, method_name, block_body_type: block_body_type, arg_types: arg_types)
       return base_result if base_result.nil? || base_result == "untyped"
 
-      nil_result = nil_branch(method_name, block_body_type)
+      nil_result = nil_branch(method_name, block_body_type, arg_types)
       return base_result if nil_result.nil? || nil_result == "untyped"
       return base_result if base_result == nil_result
 
@@ -151,11 +151,17 @@ module RbsInfer::Signatures
 
     # `NilClass`'s own surface, memoized: every nilable receiver in the project
     # asks the same question, and the answer never varies by call-site.
-    private def nil_branch(method_name, block_body_type)
-      key = [method_name, block_body_type]
+    #
+    # The nil branch is the SAME call, so it gets the same arguments — and they
+    # belong in the key: `NilClass#+` answered for one argument list must not be
+    # served to another, which is the bug the memo would otherwise introduce the
+    # moment overload selection started depending on them.
+    private def nil_branch(method_name, block_body_type, arg_types)
+      key = [method_name, block_body_type, arg_types]
       return @nil_branch_cache[key] if @nil_branch_cache.key?(key)
 
-      @nil_branch_cache[key] = resolve("NilClass", method_name, block_body_type: block_body_type)
+      @nil_branch_cache[key] = resolve("NilClass", method_name, block_body_type: block_body_type,
+                                                               arg_types: arg_types)
     end
 
     private def self_relative?(type)
@@ -194,7 +200,11 @@ module RbsInfer::Signatures
       return nil unless class_name && class_name != "untyped"
 
       # Tentar via RBS DefinitionBuilder primeiro (resolve genéricos corretamente)
-      resolved = @rbs_definition_resolver.resolve_via_rbs_builder(:singleton, class_name, method_name, block_body_type: block_body_type)
+      # The singleton path does not carry the call's arguments yet: every caller
+      # below reaches it with a method NAME only. Saying so keeps the gap visible
+      # rather than letting it read as an oversight.
+      resolved = @rbs_definition_resolver.resolve_via_rbs_builder(:singleton, class_name, method_name,
+                                                                 arg_types: nil, block_body_type: block_body_type)
       return resolved if resolved
 
       # Fallback: regex-based lookup
@@ -578,7 +588,8 @@ module RbsInfer::Signatures
 
           infer_block_return_type(node.block, class_name)
         elsif node.receiver.nil? && class_name
-          resolved = @rbs_definition_resolver.resolve_via_rbs_builder(:instance, class_name, node.name.to_s)
+          resolved = @rbs_definition_resolver.resolve_via_rbs_builder(:instance, class_name, node.name.to_s,
+                                                                     arg_types: nil)
           return resolved if resolved && resolved != "untyped"
 
           infer_block_return_type(node.block, class_name)

--- a/lib/rbs_infer/signatures/rbs_definition_resolver.rb
+++ b/lib/rbs_infer/signatures/rbs_definition_resolver.rb
@@ -16,13 +16,20 @@ module RbsInfer::Signatures
       @method_owners = {}
     end
 
-    # `arg_types` is the call site's positional argument types, when the caller
-    # has them (`["Integer"]` for `age + 10`). Without them an overloaded method
-    # can only be guessed at, and the guess is DECLARATION ORDER — which across
-    # reopens is load order and means nothing: `bigdecimal`'s RBS reopens
-    # `Integer` with `def +: (BigDecimal) -> BigDecimal | ...`, so `age + 10`
-    # resolved to `BigDecimal` and the emitted RBS contradicted its own body.
-    def resolve_via_rbs_builder(kind, class_name, method_name, block_body_type: nil, arg_types: nil)
+    # `arg_types` is the call site's positional argument types (`["Integer"]` for
+    # `age + 10`), or nil when the caller has none to offer. Without them an
+    # overloaded method can only be guessed at, and the guess is DECLARATION
+    # ORDER — which across reopens is load order and means nothing: `bigdecimal`'s
+    # RBS reopens `Integer` with `def +: (BigDecimal) -> BigDecimal | ...`, so
+    # `age + 10` resolved to `BigDecimal` and the emitted RBS contradicted its own
+    # body.
+    #
+    # REQUIRED, not defaulted, per docs/engineering/required-threaded-deps.md: a
+    # caller that forgets it is not loudly broken, it silently goes back to that
+    # guess. Writing `arg_types: nil` is a caller SAYING it has no argument
+    # information, which is a different statement from having said nothing — and
+    # the sites that say it are the list of what is left to wire.
+    def resolve_via_rbs_builder(kind, class_name, method_name, arg_types:, block_body_type: nil)
       return nil unless rbs_builder
 
       # Intersection types (e.g. `(Order & Order::Validated)` yielded by

--- a/lib/rbs_infer/signatures/rbs_definition_resolver.rb
+++ b/lib/rbs_infer/signatures/rbs_definition_resolver.rb
@@ -16,7 +16,13 @@ module RbsInfer::Signatures
       @method_owners = {}
     end
 
-    def resolve_via_rbs_builder(kind, class_name, method_name, block_body_type: nil)
+    # `arg_types` is the call site's positional argument types, when the caller
+    # has them (`["Integer"]` for `age + 10`). Without them an overloaded method
+    # can only be guessed at, and the guess is DECLARATION ORDER — which across
+    # reopens is load order and means nothing: `bigdecimal`'s RBS reopens
+    # `Integer` with `def +: (BigDecimal) -> BigDecimal | ...`, so `age + 10`
+    # resolved to `BigDecimal` and the emitted RBS contradicted its own body.
+    def resolve_via_rbs_builder(kind, class_name, method_name, block_body_type: nil, arg_types: nil)
       return nil unless rbs_builder
 
       # Intersection types (e.g. `(Order & Order::Validated)` yielded by
@@ -26,7 +32,8 @@ module RbsInfer::Signatures
       # `Steep::Interface::Builder.intersection_shape`'s later-wins merge.
       if (components = parse_intersection_components(class_name))
         components.reverse_each do |component|
-          result = resolve_via_rbs_builder(kind, component, method_name, block_body_type: block_body_type)
+          result = resolve_via_rbs_builder(kind, component, method_name, block_body_type: block_body_type,
+                                                                        arg_types: arg_types)
           return result if result && result != "untyped"
         end
         return nil
@@ -45,7 +52,11 @@ module RbsInfer::Signatures
       return nil unless method
 
       best = nil
-      method.defs.each do |d|
+      # One overload that the arguments single out answers the call; anything
+      # else keeps the previous first-that-formats walk, so a caller with no
+      # argument information is exactly as resolved as before.
+      candidates = select_overload(method.defs, arg_types)&.then { |d| [d] } || method.defs
+      candidates.each do |d|
         formatted = format_rbs_return_type(d.type.type.return_type, class_name)
         # For type variables (e.g. T in [T] { -> T } -> T), use the variable name
         # so it can be substituted by the type_params loop below
@@ -67,6 +78,46 @@ module RbsInfer::Signatures
       best
     rescue RBS::BaseError
       nil
+    end
+
+    # The one overload the call's arguments single out, or nil — "nil" meaning
+    # "this walk has nothing to say", which leaves the previous behaviour in
+    # place rather than replacing one guess with another.
+    #
+    # Matching is NOMINAL and exact, deliberately: a real answer is subtyping,
+    # which needs a checker, and Steep already is that checker — the return pass
+    # asks it for anything left `untyped`. What this has to be is SOUND, so it
+    # only ever speaks when one overload names exactly the argument types the
+    # call passes and no other overload does. Two matches, none, or a single
+    # unknown argument all say nothing.
+    def select_overload(defs, arg_types)
+      return nil if arg_types.nil? || arg_types.empty? || arg_types.any?(&:nil?)
+
+      matches = defs.select { |d| accepts_arguments?(d.type, arg_types) }
+      matches.first if matches.size == 1
+    end
+
+    # A method type whose REQUIRED positionals are exactly these types. Anything
+    # with optionals, a rest, trailing positionals or keywords is skipped: those
+    # accept argument lists this comparison does not model, so calling them a
+    # match would be the guess this method exists to avoid.
+    def accepts_arguments?(method_type, arg_types)
+      function = method_type.type
+      return false unless function.is_a?(RBS::Types::Function)
+      return false unless function.optional_positionals.empty? && function.trailing_positionals.empty?
+      return false if function.rest_positionals
+      return false unless function.required_keywords.empty? && function.optional_keywords.empty?
+      return false if function.rest_keywords
+      return false unless function.required_positionals.size == arg_types.size
+
+      function.required_positionals.zip(arg_types).all? do |param, arg|
+        normalize_type_name(param.type.to_s) == normalize_type_name(arg)
+      end
+    end
+
+    # `::Integer` from RBS and `Integer` from the analyzer are one type.
+    def normalize_type_name(name)
+      name.to_s.strip.delete_prefix("::")
     end
 
     # Resolve the element type of a collection by looking up the `each` method's

--- a/spec/dummy/sig/rbs_infer/app/models/example28.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example28.rbs
@@ -21,6 +21,6 @@ class Example28
     def age: () -> Integer
     def call_test: () -> String
     def greet: () -> String
-    def age_after_a_decade: () -> BigDecimal
+    def age_after_a_decade: () -> Integer
   end
 end

--- a/spec/expectations/models/example28.rbs
+++ b/spec/expectations/models/example28.rbs
@@ -18,7 +18,9 @@ class Example28
   class Bar
     extend ::Example28::Foo
 
+    def age: () -> Integer
     def call_test: () -> String
     def greet: () -> String
+    def age_after_a_decade: () -> Integer
   end
 end

--- a/spec/lib/rbs_infer/inference/type_merger_spec.rb
+++ b/spec/lib/rbs_infer/inference/type_merger_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
       result.value.accept(collector)
       member = collector.members.find { |candidate| candidate.name == "set_current_session" }
       resolver = instance_double("MethodTypeResolver")
-      allow(resolver).to receive(:resolve).with("Session", "signed_id").and_return("String")
+      allow(resolver).to receive(:resolve).with("Session", "signed_id", arg_types: nil).and_return("String")
 
       merger.resolve_method_return_types_from_attrs(
         collector.members,
@@ -264,7 +264,7 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
       expect(member.signature).to include("?{ (*untyped) -> untyped } -> untyped")
 
       resolver = instance_double("MethodTypeResolver")
-      allow(resolver).to receive(:resolve).with("Session", "signed_id").and_return("String")
+      allow(resolver).to receive(:resolve).with("Session", "signed_id", arg_types: nil).and_return("String")
 
       merger.resolve_method_return_types_from_attrs(
         collector.members,

--- a/spec/lib/rbs_infer/signatures/method_type_resolver_spec.rb
+++ b/spec/lib/rbs_infer/signatures/method_type_resolver_spec.rb
@@ -24,6 +24,15 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     )
   end
 
+  # Test-only wrapper, same reasoning as the builder above: `arg_types:` is
+  # REQUIRED in production, because a caller that omits it silently falls back to
+  # picking an overload by declaration order (docs/engineering/required-threaded-deps.md).
+  # None of these examples exercises an overloaded method, so they pass no
+  # arguments — said once here rather than sixteen times below.
+  def resolve(resolver, class_name, method_name, arg_types: nil, **kwargs)
+    resolver.resolve(class_name, method_name, arg_types: arg_types, **kwargs)
+  end
+
   it "resolve tipo de método anotado com #:" do
     files = {
       "foo.rb" => <<~RUBY
@@ -38,7 +47,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
 
     with_temp_files(files) do |dir, paths|
       resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
-      expect(resolver.resolve("Foo", "name")).to eq("String")
+      expect(resolve(resolver, "Foo", "name")).to eq("String")
     end
   end
 
@@ -53,7 +62,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
 
     with_temp_files(files) do |dir, paths|
       resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
-      expect(resolver.resolve("Foo", "count")).to eq("Integer")
+      expect(resolve(resolver, "Foo", "count")).to eq("Integer")
     end
   end
 
@@ -72,7 +81,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
 
     with_temp_files(files) do |dir, paths|
       resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
-      expect(resolver.resolve("Foo", "repo")).to eq("DefaultRepo")
+      expect(resolve(resolver, "Foo", "repo")).to eq("DefaultRepo")
     end
   end
 
@@ -97,7 +106,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
 
     with_temp_files(files) do |dir, paths|
       resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
-      expect(resolver.resolve("MyApp::Foo", "widget")).to eq("Widget")
+      expect(resolve(resolver, "MyApp::Foo", "widget")).to eq("Widget")
     end
   end
 
@@ -129,7 +138,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
 
     with_temp_files("my_app/entity.rb" => entity_src, "my_app/service.rb" => service_src) do |dir, paths|
       resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
-      expect(resolver.resolve("MyApp::Entity", "nome")).to eq("String")
+      expect(resolve(resolver, "MyApp::Entity", "nome")).to eq("String")
     end
   end
 
@@ -161,7 +170,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
 
     with_temp_files("my_app/entity.rb" => entity_src, "my_app/caller.rb" => caller_src) do |dir, paths|
       resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
-      expect(resolver.resolve("MyApp::Entity", "email")).to eq("Wrapper")
+      expect(resolve(resolver, "MyApp::Entity", "email")).to eq("Wrapper")
       expect(resolver.resolve_init_param_types("MyApp::Entity")["email"]).to eq("String")
     end
   end
@@ -194,8 +203,8 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
 
     with_temp_files(files) do |dir, paths|
       resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
-      expect(resolver.resolve("Model & Model::Validated", "file")).to eq("Uploader")
-      expect(resolver.resolve("(Model & Model::Validated)", "file")).to eq("Uploader")
+      expect(resolve(resolver, "Model & Model::Validated", "file")).to eq("Uploader")
+      expect(resolve(resolver, "(Model & Model::Validated)", "file")).to eq("Uploader")
     end
   end
 
@@ -224,7 +233,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
 
     with_temp_files(files) do |dir, paths|
       resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
-      expect(resolver.resolve("(LeftClass & RightClass)", "shared")).to eq("Symbol")
+      expect(resolve(resolver, "(LeftClass & RightClass)", "shared")).to eq("Symbol")
     end
   end
 
@@ -294,7 +303,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
         # `sig/`). The source fallback is more forgiving — `FileIndex` matches on a
         # path SUFFIX, so even a bare `Archiver` finds `post/archiver.rb` — which is
         # precisely why this miss went unnoticed: it degraded only on the RBS path.
-        expect(resolver.resolve("Post::Archiver", "call")).to eq("String")
+        expect(resolve(resolver, "Post::Archiver", "call")).to eq("String")
       end
     end
 
@@ -350,7 +359,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
 
       expect(resolver.resolve_all("Example")).to include("ticket" => "Ticket?")
       # The single-method path already answered this; the two agreeing is the point.
-      expect(resolver.resolve("Example", "ticket")).to eq("Ticket?")
+      expect(resolve(resolver, "Example", "ticket")).to eq("Ticket?")
     end
 
     it "keeps a type the source itself states, over the RBS" do
@@ -381,25 +390,25 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
 
     it "unions the nil branch when NilClass defines the method" do
       # `Object#nil?: () -> false` against `NilClass#nil?: () -> true`.
-      expect(resolver.resolve("String", "nil?")).to eq("false")
-      expect(resolver.resolve("String?", "nil?")).to eq("bool")
+      expect(resolve(resolver, "String", "nil?")).to eq("false")
+      expect(resolve(resolver, "String?", "nil?")).to eq("bool")
     end
 
     it "drops the nil branch's literal when the base's class already covers it" do
       # `NilClass#to_s: () -> ""`, and `"" <: String` — the union is `String`.
-      expect(resolver.resolve("Integer?", "to_s")).to eq("String")
+      expect(resolve(resolver, "Integer?", "to_s")).to eq("String")
     end
 
     it "keeps the optimistic base answer when NilClass does not define it" do
       # The nil branch would be a NoMethodError — the app's steep check flags the
       # unhandled nil; there is no second return type to union in.
-      expect(resolver.resolve("String?", "upcase")).to eq("String")
+      expect(resolve(resolver, "String?", "upcase")).to eq("String")
     end
 
     it "keeps the base answer when a branch's type is receiver-relative" do
       # `self` means a different type in each branch, and the caller resolves a
       # returned `self` against ONE receiver, so the union isn't expressible.
-      expect(resolver.resolve("String?", "itself")).to eq("self")
+      expect(resolve(resolver, "String?", "itself")).to eq("self")
     end
   end
 end

--- a/spec/lib/rbs_infer/signatures/overload_selection_spec.rb
+++ b/spec/lib/rbs_infer/signatures/overload_selection_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rbs"
+
+# Picking an overload by the call's argument types. Without them the choice is
+# DECLARATION ORDER, which across reopens is load order and carries no meaning:
+# `bigdecimal`'s RBS reopens `Integer` with `def +: (BigDecimal) -> BigDecimal
+# | ...`, so `age + 10` resolved to `BigDecimal` while its own body was
+# `Integer` — the emitted RBS contradicted the source it was generated from.
+RSpec.describe RbsInfer::Signatures::RbsDefinitionResolver do
+  subject(:resolver) { described_class.new }
+
+  # `Definition::Method#defs` entries answer `#type` with a MethodType; that is
+  # all the selection reads, so a Struct stands in for the whole definition.
+  TypeDef = Struct.new(:type)
+
+  def defs(*method_types)
+    method_types.map { |mt| TypeDef.new(RBS::Parser.parse_method_type(mt)) }
+  end
+
+  # The real shape from the bigdecimal reopen: the BigDecimal overload is
+  # FIRST, so "the first that formats" answers BigDecimal for `2 + 2`.
+  let(:integer_plus) do
+    defs("(::BigDecimal) -> ::BigDecimal",
+         "(::Integer) -> ::Integer",
+         "(::Float) -> ::Float")
+  end
+
+  describe "#select_overload" do
+    it "picks the overload whose parameter names the argument's type" do
+      selected = resolver.select_overload(integer_plus, ["Integer"])
+
+      expect(selected.type.type.return_type.to_s).to eq("::Integer")
+    end
+
+    it "matches across the `::` prefix, which is the same type written twice" do
+      expect(resolver.select_overload(integer_plus, ["::Float"]).type.type.return_type.to_s)
+        .to eq("::Float")
+    end
+
+    # Every "says nothing" case, each of which leaves the previous walk in place.
+    it "says nothing without argument types" do
+      expect(resolver.select_overload(integer_plus, nil)).to be_nil
+    end
+
+    it "says nothing when an argument's type is unknown" do
+      expect(resolver.select_overload(integer_plus, [nil])).to be_nil
+    end
+
+    it "says nothing when no overload takes that type" do
+      expect(resolver.select_overload(integer_plus, ["String"])).to be_nil
+    end
+
+    it "says nothing when the arity does not match" do
+      expect(resolver.select_overload(integer_plus, %w[Integer Integer])).to be_nil
+    end
+
+    it "says nothing when two overloads name the same type" do
+      ambiguous = defs("(::Integer) -> ::Integer", "(::Integer) -> ::Float")
+
+      expect(resolver.select_overload(ambiguous, ["Integer"])).to be_nil
+    end
+  end
+
+  describe "#accepts_arguments?" do
+    def method_type(source) = RBS::Parser.parse_method_type(source)
+
+    it "accepts a method type whose required positionals are exactly these types" do
+      expect(resolver.accepts_arguments?(method_type("(::Integer) -> ::Integer"), ["Integer"])).to be(true)
+    end
+
+    # These all describe argument lists a positional-only comparison cannot
+    # stand for, so calling them a match would be the guess this avoids.
+    it "declines optional positionals" do
+      expect(resolver.accepts_arguments?(method_type("(?::Integer) -> ::Integer"), ["Integer"])).to be(false)
+    end
+
+    it "declines a rest positional" do
+      expect(resolver.accepts_arguments?(method_type("(*::Integer) -> ::Integer"), ["Integer"])).to be(false)
+    end
+
+    it "declines keywords" do
+      expect(resolver.accepts_arguments?(method_type("(::Integer, base: ::Integer) -> ::Integer"), ["Integer"]))
+        .to be(false)
+    end
+  end
+end

--- a/spec/lib/rbs_infer/signatures/rbs_definition_resolver_spec.rb
+++ b/spec/lib/rbs_infer/signatures/rbs_definition_resolver_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe RbsInfer::Signatures::RbsDefinitionResolver do
       # Use `Integer & Comparable` — both are present in core RBS.
       # `Integer#succ` exists on the left component; the resolver should
       # return a result instead of nil.
-      result = resolver.resolve_via_rbs_builder(:instance, "Integer & Comparable", :succ)
+      result = resolver.resolve_via_rbs_builder(:instance, "Integer & Comparable", :succ, arg_types: nil)
       expect(result).not_to be_nil
     end
   end


### PR DESCRIPTION
`age + 10`, with `age: () -> Integer`, was emitted as `-> BigDecimal` — an RBS that contradicts the body it was generated from, so `steep check` rejected the very method rbs_infer had just declared:

```
Cannot allow method body have type `::Integer` because declared as type `::BigDecimal`
```

### Cause

Nothing looked at the argument. `RbsDefinitionResolver#resolve_via_rbs_builder` walked `method.defs` and took the first overload whose return type formats — and for `Integer#+` the first one is `(BigDecimal) -> BigDecimal`, because `bigdecimal`'s RBS reopens `Integer`:

```rbs
# .gem_rbs_collection/bigdecimal/4.0/bigdecimal.rbs:1245 (class Integer)
def +: (BigDecimal) -> BigDecimal
     | ...
```

The answer was therefore decided by declaration order, which across reopens is **load** order and carries no meaning. Only calls whose receiver is itself a method call were affected — `42 + 10` and `n + 10` go through the literal and local-variable paths and were already right:

| expression | before | after |
|---|---|---|
| `age + 10` | `BigDecimal` | `Integer` |
| `42 + 10` | `Integer` | `Integer` |
| `n + 10` | `Integer` | `Integer` |

### Fix

Take the argument types from where they already exist. `TypeMerger#infer_call_return_type` holds the whole call node, so it types the positional arguments with the same machinery it uses for the receiver and threads them through `MethodTypeResolver#resolve` (all branches: nilable, intersection, union) down to the resolver.

The selection is **nominal and exact**, and it only speaks when one overload names exactly those types and no other does. Two matches, none, or a single unknown argument all leave the previous walk untouched — so the change is strictly additive and nothing that resolved before resolves differently. Real subtyping is a checker's job, and Steep already answers whatever is left `untyped` in the return pass.

Declining is the default wherever an answer would be a guess:

- splats, block-passes, keywords and forwarding describe argument lists a positional array cannot stand for;
- a **constant** argument is the class object (`singleton(Foo)`), while `resolve_receiver_type` reads a constant as the class whose singleton is being called — handing that over would match an overload taking an instance;
- overloads with optionals, a rest, trailing positionals or keywords are skipped for the same reason.

### Validation

- Unit suite: 1113 examples, 0 failures — including 11 new ones covering each "says nothing" case.
- Dummy snapshot suite (86 examples): passes, with exactly one line changed in the whole app — `Example28::Bar#age_after_a_decade`, `BigDecimal` → `Integer`. A full `make rbs_infer` regeneration of the dummy's `sig/` changes that same single line and nothing else.
- Steep baseline: byte-identical to the committed one (42 diagnostics). The reported `MethodBodyTypeMismatch` is gone and no new diagnostic appeared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)