### PR TITLE
Say WHEN a `self.class.class_eval` defines its methods

### DIFF
--- a/bin/rbs_infer
+++ b/bin/rbs_infer
@@ -3,6 +3,7 @@
 
 require "rbs_infer"
 require "fileutils"
+require "yaml"
 require "optparse"
 
 output = false
@@ -213,4 +214,32 @@ if output
   end
 else
   generate.call(files)
+end
+
+# The `.steep_postconditions.yml` half of the marker: WHERE the relocated
+# methods are declared is the RBS above, WHEN they exist is this
+# (felixefelip/rbs_infer#245). Steep globs `sig/**/.steep_postconditions.yml`
+# and merges, so this sits beside the one Steep writes itself rather than
+# fighting it for the same path.
+#
+# Swept once over the inputs at the end, not accumulated during generation:
+# `generate` runs once per dependency level and again per stabilization pass,
+# and the entries would be written as many times over.
+if output
+  postconditions = files.sort.flat_map do |file|
+    RbsInfer::Project::SelfClassEvalMarker.postconditions_for(File.read(file))
+  rescue StandardError
+    []
+  end
+
+  sidecar = File.join(output_dir, ".steep_postconditions.yml")
+  if postconditions.empty?
+    # Removed rather than left behind: a stale entry names a marker the RBS no
+    # longer declares, and the narrowing then silently stops applying.
+    FileUtils.rm_f(sidecar)
+  else
+    FileUtils.mkdir_p(File.dirname(sidecar))
+    File.write(sidecar, YAML.dump("version" => 1, "postconditions" => postconditions))
+    puts sidecar
+  end
 end

--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -875,6 +875,7 @@ require_relative "project/source_expanders"
 # so every project gets the reopen read whether or not it uses a framework.
 require_relative "project/class_eval_expander"
 require_relative "project/self_class_eval_expander"
+require_relative "project/self_class_eval_marker"
 require_relative "project/stored_block_replay_expander"
 require_relative "project/stored_block_replay_expander/reader_collector"
 require_relative "project/stored_block_replay_expander/collector"

--- a/lib/rbs_infer/project/self_class_eval_expander.rb
+++ b/lib/rbs_infer/project/self_class_eval_expander.rb
@@ -4,6 +4,7 @@ require "prism"
 require_relative "source_expanders"
 require_relative "reopening_call"
 require_relative "block_reopen"
+require "steep/postconditions/marker_naming"
 
 module RbsInfer::Project
   # Desugars `self.class.class_eval do … end` written inside an INSTANCE method
@@ -45,18 +46,28 @@ module RbsInfer::Project
   module SelfClassEvalExpander
     module_function
 
-    def expand(source)
-      return nil unless ReopeningCall.possible?(source)
+    # Every relocated block the file holds, as `Found` records. Public because
+    # WHERE the methods land and WHEN they exist are two answers to one reading
+    # of the source, and `SelfClassEvalMarker` gives the second — from these
+    # same records, so the two cannot disagree about which method defines what.
+    def relocations(source)
+      return [] unless ReopeningCall.possible?(source)
 
       parsed = Prism.parse(source)
-      return nil unless parsed.success?
+      return [] unless parsed.success?
 
       collector = Collector.new
       parsed.value.accept(collector)
-      return nil if collector.found.empty?
+      collector.found
+    end
 
-      reopens = collector.found.filter_map do |found|
-        BlockReopen.appended(source: source, block: found.block, kind: found.kind, target: found.target)
+    def expand(source)
+      found = relocations(source)
+      return nil if found.empty?
+
+      reopens = found.filter_map do |relocation|
+        target = marker_for(relocation)&.delete_prefix("::") || relocation.target
+        BlockReopen.appended(source: source, block: relocation.block, kind: relocation.kind, target: target)
       end
       reopens = BlockReopen.missing_from(source, reopens)
       return nil if reopens.empty?
@@ -64,11 +75,40 @@ module RbsInfer::Project
       [source, reopens.join("\n")].join("\n")
     end
 
