### PR TITLE
Let a stored block's `self` binding and its return type coexist

### DIFF
--- a/lib/rbs_infer/signatures/rbs_parser_util.rb
+++ b/lib/rbs_infer/signatures/rbs_parser_util.rb
@@ -340,7 +340,15 @@ module RbsInfer::Signatures
     # A union is PARENTHESIZED here, unlike in the parameter list: `{ () -> A | B }`
     # is a syntax error, while `{ (A | B) -> untyped }` is fine. Measured, not
     # assumed — the two positions really do differ.
-    BLOCK_RETURN = /(?<open>\??\{ \([^)]*\) -> )untyped(?<close> \})/
+    #
+    # The `[self: T]` is optional because `bind_block_self` runs FIRST and puts it
+    # exactly here, between the parameter list and the arrow. Requiring the arrow
+    # to follow the list directly made this a silent no-op for every block that
+    # got a binding — and since the binding itself only lands on the passes where
+    # the checker can resolve the replay, the two answers alternated instead of
+    # accumulating: a stored block never reached a fixed point at all
+    # (felixefelip/rbs_infer#209).
+    BLOCK_RETURN = /(?<open>\??\{ \([^)]*\) (?:\[self: .+?\] )?-> )untyped(?<close> \})/
 
     def replace_block_return_type(method_sig, type)
       return method_sig unless method_sig && usable_type?(type)
@@ -357,12 +365,21 @@ module RbsInfer::Signatures
     # (felixefelip/rbs_infer#208).
     #
     # A clause that already binds `self` is left alone: that binding came from a
-    # hand-written annotation, and an annotation is the authority.
+    # hand-written annotation, and an annotation is the authority. Scoped to the
+    # BLOCK clause, because a method that stores its block also tends to RETURN
+    # it, and a returned proc carries the very binding this asks about
+    # (`-> (^(*untyped) [self: singleton(Bar)] -> Symbol)?`). Read off the whole
+    # signature, that return made the guard trip on a block clause that had no
+    # binding at all — and since the return only carries one on the passes where
+    # the ivar holding the proc had already picked it up, the binding appeared
+    # and vanished on alternating passes, which is a file that never converges
+    # (felixefelip/rbs_infer#209).
     BLOCK_SELF_BINDING = /(?<open>\??\{ \([^)]*\) )(?=->)/
