### PR TITLE
Scope a replay's sidecar entry to the module it is written in

### DIFF
--- a/lib/rbs_infer/project/stored_block_replay_expander.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander.rb
@@ -41,10 +41,12 @@ module RbsInfer::Project
     REPLAY_METHODS = %i[class_eval module_eval].freeze
 
     # `call` is the STORAGE method's name (`bazingado`), not the replay's
-    # (`bazinga`): it is the name written on the block being moved, which is
-    # what `StoredBlockReplayImplements` needs to point Steep at that block in
-    # the real source.
-    Replay = Data.define(:target, :block, :kind, :call)
+    # (`bazinga`): it is the name written on the block being moved. `scope` is
+    # the class/module that block is written IN (`Example29::Baz`), which is not
+    # the `target` it is replayed onto. Together they point Steep at this one
+    # block in the real source, which a name alone cannot do once a file writes
+    # the same DSL call twice — see `StoredBlockReplayImplements`.
+    Replay = Data.define(:target, :block, :kind, :call, :scope)
 
     module_function
 

--- a/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
@@ -206,7 +206,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
           next unless kind
 
           candidates << Replay.new(target: apply.subject, block: blocks.first.block, kind: kind,
-                                   call: storage_method)
+                                   call: storage_method, scope: blocks.first.subject)
         end
       end
 

--- a/lib/rbs_infer/project/stored_block_replay_implements.rb
+++ b/lib/rbs_infer/project/stored_block_replay_implements.rb
@@ -30,9 +30,21 @@ module RbsInfer::Project
     module_function
 
     # @param source [String] the file's source
-    # @return [Array<Hash>] `[{ "call" => "<storage method>", "implements" =>
-    #   "::<Target>" }]`, one per stored block whose replay target is decided,
-    #   else `[]`.
+    # @return [Array<Hash>] `[{ "call" => "<storage method>", "in" => "::<Scope>",
+    #   "implements" => "::<Target>" }]`, one per stored block whose replay
+    #   target is decided, else `[]`.
+    #
+    # `in` is the class/module the block is WRITTEN in, and it is what makes one
+    # DSL name usable twice in a file: a call name alone cannot tell `bazingado
+    # do` in `Baz` (replayed onto `Bar`) from the one in `BazOther` (replayed
+    # onto `BarOther`), and Steep would put both entries on both blocks.
+    # Requires felixefelip/steep#145; before it this had to decline such a file
+    # entirely and neither block was checked against its real definee.
+    #
+    # Not the block's LINE, which is the obvious key and the wrong one: Steep
+    # applies the module-wide annotations first and those may add lines, so a
+    # line measured against the real file no longer points at the same call by
+    # the time the block entries are read. A scope survives that rewrite.
     #
     # No `self` key: `@implements <Target>` already runs the block's `def`
     # bodies with an instance of `<Target>` as self, which is what a
@@ -46,31 +58,12 @@ module RbsInfer::Project
       return [] unless parsed.success?
 
       replays = StoredBlockReplayExpander::Collector.new(source).collect(parsed.value)
-      return [] if replays.empty?
-
-      entries_for(parsed.value, replays)
-    end
-
-    # Steep matches a `blocks` entry by CALL NAME alone (every receiverless
-    # `name do … end` in the file gets the annotation), so a name written twice
-    # cannot be annotated: the two blocks may well have different targets, and
-    # both would receive both entries. Emit only the names written once, and
-    # count them the way Steep does rather than from the replays — a second
-    # block that the Collector declined is still a second block to Steep.
-    def entries_for(root, replays)
-      counts = block_call_counts(root)
 
       replays.filter_map do |replay|
-        next unless counts[replay.call] == 1
+        next unless replay.scope
 
-        { "call" => replay.call, "implements" => "::#{replay.target}" }
-      end.uniq
-    end
-
-    def block_call_counts(root)
-      RbsInfer::Analyzer.find_all_nodes(root) do |node|
-        node.is_a?(Prism::CallNode) && node.receiver.nil? && node.block.is_a?(Prism::BlockNode)
-      end.each_with_object(Hash.new(0)) { |node, counts| counts[node.name.to_s] += 1 }
+        { "call" => replay.call, "in" => "::#{replay.scope}", "implements" => "::#{replay.target}" }
+      end
     end
   end
 end