+    # The marker class the relocated `def`s are DECLARED on, or nil when the
+    # method cannot name one.
+    #
+    # Not the class they land on at runtime: `build_age` is what puts them
+    # there, so declaring them on `Foo` says they are always present and a read
+    # before the call stops being the `NoMethodError` it is. They go on
+    # `Foo::AfterBuildAge` instead, which `SelfClassEvalMarker` pairs with the
+    # postcondition that calling `build_age` narrows the receiver to
+    # `Foo & Foo::AfterBuildAge` (felixefelip/rbs_infer#245).
+    #
+    # Computed HERE and read from here by the sidecar half, because a marker the
+    # RBS does not declare makes the narrowing silently no-op — the two ends have
+    # to agree on the string, so only one of them may compose it.
+    #
+    # nil when the composed name is not a constant: `MarkerNaming` strips a
+    # trailing `?`/`!`/`=` and stops there, so an operator method (`[]=`) still
+    # yields `After[]`. The caller then falls back to the class itself — the #244
+    # behaviour, wrong about WHEN but right about WHERE, and better than dropping
+    # the methods entirely.
+    def marker_for(relocation)
+      return nil unless relocation.method
+      return nil unless Steep::Postconditions::MarkerNaming.valid_method_name?(relocation.method)
+
+      name = Steep::Postconditions::MarkerNaming.marker_name_for(relocation.target, relocation.method)
+      name.split("::").last&.match?(/\A[A-Z]\w*\z/) ? name : nil
+    end
+
     # Finds the calls whose receiver is statically the enclosing class. It is a
     # lexical walk because that is what decides the answer: which class the
     # method is written in, and that `self` there is an instance of it.
     class Collector < Prism::Visitor
-      Found = Data.define(:block, :kind, :target)
+      # `target` is the class the `def`s land on at runtime; `method` is the
+      # method that puts them there, which is what names the marker.
+      Found = Data.define(:block, :kind, :target, :method)
 
       attr_reader :found
 
@@ -79,6 +119,7 @@ module RbsInfer::Project
         # The scope depth of the instance method being visited, when that method
         # is written directly in a class body; nil otherwise.
         @instance_def_scope = nil
+        @instance_def_name = nil
         @found = []
         super()
       end
@@ -96,11 +137,16 @@ module RbsInfer::Project
       end
 
       def visit_def_node(node)
-        outer = @instance_def_scope
-        @instance_def_scope = @scope.size if instance_method?(node) && @block_depth.zero?
+        outer_scope = @instance_def_scope
+        outer_name = @instance_def_name
+        if instance_method?(node) && @block_depth.zero?
+          @instance_def_scope = @scope.size
+          @instance_def_name = node.name.to_s
+        end
         super
       ensure
-        @instance_def_scope = outer
+        @instance_def_scope = outer_scope
+        @instance_def_name = outer_name
       end
 
       def visit_block_node(node)
@@ -137,7 +183,7 @@ module RbsInfer::Project
         # owner (felixefelip/rbs_infer#238).
         return unless @instance_def_scope == @scope.size && @block_depth.zero?
 
-        @found << Found.new(block: node.block, kind: kind, target: owner)
+        @found << Found.new(block: node.block, kind: kind, target: owner, method: @instance_def_name)
       end
 
       # `self.class`, and nothing else that spells a class: `self.class.new.class`