+    BOUND_BLOCK = /\??\{ \([^)]*\) \[self: /
 
     def bind_block_self(method_sig, self_type)
       return method_sig unless method_sig && usable_type?(self_type)
-      return method_sig if method_sig.include?("[self:")
+      return method_sig if method_sig.match?(BOUND_BLOCK)
 
       method_sig.sub(BLOCK_SELF_BINDING) { "#{Regexp.last_match[:open]}[self: #{self_type}] " }
     end

--- a/spec/dummy/sig/rbs_infer/app/models/example32.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example32.rbs
@@ -1,9 +1,9 @@
 class Example32
-  @_bazingado_block: (^(*untyped) -> Symbol)?
+  @_bazingado_block: (^(*untyped) [self: singleton(Example32::Bar)] -> Symbol)?
 
   module Foo
-    def bazinga: (singleton(::Example32::Baz) module_included) -> (^(*untyped) [self: singleton(Example32::Bar)] -> untyped)?
-    def bazingado: (?singleton(Example32::Bar)? base) ?{ (*untyped) [self: singleton(Example32::Bar)] -> untyped } -> (^(*untyped) -> Symbol)?
+    def bazinga: (singleton(::Example32::Baz) module_included) -> (^(*untyped) [self: singleton(Example32::Bar)] -> Symbol)?
+    def bazingado: (?singleton(Example32::Bar)? base) ?{ (*untyped) [self: singleton(Example32::Bar)] -> Symbol } -> (^(*untyped) [self: singleton(Example32::Bar)] -> Symbol)?
   end
 
   module Baz

--- a/spec/lib/rbs_infer/signatures/rbs_parser_util_spec.rb
+++ b/spec/lib/rbs_infer/signatures/rbs_parser_util_spec.rb
@@ -538,6 +538,63 @@ RSpec.describe RbsInfer::Signatures::RbsParserUtil do
       expect(described_class.replace_block_return_type("m: () ?{ () -> untyped } -> untyped", "Post"))
         .to eq("m: () ?{ () -> Post } -> untyped")
     end
+
+    # `bind_block_self` runs FIRST and puts the binding between the parameter
+    # list and the arrow, so a clause that reaches here has usually got one.
+    it "reaches past a `self` binding to the return behind it" do
+      expect(described_class.replace_block_return_type("m: () ?{ (*untyped) [self: singleton(Bar)] -> untyped } -> untyped", "Symbol"))
+        .to eq("m: () ?{ (*untyped) [self: singleton(Bar)] -> Symbol } -> untyped")
+    end
+
+    it "reads a bound clause whose self type is itself bracketed" do
+      expect(described_class.replace_block_return_type("m: () { (String) [self: Array[Foo]] -> untyped } -> untyped", "Post"))
+        .to eq("m: () { (String) [self: Array[Foo]] -> Post } -> untyped")
+    end
+  end
+
+  describe ".bind_block_self" do
+    it "binds `self` between the parameter list and the arrow" do
+      expect(described_class.bind_block_self("m: () ?{ (*untyped) -> untyped } -> untyped", "singleton(Bar)"))
+        .to eq("m: () ?{ (*untyped) [self: singleton(Bar)] -> untyped } -> untyped")
+    end
+
+    it "adds only the binding — not the `?`, not the parameter list" do
+      expect(described_class.bind_block_self("m: () ?{ (String, Integer) -> Post } -> untyped", "Module"))
+        .to eq("m: () ?{ (String, Integer) [self: Module] -> Post } -> untyped")
+    end
+
+    it "leaves alone what it cannot account for" do
+      [
+        # the clause already binds one — a hand-written annotation is the authority
+        ["m: () ?{ (*untyped) [self: Module] -> untyped } -> untyped", "singleton(Bar)"],
+        # no block at all
+        ["m: (untyped a) -> untyped", "Module"],
+        # nothing to say
+        ["m: () ?{ (*untyped) -> untyped } -> untyped", nil],
+        ["m: () ?{ (*untyped) -> untyped } -> untyped", "untyped"]
+      ].each { |sig, self_type| expect(described_class.bind_block_self(sig, self_type)).to eq(sig) }
+    end
+
+    # A method that STORES its block also returns it, and that returned proc
+    # carries the binding — which is not the block clause's, and must not be read
+    # as one. Taking it for one left the clause unbound on exactly the passes
+    # where the ivar holding the proc had already picked the binding up, so the
+    # two alternated and the file never converged (felixefelip/rbs_infer#209).
+    it "is not fooled by a `self` binding in the RETURN type" do
+      sig = "bazingado: (?singleton(Bar)? base) ?{ (*untyped) -> Symbol } -> (^(*untyped) [self: singleton(Bar)] -> Symbol)?"
+
+      expect(described_class.bind_block_self(sig, "singleton(Bar)"))
+        .to eq("bazingado: (?singleton(Bar)? base) ?{ (*untyped) [self: singleton(Bar)] -> Symbol } -> (^(*untyped) [self: singleton(Bar)] -> Symbol)?")
+    end
+
+    # The pair, in the order `BlockSignatureResolver` applies them: binding, then
+    # return. Both have to land, or the clause is a different type each pass.
+    it "composes with the return replacement that follows it" do
+      bound = described_class.bind_block_self("bazingado: (?singleton(Bar)? base) ?{ (*untyped) -> untyped } -> untyped", "singleton(Bar)")
+
+      expect(described_class.replace_block_return_type(bound, "Symbol"))
+        .to eq("bazingado: (?singleton(Bar)? base) ?{ (*untyped) [self: singleton(Bar)] -> Symbol } -> untyped")
+    end
   end
 
   describe ".require_block" do


### PR DESCRIPTION
## The symptom

`spec/dummy/app/models/example32.rb` — the hand-rolled `ActiveSupport::Concern` (`bazingado(base = nil, &block)` storing into `@_bazingado_block`, replayed by `base.class_eval(&@_bazingado_block)`) — never converges:

```
Warning: types did not converge after 10 stabilization passes (1 files still changing).
```

Raising `--max-passes` does not help. `RBS_INFER_DEBUG_CONVERGENCE=1` shows why — a clean period-2 cycle, the two answers trading places rather than accumulating:

```
-   @_bazingado_block: (^(*untyped) -> Symbol)?
-     def bazingado: (…) ?{ (*untyped) [self: singleton(Example32::Bar)] -> untyped } -> (^(*untyped) -> Symbol)?
+   @_bazingado_block: (^(*untyped) [self: singleton(Example32::Bar)] -> untyped)?
+     def bazingado: (…) ?{ (*untyped) -> Symbol } -> (^(*untyped) [self: singleton(Example32::Bar)] -> untyped)?
```

Two independent defects in `RbsParserUtil`, either of which alone denies the fixed point.

## 1. `bind_block_self`'s guard read the whole signature

```ruby
return method_sig if method_sig.include?("[self:")
```

The intent is "a clause that already binds `self` was hand-annotated, and an annotation is the authority". But a method that STORES its block also tends to RETURN it, and that returned proc carries the very binding being asked about:

```
-> (^(*untyped) [self: singleton(Example32::Bar)] -> Symbol)?
```

So the guard tripped on a block clause that had no binding at all. And since the return only carries one on the passes where the ivar holding the proc had already picked it up, the binding appeared and vanished on alternating passes.

Scoped the guard to the block clause (`BOUND_BLOCK`).

## 2. `BLOCK_RETURN` could not see past a binding

```ruby
BLOCK_RETURN = /(?<open>\??\{ \([^)]*\) -> )untyped(?<close> \})/
```

It required the arrow to follow the parameter list directly. But `BlockSignatureResolver#apply` runs `resolve_stored_self_types` **before** `resolve_return_types` — deliberately, per its own doc comment — and that inserts `[self: T] ` in exactly that position. So `replace_block_return_type` was a silent no-op on every block clause that had received a binding.

Made the binding optional in the pattern.

## Result

`Example32` converges within the default 10 passes, and on a type strictly more precise than either of the states it used to alternate between:

```rbs
def bazingado: (?singleton(Example32::Bar)? base)
                 ?{ (*untyped) [self: singleton(Example32::Bar)] -> Symbol }
               -> (^(*untyped) [self: singleton(Example32::Bar)] -> Symbol)?
```

## Tests

- `bind_block_self` had **no** unit coverage. It has some now, including the returned-proc case that caused this and the two rewrites composed in the order the resolver applies them.
- `spec/lib`: 1130 examples, 0 failures.
- `spec/integration` + `spec/bin`: 116 examples, 3 failures — the same 3 as on `main` without this change (verified via `git stash`). They are pre-existing: `spec/expectations/expanded/` and `steep_baseline.txt` were not regenerated when the `example31`/`example32` fixtures landed, and are untouched here.

## Out of scope

`Example32::Bar` still receives no `age` — `StoredBlockReplayExpander::Collector` only recognises the `example29`/`example31` spelling (`class_eval(&param.reader)` with an `attr_reader`), not `example32`'s inverted one (`base.class_eval(&@ivar)`, the replay running on the source with the target passed in, which is what real `append_features` does). That is a separate gap; this PR only makes the file reach a fixed point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