--- a/spec/dummy/sig/generated/.steep_contracts.yml
+++ b/spec/dummy/sig/generated/.steep_contracts.yml
@@ -133,24 +133,6 @@ methods:
           kind: self
         method: ticket
     enforced: false
-  Example29::Baz#age_after_a_decade:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: age
-    enforced: false
-  Example29::BazOther#name_upcase:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: name
-    enforced: false
   Post#author_name:
     requires:
     - kind: not_nil

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -107,6 +107,7 @@ app/models/example28.rb:
       bazinga: singleton(Example28::Bar)
   blocks:
   - call: bazingado
+    in: "::Example28::Baz"
     implements: "::Example28::Bar"
 app/models/example29.rb:
   modules:
@@ -124,6 +125,13 @@ app/models/example29.rb:
       - when:
           module_included: singleton(Example29::BazOther)
         self: singleton(Example29::BarOther)
+  blocks:
+  - call: bazingado
+    in: "::Example29::Baz"
+    implements: "::Example29::Bar"
+  - call: bazingado
+    in: "::Example29::BazOther"
+    implements: "::Example29::BarOther"
 app/models/example3.rb:
   modules:
   - anchor: GeneratedAttributes

--- a/spec/expectations/models/example29.rbs
+++ b/spec/expectations/models/example29.rbs
@@ -1,0 +1,42 @@
+class Example29
+  module Foo
+    attr_reader bazingado_block: untyped
+    def bazinga: ((singleton(::Example29::Baz) | singleton(::Example29::BazOther)) module_included) -> untyped
+    def bazingado: () ?{ (*untyped) -> Symbol } -> (^(*untyped) -> Symbol)?
+  end
+
+  module Baz
+    extend ::Example29::Foo
+  end
+
+  module BazOther
+    extend ::Example29::Foo
+  end
+
+  class AfterBazingado
+    attr_reader bazingado_block: (^(*untyped) -> Symbol)?
+  end
+end
+
+class Example29
+  class Bar
+    extend ::Example29::Foo
+
+    def self.validade_age: () -> String
+
+    def age: () -> Integer
+    def call_test: () -> String
+    def greet: () -> String
+    def age_after_a_decade: () -> Integer
+  end
+end
+
+class Example29
+  class BarOther
+    extend ::Example29::Foo
+
+    def name: () -> String
+    def call_name_upcase: () -> String
+    def name_upcase: () -> String
+  end
+end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -25,7 +25,7 @@ app/models/included_hook.rb:60:10: [warning] Method `::IncludedHook::Sugared#fro
 app/models/included_hook.rb:66:10: [warning] Method `::IncludedHook::Sugared#badge` is not declared in RBS
 app/models/included_hook.rb:82:10: [warning] Method `::IncludedHook::Homespun#from_homespun` is not declared in RBS
 app/models/included_hook.rb:86:10: [warning] Method `::IncludedHook::Homespun#stamp` is not declared in RBS
-app/models/included_hook/home_made.rb:27:22: [warning] Cannot pass a value of type `(^(*untyped) [self: ::Module] -> untyped | nil)` as a block-pass-argument of type `^(::Module) [self: ::Module] -> U(243)`
+app/models/included_hook/home_made.rb:27:22: [warning] Cannot pass a value of type `(^(*untyped) [self: ::Module] -> untyped | nil)` as a block-pass-argument of type `^(::Module) [self: ::Module] -> U(_)`
 app/models/included_hook/shared.rb:17:10: [warning] Method `::IncludedHook::Shared#from_shared` is not declared in RBS
 app/models/post/notifiable.rb:28:24: [error] Type `(::User | nil)` does not have method `full_name`
 app/models/send_dispatch.rb:107:33: [error] `public_send` cannot call `stamp` on `::SendDispatch`, which declares it private

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -685,6 +685,31 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     expect(rbs.chomp).to eq(expected_rbs(name).chomp)
   end
 