--- a/lib/rbs_infer/project/self_class_eval_marker.rb
+++ b/lib/rbs_infer/project/self_class_eval_marker.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "prism"
+require "steep/postconditions/marker_naming"
+require_relative "self_class_eval_expander"
+
+module RbsInfer::Project
+  # WHEN the methods a `self.class.class_eval` defines come into existence.
+  #
+  # `SelfClassEvalExpander` answers WHERE they land — on the enclosing class —
+  # and that alone says they are always there. They are not: `build_age` is what
+  # puts them there, so a call that precedes it raises `NoMethodError`, and
+  # declaring them on the class outright is what makes the checker stop saying
+  # so (felixefelip/rbs_infer#245).
+  #
+  # The fix is the marker the fork already has for exactly this shape of fact:
+  #
+  #   * the `def`s are declared on `Foo::AfterBuildAge`, not on `Foo`;
+  #   * `build_age` carries `unconditional.self: "::Foo & ::Foo::AfterBuildAge"`,
+  #     so calling it narrows the receiver to the intersection.
+  #
+  # A read before the call sees plain `Foo`, which has no `age` — the original
+  # error, now for the reason that is actually true. A read after sees the
+  # intersection, which has it.
+  #
+  # STRICTER than runtime, deliberately: `class_eval` mutates the CLASS, so
+  # `other.build_age` makes `age` real for every instance, and the marker follows
+  # only the receiver it was called on. That is the same "prove it from the call
+  # sites you can see" the analyzer applies everywhere else, and the alternative
+  # — declaring `age` unconditionally — is what this exists to stop.
+  #
+  # Both halves are keyed to the same marker name, composed by Steep's own
+  # `MarkerNaming` so the two ends cannot drift: a marker the RBS does not
+  # declare makes `apply_unconditional_postconditions` silently no-op.
+  #
+  # One diagnostic survives and belongs in the baseline: Steep reads the `def`s
+  # in the ORIGINAL block against the enclosing class, where they are no longer
+  # declared, and says so. The `blocks:` sidecar that would redirect them at the
+  # marker matches only RECEIVERLESS calls, and this call has `self.class` as its
+  # receiver — so pointing it there needs a wider matcher on the Steep side than
+  # this change is buying.
+  module SelfClassEvalMarker
+    module_function
+
+    # @return [Array<Hash>] `[{ target:, method:, marker:, narrowed_self: }]`,
+    #   one per relocated block whose method can name a marker, else `[]`.
+    #
+    # The name comes from the expander, which is what writes it into the RBS —
+    # composing it a second time here is how the two ends drift apart, and a
+    # marker the RBS does not declare makes the narrowing silently no-op.
+    def markers_for(source)
+      expander = RbsInfer::Project::SelfClassEvalExpander
+
+      expander.relocations(source).filter_map do |relocation|
+        marker = expander.marker_for(relocation) or next
+
+        {
+          target: relocation.target,
+          method: relocation.method,
+          marker: marker,
+          narrowed_self: "::#{relocation.target} & #{marker}"
+        }
+      end
+    end
+
+    # The `.steep_postconditions.yml` entries: calling the method narrows the
+    # receiver to the intersection that carries the new methods.
+    def postconditions_for(source)
+      markers_for(source).map do |marker|
+        {
+          "class" => marker[:target],
+          "method" => marker[:method],
+          "unconditional" => { "self" => marker[:narrowed_self] }
+        }
+      end
+    end
+
+  end
+end

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/example30.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/example30.rb
@@ -25,8 +25,8 @@ module Example30
   end
 end
 
-class Example30::Foo
-  def age
-    25
-  end
+class Example30::Foo::AfterBuildAge
+        def age
+          25
+        end
 end

--- a/spec/dummy/sig/rbs_infer/.steep_postconditions.yml
+++ b/spec/dummy/sig/rbs_infer/.steep_postconditions.yml
@@ -1,0 +1,7 @@
+---
+version: 1
+postconditions:
+- class: Example30::Foo
+  method: build_age
+  unconditional:
+    self: "::Example30::Foo & ::Example30::Foo::AfterBuildAge"

--- a/spec/dummy/sig/rbs_infer/app/models/example30.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example30.rbs
@@ -3,6 +3,13 @@ module Example30
     def name: () -> String
     def build_age: () -> Symbol
     def call_age: () -> Integer
-    def age: () -> Integer
+  end
+end
+
+module Example30
+  class Foo
+    class AfterBuildAge
+      def age: () -> Integer
+    end
   end
 end

--- a/spec/expectations/expanded/app/models/example30.rb
+++ b/spec/expectations/expanded/app/models/example30.rb
@@ -22,7 +22,7 @@ module Example30
   end
 end
 
-class Example30::Foo
+class Example30::Foo::AfterBuildAge
         def age
           25
         end

--- a/spec/expectations/models/example30.rbs
+++ b/spec/expectations/models/example30.rbs
@@ -3,6 +3,13 @@ module Example30
     def name: () -> String
     def build_age: () -> Symbol
     def call_age: () -> Integer