+  # The same replay TWICE in one file: `Baz` stores a block replayed onto `Bar`,
+  # `BazOther` stores another replayed onto `BarOther`. One `bazingado` name, two
+  # blocks, two targets — which is what the `blocks` sidecar could not express
+  # until its entries carried the opener's line (felixefelip/steep#145). Before
+  # that, the file had to be declined whole and each block was checked against
+  # its lexical module, where `age`/`name` do not exist.
+  #
+  # Each block's body reaches its OWN target's methods (`age` on Bar, `name` on
+  # BarOther), so this pins that the two replays never cross.
+  it "example29" do
+    name = "models/example29"
+    rbs = RbsInfer::Analyzer.new(
+      target_file: "app/models/example29.rb",
+      source_files: source_files
+    ).generate_rbs
+
+    if ENV["UPDATE_EXPECTATIONS"]
+      path = expectations_dir.join("#{name}.rbs")
+      path.dirname.mkpath
+      path.write(rbs)
+    end
+
+    expect(rbs.chomp).to eq(expected_rbs(name).chomp)
+  end
+
   it "example20" do
     name = "models/example20"
     rbs = RbsInfer::Analyzer.new(

--- a/spec/lib/rbs_infer/extensions/rails/module_self_type_generator_spec.rb
+++ b/spec/lib/rbs_infer/extensions/rails/module_self_type_generator_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe RbsInfer::Extensions::Rails::ModuleSelfTypeGenerator do
       entry = described_class.new(app_dir: dir).build_table.fetch("app/models/replayed.rb")
 
       expect(entry["blocks"]).to eq(
-        [{ "call" => "keep", "implements" => "::Replayed::Target" }]
+        [{ "call" => "keep", "in" => "::Replayed::Src", "implements" => "::Replayed::Target" }]
       )
     end
   end

--- a/spec/lib/rbs_infer/project/stored_block_replay_implements_spec.rb
+++ b/spec/lib/rbs_infer/project/stored_block_replay_implements_spec.rb
@@ -32,13 +32,13 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayImplements do
     RUBY
 
     expect(described_class.blocks_for(source: source))
-      .to eq([{ "call" => "keep", "implements" => "::Target" }])
+      .to eq([{ "call" => "keep", "in" => "::Src", "implements" => "::Target" }])
   end
 
-  # Steep matches an entry by call name over the whole file, so a name written
-  # twice would put BOTH entries on BOTH blocks — including on the block whose
-  # target is the other one.
-  it "declines a storage call written more than once in the file" do
+  # One DSL name, two blocks, two targets. Steep matches an entry by call name
+  # over the whole file, so the `in` scope is what keeps each entry on its own
+  # block instead of putting both on both (felixefelip/steep#145).
+  it "tells two blocks of the same storage call apart by the scope they sit in" do
     source = dsl + <<~RUBY
       module SrcA
         extend DSL
@@ -61,13 +61,15 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayImplements do
       end
     RUBY
 
-    expect(described_class.blocks_for(source: source)).to eq([])
+    expect(described_class.blocks_for(source: source)).to eq(
+      [{ "call" => "keep", "in" => "::SrcA", "implements" => "::First" },
+       { "call" => "keep", "in" => "::SrcB", "implements" => "::Second" }]
+    )
   end
 
-  # A second block Steep would also annotate is a reason to decline even when
-  # the Collector never produced a replay for it — the count has to be taken
-  # the way Steep takes it.
-  it "declines when an unrelated block reuses the storage call's name" do
+  # An unrelated block of the same name gets no entry of its own, and the
+  # `in` scope keeps it from picking up someone else's.
+  it "leaves an unrelated block reusing the storage call's name alone" do
     source = dsl + <<~RUBY
       module Src
         extend DSL
@@ -84,7 +86,10 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayImplements do
       end
     RUBY
 
-    expect(described_class.blocks_for(source: source)).to eq([])
+    entries = described_class.blocks_for(source: source)
+
+    expect(entries).to eq([{ "call" => "keep", "in" => "::Src", "implements" => "::Target" }])
+    expect(entries.map { |entry| entry["line"] }).not_to include(17)
   end
 
   it "returns nothing for a file with no replay" do

--- a/spec/support/steep_baseline_runner.rb
+++ b/spec/support/steep_baseline_runner.rb
@@ -76,10 +76,20 @@ class SteepBaselineRunner
       entry.fetch("diagnostics").map do |diagnostic|
         start = diagnostic.fetch("range").fetch("start")
         severity = SEVERITIES.fetch(diagnostic.fetch("severity"))
-        message = diagnostic.fetch("message").lines.first.chomp
+        message = normalize_message(diagnostic.fetch("message").lines.first.chomp)
 
         "#{file}:#{start.fetch("line")}:#{start.fetch("character")}: [#{severity}] #{message}"
       end
     end.sort.uniq
+  end
+
+  # A fresh type variable is numbered from a counter that spans the whole check,
+  # so `U(243)` becomes `U(257)` when an unrelated file starts inferring more —
+  # a baseline diff that says nothing happened. The identity is what matters
+  # here and the number is not part of it, so drop it.
+  FRESH_TYPE_VARIABLE = /\b([A-Z])\(\d+\)/
+
+  def normalize_message(message)
+    message.gsub(FRESH_TYPE_VARIABLE, '\1(_)')
   end
 end

--- a/spec/support/steep_baseline_runner_spec.rb
+++ b/spec/support/steep_baseline_runner_spec.rb
@@ -54,6 +54,15 @@ RSpec.describe SteepBaselineRunner do
     )
   end
 