-    def age: () -> Integer
+  end
+end
+
+module Example30
+  class Foo
+    class AfterBuildAge
+      def age: () -> Integer
+    end
   end
 end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -10,6 +10,8 @@ app/models/example3.rb:64:13: [error] Type `(::Example3::User | nil)` does not h
 app/models/example3.rb:65:26: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:66:26: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example3.rb:67:13: [error] Type `(::String | nil)` does not have method `upcase`
+app/models/example30.rb:16:6: [error] Type `::Example30::Foo` does not have method `age`
+app/models/example30.rb:9:12: [warning] Method `::Example30::Foo#age` is not declared in RBS
 app/models/example4.rb:14:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:22:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:27:23: [error] Type `(::String | nil)` does not have method `upcase`

--- a/spec/lib/rbs_infer/project/self_class_eval_expander_spec.rb
+++ b/spec/lib/rbs_infer/project/self_class_eval_expander_spec.rb
@@ -6,7 +6,10 @@ require "rbs_infer"
 RSpec.describe RbsInfer::Project::SelfClassEvalExpander do
   def expand(source) = described_class.expand(source)
 
-  it "reopens the class the instance method is defined in" do
+  # The reopening names the MARKER, not the class: the methods exist only once
+  # `build` has run, and `SelfClassEvalMarker` pairs this with the
+  # postcondition that makes calling it say so.
+  it "reopens the marker of the class the instance method is defined in" do
     expanded = expand(<<~RUBY)
       class Foo
         def build
@@ -21,7 +24,7 @@ RSpec.describe RbsInfer::Project::SelfClassEvalExpander do
 
     # The body keeps its source indentation: re-indenting it to the reopening's
     # column reads better and rewrites the contents of any heredoc inside it.
-    expect(expanded).to include("class Foo\n      def age\n        25\n      end\nend")
+    expect(expanded).to include("class Foo::AfterBuild\n      def age\n        25\n      end\nend")
     expect(Prism.parse(expanded).success?).to be(true)
   end
 
@@ -36,7 +39,7 @@ RSpec.describe RbsInfer::Project::SelfClassEvalExpander do
       end
     RUBY
 
-    expect(expanded).to include("class Wrap::Foo\n")
+    expect(expanded).to include("class Wrap::Foo::AfterBuild\n")
   end
 
   it "reopens a module target as a module" do
@@ -48,7 +51,7 @@ RSpec.describe RbsInfer::Project::SelfClassEvalExpander do
       end
     RUBY
 
-    expect(expanded).to include("module Foo\n")
+    expect(expanded).to include("module Foo::AfterBuild\n")
   end
 
   # Each of these is a receiver or a `self` the call shape does not decide.
@@ -155,7 +158,7 @@ RSpec.describe RbsInfer::Project::SelfClassEvalExpander do
     once = expand(source)
 
     expect(expand(once)).to be_nil
-    expect(once.scan("class Foo\n").size).to eq(2)
+    expect(once.scan("class Foo::AfterBuild\n").size).to eq(1)
   end
 
   # Re-indenting the relocated body to the reopening's column reads better and

--- a/spec/lib/rbs_infer/project/self_class_eval_marker_spec.rb
+++ b/spec/lib/rbs_infer/project/self_class_eval_marker_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rbs_infer"
+
+RSpec.describe RbsInfer::Project::SelfClassEvalMarker do
+  let(:source) do
+    <<~RUBY
+      class Foo
+        def build
+          self.class.class_eval do
+            def age
+              25
+            end
+          end
+        end
+      end
+    RUBY
+  end
+
+  it "names the marker after the method that defines the methods" do
+    expect(described_class.markers_for(source).map { |m| m[:marker] })
+      .to eq(["::Foo::AfterBuild"])
+  end
+
+  # The intersection, not the marker alone: the receiver keeps everything it
+  # already had and gains what the call put there.
+  it "narrows the receiver to the class intersected with its marker" do
+    expect(described_class.postconditions_for(source)).to eq(
+      [{
+        "class" => "Foo",
+        "method" => "build",
+        "unconditional" => { "self" => "::Foo & ::Foo::AfterBuild" }
+      }]
+    )
+  end
+
+  it "agrees with the RBS the expander emits, which is what makes it apply" do
+    marker = described_class.markers_for(source).first.fetch(:marker)
+    expanded = RbsInfer::Project::SelfClassEvalExpander.expand(source)
+
+    # A marker the RBS does not declare makes the narrowing silently no-op, so
+    # the name in the sidecar has to be the name in the reopening, verbatim.
+    expect(expanded).to include("class #{marker.delete_prefix("::")}\n")
+  end
+
+  it "says nothing for a file with no relocation" do
+    expect(described_class.postconditions_for("class Foo\n  def build; end\nend\n")).to eq([])
+  end
+
+  # A method whose name cannot form a constant has no marker to point at. The
+  # expander falls back to the class itself, so there is nothing to narrow to
+  # and nothing to say here either.
+  it "says nothing for a method whose name cannot name a constant" do
+    source = <<~RUBY
+      class Foo
+        def []=(key, value)
+          self.class.class_eval { def age; 25; end }
+        end
+      end
+    RUBY
+
+    expect(described_class.postconditions_for(source)).to eq([])
+    expect(RbsInfer::Project::SelfClassEvalExpander.expand(source)).to include("class Foo\n")
+  end
+end