+  it "drops a fresh type variable's number, which is not part of its identity" do
+    runner = described_class.new(project_root: DUMMY_APP_ROOT)
+
+    expect(runner.send(:normalize_message, "as a block-pass-argument of type `^(::Module) -> U(243)`"))
+      .to eq("as a block-pass-argument of type `^(::Module) -> U(_)`")
+    expect(runner.send(:normalize_message, "Type `::Integer` does not have method `abs`"))
+      .to eq("Type `::Integer` does not have method `abs`")
+  end
+
   it "rejects a failed Steep process instead of accepting its partial stdout" do
     allow(Open3).to receive(:capture3).and_return([
       "app/models/example.rb:1:0: [error] partial",


### PR DESCRIPTION
Follow-up to #240, driven by the new `example29` fixture: a file with **two** stored-block replays got neither annotated, and Steep reported the block bodies against their lexical module:

```
app/models/example29.rb:26:8: [error] Type `(::Object & ::Example29::Baz)` does not have method `age`
app/models/example29.rb:54:8: [error] Type `(::Object & ::Example29::BazOther)` does not have method `name`
```

Steep matches a `blocks` entry by call name over the whole file, so two `bazingado do` blocks with different targets would each receive both entries. #240 chose to decline the file whole rather than say something false — correct, and useless.

## The change

`Replay` now carries the scope the block is **written in** — which `Collector` already knew as the storage call's subject, and which is not the `target` it is replayed onto — and the entry names it as `in:` (requires felixefelip/steep#145):

```yaml
app/models/example29.rb:
  blocks:
  - call: bazingado
    in: "::Example29::Baz"
    implements: "::Example29::Bar"
  - call: bazingado
    in: "::Example29::BazOther"
    implements: "::Example29::BarOther"
```

## Why not the block's line

That was the first attempt and it is wrong: Steep applies the module-wide annotations first and `inject` may **add** lines, so a line measured against the real file no longer points at the same call by the time the block entries are read. It silently un-annotated `example28` too, which had been working — caught by the baseline, not by reasoning, so the scope version carries a test on the Steep side for exactly that.

## Baseline noise

Also normalizes `U(243)`-style fresh type variables out of the baseline. The number comes from a counter spanning the whole check, so it moves whenever an unrelated file starts inferring more — a diff that says nothing happened, and one this change would otherwise have carried.

## Validation

- `spec/expectations/models/example29.rbs` is the regression: one DSL name, two blocks, two targets, each block's body reaching its OWN target's methods (`Bar#age_after_a_decade: () -> Integer` from `Bar#age`, `BarOther#name_upcase: () -> String` from `BarOther#name`). `Baz`/`BazOther` stay empty, which is what they are at runtime.
- Steep baseline: 42 diagnostics, identical to the committed one — every `example28`/`example29` error gone, nothing new.
- `.steep_contracts.yml` loses two entries (`Example29::Baz#age_after_a_decade`, `Example29::BazOther#name_upcase`): postconditions that existed only because the methods sat on the wrong owner, where `age`/`name` did not resolve.
- Unit suite 1113 examples, dummy snapshots 87 examples, both 0 failures; `example29.rbs` is the only expectation added and no other changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)