### PR DESCRIPTION
The (B) half agreed after #244. That PR put the relocated methods on the enclosing class, which says they are *always* there. They are not — `build_age` is what puts them there — so `call_age` reading `age` before calling it raises `NoMethodError`, and declaring `age` on `Foo` is precisely what made the checker stop reporting it. #244 traded three diagnostics for none: two wrong, one right.

| line | before #244 | after #244 | now |
|---|---|---|---|
| 16 `age` | error (wrong reason) | silent | **error** — no marker yet |
| 18 `build_age` | — | — | acquires `Foo & Foo::AfterBuildAge` |
| 20 `age + 10` | error (**false**) | ok | ok |

## How

The marker the fork already has for this shape of fact:

- the `def`s are declared on `Foo::AfterBuildAge`, not on `Foo`;
- `build_age` carries `unconditional.self: "::Foo & ::Foo::AfterBuildAge"`.

A read before the call sees plain `Foo`, which has no `age`. A read after sees the intersection, which has it.

```yaml
# sig/rbs_infer/.steep_postconditions.yml
version: 1
postconditions:
- class: Example30::Foo
  method: build_age
  unconditional:
    self: "::Example30::Foo & ::Example30::Foo::AfterBuildAge"
```

**No Steep change was needed**, and the reason is worth recording: the postconditions loader *globs* `sig/**/.steep_postconditions.yml` and merges, explicitly so external generators can write their own. rbs_infer's file sits beside the one Steep writes rather than fighting it for the same path. I validated the whole design by hand — writing the marker RBS and the sidecar directly — before writing a line of generator code.

## One place composes the name

`SelfClassEvalExpander.marker_for` composes the marker name and the sidecar half reads it from there. Composing it twice is how the two ends drift, and a marker the RBS does not declare makes `apply_unconditional_postconditions` **silently no-op** — the failure is invisible, so the coupling has to be structural.

It returns nil when the method cannot name a constant: `MarkerNaming` strips a trailing `?`/`!`/`=` and stops, so `[]=` still yields `After[]`. The caller then falls back to the class — #244's answer, wrong about WHEN but right about WHERE, and better than dropping the methods entirely.

The sidecar is swept once over the inputs at the end of the CLI rather than accumulated during generation, which runs once per dependency level and again per stabilization pass.

## Deliberately stricter than runtime

`class_eval` mutates the **class**, so `other.build_age` makes `age` real for every instance, while the marker follows only the receiver it was called on. That is the "prove it from the call sites you can see" stance the analyzer takes everywhere, and the alternative is the unconditional declaration this exists to stop. Flagged when the approach was agreed, and stated in the module.

## One diagnostic stays in the baseline

Steep reads the `def`s in the *original* block against the enclosing class, where they are no longer declared, and says so. The `blocks:` sidecar that would redirect them at the marker matches only **receiverless** calls (felixefelip/steep#145), and this call's receiver is `self.class` — widening that matcher is its own change.

## Validation

Full suite with no update flags: **1250 examples, 0 failures**. The dummy's baseline gains exactly the two lines above and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)