### PR TITLE
Declare a nested module's ivars on the module that writes them

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -193,7 +193,7 @@ module RbsInfer
       is_module: false,
       type_params: method_type_resolver.type_param_string(receiver),
       class_methods_index: class_methods_index
-    ).build(members, {}, {}, ivar_types: {}, singleton_ivar_types: {}, markers: [])
+    ).build(members, {}, {}, ivar_types: {}, singleton_ivar_types: {}, module_ivar_types: {}, markers: [])
   end
 
   def build_single_target_rbs
@@ -246,19 +246,33 @@ module RbsInfer
     # (felixefelip/rbs_infer#86). Threaded straight to the builder — the
     # marker/widening machinery below is about instance ivars only.
     singleton_ivar_types = ivar_inference.singleton
+    # Ivars a NESTED module writes belong to that module, and are DECLARED in its
+    # own block — the class never had the slot (felixefelip/rbs_infer#249).
+    module_ivar_types = ivar_inference.by_module
+
+    # Where a slot is declared and what an instance may hold are two questions
+    # with two answers. Declaration follows the writer, which is what the module
+    # split above is for; inference wants everything reachable on an instance,
+    # and a class that `include`s the module reaches the module's slots too — so
+    # the passes below read the union.
+    #
+    # Splitting these was not optional: giving the inference passes the narrow
+    # map turned every `Current` reader into `-> untyped`, because the accessors
+    # live in the same nested module as the ivars they read.
+    reachable_ivar_types = module_ivar_types.values.reduce(ivar_types.dup) { |all, ivars| all.merge(ivars) }
 
     # Params assigned directly to ivars (`def x=(v); @x = v; end`) accept
     # everything the ivar can hold — align `User` → `User?` when the ivar
     # is nilable (felixefelip/rbs_infer#19, mirroring the rbs_rails
     # setter convention: `(T?) -> T?`).
-    widen_assigned_param_types(method_param_types, ivar_types)
+    widen_assigned_param_types(method_param_types, reachable_ivar_types)
 
     # Melhorar return types de métodos que retornam untyped usando chain resolution
     return_type_resolver.improve_method_return_types(target_members, attr_types, parsed_target: @parsed_target)
 
     # Second TypeMerger pass: now benefits from Steep-resolved types, inferred
     # param types and ivar types (ivar getters/setters — rbs_infer#19)
-    type_merger.resolve_method_return_types_from_attrs(target_members, attr_types, method_type_resolver: method_type_resolver, parsed_target: @parsed_target, method_param_types: method_param_types, ivar_types: ivar_types)
+    type_merger.resolve_method_return_types_from_attrs(target_members, attr_types, method_type_resolver: method_type_resolver, parsed_target: @parsed_target, method_param_types: method_param_types, ivar_types: reachable_ivar_types)
 
     # A body with an early `return` can return nil however its tail was typed. Runs
     # AFTER every pass that sets a return type — each used to widen (or forget to) on
@@ -296,7 +310,7 @@ module RbsInfer
 
     namespace_classes = resolve_namespace_classes
     rbs_builder = RbsInfer::Signatures::RbsBuilder.new(target_class: @target_class, superclass_name: @superclass_name, namespace_classes: namespace_classes, is_module: @is_module, type_params: method_type_resolver.type_param_string(@target_class), class_methods_index: class_methods_index)
-    rbs_builder.build(target_members, init_arg_types, attr_types, optional_params, method_param_types, ivar_types: ivar_types, singleton_ivar_types: singleton_ivar_types, markers: markers)
+    rbs_builder.build(target_members, init_arg_types, attr_types, optional_params, method_param_types, ivar_types: ivar_types, singleton_ivar_types: singleton_ivar_types, module_ivar_types: module_ivar_types, markers: markers)
   end
 
   # Builds the marker class list to inject into the generated RBS.
@@ -319,7 +333,20 @@ module RbsInfer
   end
 
   def synthesize_setter_markers(target_members, attr_types)
-    per_method = steep_bridge.ivar_write_types_per_method(@parsed_target.source, target_class: @target_class)
+    # Every scope whose methods can narrow an ivar on this receiver: the class
+    # and the modules nested in it. Asked one by one because a scope is what
+    # `ivar_write_types_per_method` takes, and since felixefelip/rbs_infer#249 it
+    # answers for that scope exactly — a nested module's writers used to arrive
+    # in the class's answer, and reading only the class dropped their markers
+    # (`Example29::AfterBazingado`) entirely.
+    #
+    # Merged rather than kept apart because a marker is named for the RECEIVER,
+    # and `Baz.bazingado` narrows the same object whichever scope `bazingado` is
+    # written in. WHERE such a marker should be declared is the same question
+    # this PR settles for ivars, one level up, and is not settled here.
+    per_method = [@target_class, *target_members.filter_map(&:owner).uniq.map { |o| "#{@target_class}::#{o}" }]
+                 .map { |scope| steep_bridge.ivar_write_types_per_method(@parsed_target.source, target_class: scope) }
+                 .reduce({}) { |all, scoped| all.merge(scoped) { |_, a, b| a.merge(b) } }
     return [] if per_method.empty?
 
     declared_ivar_types = collect_declared_attr_types(target_members, attr_types)

--- a/lib/rbs_infer/inference/return_type_resolver.rb
+++ b/lib/rbs_infer/inference/return_type_resolver.rb
@@ -13,7 +13,13 @@ module RbsInfer::Inference
     # type for plain instance variables (`@x: T`); `singleton` maps ivar name
     # → type for class-instance variables written inside `def self.x` /
     # `class << self` (`self.@x: T`) — felixefelip/rbs_infer#86.
-    IvarInference = Struct.new(:instance, :singleton)
+    #
+    # `by_module` is the same instance split one level down: `owner name →
+    # { ivar name → type }` for the ivars a NESTED module writes, which are the
+    # module's and not the class's. The builder emits them inside that module's
+    # own block, where the method that writes them will look for them
+    # (felixefelip/rbs_infer#249).
+    IvarInference = Struct.new(:instance, :singleton, :by_module)
 
     def initialize(target_file:, target_class:, method_type_resolver:, constant_resolver:, instance_types: [], steep_bridge: nil)
       @target_file = target_file
@@ -256,7 +262,7 @@ module RbsInfer::Inference
     end
 
     def infer_ivar_types(members, attr_types, parsed_target: nil, method_param_types: {})
-      return IvarInference.new({}, {}) unless parsed_target
+      return IvarInference.new({}, {}, {}) unless parsed_target
 
       # Attr names already declared → the ivar they back is typed by the attr,
       # so we skip re-emitting it. Split by receiver scope: an instance attr
@@ -265,8 +271,16 @@ module RbsInfer::Inference
       # attr (`class << self; attr_accessor :x`) covers that one
       # (felixefelip/rbs_infer#86).
       attrs = members.select { |m| [:attr_accessor, :attr_reader, :attr_writer].include?(m.kind) }
+      # Every non-singleton attr, wherever it is declared: one in a nested module
+      # the class includes still types the class's `@x`, so it still means "don't
+      # re-emit". The owner matters for WHERE a slot is declared, not for whether
+      # an accessor already covers it.
       instance_attr_names = attrs.reject(&:singleton).map(&:name).to_set
       singleton_attr_names = attrs.select(&:singleton).map(&:name).to_set
+      # The same coverage question asked of one module: its own attrs cover its
+      # own ivars, and a sibling module's do not.
+      module_attr_names = Hash.new { |h, k| h[k] = Set.new }
+      attrs.reject(&:singleton).select(&:owner).each { |a| module_attr_names[a.owner] << a.name }
 
       ivar_types = {}
 
@@ -281,6 +295,7 @@ module RbsInfer::Inference
       # Don't close the door on the Prism fallback: the nil becomes mere
       # nilability and the fallback adds the call-sites' nominal types.
       steep_nil_only = Set.new
+      module_ivar_types = Hash.new { |h, k| h[k] = {} }
       if @steep_bridge && parsed_target.source
         steep_ivars = @steep_bridge.ivar_write_types(parsed_target.source, target_class: @target_class)
         steep_ivars.each do |name, type|
@@ -290,6 +305,19 @@ module RbsInfer::Inference
             next
           end
           ivar_types[name] = type
+        end
+
+        # Each nested module is its own scope for this question, so it is asked
+        # as one — `ivar_write_types` already takes the scope to answer for, and
+        # since felixefelip/rbs_infer#249 it answers for that scope EXACTLY
+        # rather than sweeping nested modules into their enclosing class.
+        members.filter_map(&:owner).uniq.each do |owner|
+          @steep_bridge.ivar_write_types(parsed_target.source, target_class: "#{@target_class}::#{owner}")
+                       .each do |name, type|
+            next if module_attr_names[owner].include?(name) || type == "nil"
+
+            module_ivar_types[owner][name] = type
+          end
         end
       end
 
@@ -308,18 +336,37 @@ module RbsInfer::Inference
       # (DefCollector already knows which defs are singleton).
       singleton_type_sets = Hash.new { |h, k| h[k] = IvarTypeSet.new }
 
+      # The fallback's half of the owner split. A nested module's instance
+      # methods write the MODULE's ivars, so they get their own bucket rather
+      # than pooling into the class's — the same division the Steep pass above
+      # makes by asking per scope (felixefelip/rbs_infer#249).
+      module_type_sets = Hash.new { |h, k| h[k] = Hash.new { |i, j| i[j] = IvarTypeSet.new } }
+
       collector.defs.each do |defn|
         singleton = collector.class_method?(defn)
+        owner = collector.owner_of(defn)
         # Keyed by the method's identity, not its name — see MethodKey
         # (felixefelip/rbs_infer#215).
         param_types = RbsInfer::Inference::MethodKey.lookup(
           method_param_types,
           defn.name.to_s,
-          owner: RbsInfer::Inference::MethodKey.qualify_owner(@target_class, collector.owner_of(defn)),
+          owner: RbsInfer::Inference::MethodKey.qualify_owner(@target_class, owner),
           kind: singleton ? :class_method : :method
         ) || {}
-        target = singleton ? singleton_type_sets : fallback_type_sets
-        skip_names = singleton ? singleton_attr_names : instance_attr_names
+        target = if singleton
+                   singleton_type_sets
+                 elsif owner
+                   module_type_sets[owner]
+                 else
+                   fallback_type_sets
+                 end
+        skip_names = if singleton
+                       singleton_attr_names
+                     elsif owner
+                       module_attr_names[owner]
+                     else
+                       instance_attr_names
+                     end
         collect_ivar_writes(defn, known_return_types, target, skip_names, param_types: param_types)
       end
 
@@ -351,7 +398,20 @@ module RbsInfer::Inference
         singleton_ivar_types[name] = emitted if emitted
       end
 
-      IvarInference.new(ivar_types, singleton_ivar_types)
+      # A module has no constructor of its own — whoever includes or extends it
+      # runs the write, and nothing here can say it ran. So every ivar a nested
+      # module writes is nilable, which is the same conclusion the class-level
+      # rule reaches for an ivar that `initialize` never touches.
+      module_type_sets.each do |owner, type_sets|
+        type_sets.each do |name, type_set|
+          next if module_ivar_types[owner].key?(name)
+
+          emitted = type_set.emit(force_nilable: true)
+          module_ivar_types[owner][name] = emitted if emitted
+        end
+      end
+
+      IvarInference.new(ivar_types, singleton_ivar_types, module_ivar_types.reject { |_, ivars| ivars.empty? })
     end
 
     # Returns Set[String] of ivar names (without `@`) definitely initialized in

--- a/lib/rbs_infer/signatures/rbs_builder.rb
+++ b/lib/rbs_infer/signatures/rbs_builder.rb
@@ -24,7 +24,7 @@ module RbsInfer::Signatures
 
     ATTR_KINDS = %i[attr_reader attr_writer attr_accessor].freeze
 
-    def build(members, init_arg_types, attr_types, optional_params = Set.new, method_param_types = {}, ivar_types:, singleton_ivar_types:, markers:)
+    def build(members, init_arg_types, attr_types, optional_params = Set.new, method_param_types = {}, ivar_types:, singleton_ivar_types:, module_ivar_types:, markers:)
       members = reconcile_attrs_with_explicit_defs(members)
       parts = @target_class.split("::")
       class_name = parts.pop
@@ -69,7 +69,7 @@ module RbsInfer::Signatures
       # parsing the pseudo-source, with the core unaware of the extension
       # (felixefelip/rbs_infer#19, #22).
       nested = []
-      emit_parsed_nested_modules(nested, members, member_indent, attr_types, method_param_types)
+      emit_parsed_nested_modules(nested, members, member_indent, attr_types, method_param_types, module_ivar_types)
       add_group(lines, body_start, nested)
 
       # Mixins: extend (e.g. ActiveSupport::Concern) + include (concerns),
@@ -287,7 +287,7 @@ module RbsInfer::Signatures
     # parsed `include X` is emitted separately as a direct member, so the
     # module declaration here gives that include a real target — no
     # dangling mixin (felixefelip/rbs_infer#22).
-    def emit_parsed_nested_modules(lines, members, member_indent, attr_types, method_param_types)
+    def emit_parsed_nested_modules(lines, members, member_indent, attr_types, method_param_types, module_ivar_types)
       owned = members.reject { |m| m.owner.nil? }
       return if owned.empty?
 
@@ -305,6 +305,15 @@ module RbsInfer::Signatures
         # members. Emitting the lines flat made a nested module the one place in
         # the file where everything touched.
         body_start = lines.size
+
+        # The module's own instance variables. A method here writes them on
+        # whatever includes or extends the module, never on the enclosing class,
+        # so this is the only declaration site Steep will look at from inside
+        # `owner` — and includers still see the slot, because RBS resolves
+        # instance variables through ancestors (felixefelip/rbs_infer#249).
+        add_group(lines, body_start, (module_ivar_types[owner] || {}).map do |name, type|
+          "#{inner_indent}@#{name}: #{type}"
+        end)
 
         add_group(lines, body_start, mod_members.select { |m| m.kind == :constant }.map do |const|
           "#{inner_indent}#{const.signature}"

--- a/lib/rbs_infer/signatures/steep_bridge/lexical_scope.rb
+++ b/lib/rbs_infer/signatures/steep_bridge/lexical_scope.rb
@@ -8,31 +8,31 @@ class RbsInfer::Signatures::SteepBridge
         name ? namespace + [[name, node.type]] : namespace
       end
 
-      # True when the lexical class path `namespace` (array of segments) is
-      # `target_class` *or* something nested under it. The nested case is
-      # required: an expander (e.g. CurrentAttributes) can emit a nested
-      # `module GeneratedAttributeMethods` that is `include`d into the class
-      # and writes the same ivars, so its writes belong to the target. The
-      # `::` boundary keeps a sibling like `BoardMember` from matching
-      # target `Board`. A nil `target_class` means "don't scope" (whole
-      # file), preserved for callers with no single target.
       # Whether a write at lexical `namespace` (a list of `[name, kind]` frames,
-      # outermost first) belongs to `target_class`.
+      # outermost first) belongs to `target_class`. Exactly — the scope that
+      # WRITES an ivar is the scope that owns it. A nil `target_class` means
+      # "don't scope" (whole file), preserved for callers with no single target.
       #
-      # Frames strictly below the target only count while they are *modules*:
-      # a nested module's members are the target's, emitted in place by the
-      # owner mechanism (felixefelip/rbs_infer#22). A nested *class* is its own
-      # target, so its writes are not the target's — without this, `@name = name`
-      # in `Example3::User#initialize` surfaced as `@name: String` on `Example3`.
+      # A nested module used to count as the target too, so that a nested
+      # `module GeneratedAttributeMethods` the class `include`s would put its
+      # ivars on the class. It reached the right conclusion the wrong way: the
+      # includer sees the slot because RBS resolves instance variables through
+      # ANCESTORS, so declaring `@x` on the module already gives every includer
+      # `@x` — the loophole was never what made that case work.
+      #
+      # What it did do is claim ivars from modules nobody includes. `Example32`'s
+      # `Foo` is only ever `extend`ed, so `@_bazingado_block` was declared on
+      # `Example32`, which no runtime object ever writes it on, and Steep
+      # answered `Cannot find the declaration of instance variable` at the write
+      # itself (felixefelip/rbs_infer#249).
+      #
+      # The nested module's ivars are emitted in its own `module … end` block by
+      # `RbsBuilder`, alongside the members the owner mechanism already put there
+      # (felixefelip/rbs_infer#22).
       def class_scope_match?(namespace, target_class)
         return true if target_class.nil?
 
-        target = target_class.to_s.sub(/\A::/, "")
-        current = namespace.map(&:first).join("::")
-        return true if current == target
-        return false unless current.start_with?("#{target}::")
-
-        namespace.drop(target.split("::").size).all? { |(_, kind)| kind == :module }
+        namespace.map(&:first).join("::") == target_class.to_s.sub(/\A::/, "")
       end
 
       private

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -87,6 +87,10 @@ postconditions:
       author_name: "::String"
       user: "((::User & ::User::Validated) | ::User)"
       viewer_name: "::String"
+  effects:
+    may_write:
+    - "@author_name"
+    - "@viewer_name"
 - class: Current
   method: __rbs_infer_instance
   effects:
@@ -158,6 +162,42 @@ postconditions:
     - "@account"
     - "@author_name"
     - "@user"
+    - "@viewer_name"
+- class: Current::GeneratedAttributeMethods
+  method: account
+  effects:
+    returns_ivar: "@account"
+- class: Current::GeneratedAttributeMethods
+  method: account=
+  effects:
+    may_write:
+    - "@account"
+- class: Current::GeneratedAttributeMethods
+  method: author_name
+  effects:
+    returns_ivar: "@author_name"
+- class: Current::GeneratedAttributeMethods
+  method: author_name=
+  effects:
+    may_write:
+    - "@author_name"
+- class: Current::GeneratedAttributeMethods
+  method: user
+  effects:
+    returns_ivar: "@user"
+- class: Current::GeneratedAttributeMethods
+  method: user=
+  effects:
+    may_write:
+    - "@user"
+- class: Current::GeneratedAttributeMethods
+  method: viewer_name
+  effects:
+    returns_ivar: "@viewer_name"
+- class: Current::GeneratedAttributeMethods
+  method: viewer_name=
+  effects:
+    may_write:
     - "@viewer_name"
 - class: DashboardController
   method: __rbs_infer__run_show
@@ -940,6 +980,11 @@ postconditions:
   effects:
     may_write:
     - "@bazingado_block"
+- class: Example32::Foo
+  method: bazingado
+  effects:
+    may_write:
+    - "@_bazingado_block"
 - class: Example3::Foo
   method: user=
   unconditional:

--- a/spec/dummy/sig/rbs_infer/app/models/example32.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example32.rbs
@@ -1,9 +1,9 @@
 class Example32
-  @_bazingado_block: (^(*untyped) [self: singleton(Example32::Bar)] -> Symbol)?
-
   module Foo
-    def bazinga: (singleton(::Example32::Baz) module_included) -> (^(*untyped) [self: singleton(Example32::Bar)] -> Symbol)?
-    def bazingado: (?singleton(Example32::Bar)? base) ?{ (*untyped) [self: singleton(Example32::Bar)] -> Symbol } -> (^(*untyped) [self: singleton(Example32::Bar)] -> Symbol)?
+    @_bazingado_block: (^(*untyped) [self: singleton(Example32::Bar)] -> Symbol)?
+
+    def bazinga: (singleton(::Example32::Baz) module_included) -> (^(*untyped) [self: singleton(Example32::Bar)] -> Symbol | nil | Symbol)
+    def bazingado: (?singleton(Example32::Bar)? base) ?{ (*untyped) [self: singleton(Example32::Bar)] -> Symbol } -> (^(*untyped) [self: singleton(Example32::Bar)] -> Symbol | nil | Symbol)
   end
 
   module Baz

--- a/spec/dummy/sig/rbs_infer/app/models/included_hook/home_made.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/included_hook/home_made.rbs
@@ -1,7 +1,7 @@
 class IncludedHook
   module HomeMade
-    @included_block: (^(*untyped) [self: Module] -> untyped)?
+    @included_block: (^(*untyped) [self: Module] -> Symbol)?
 
-    def included: (?Module? base) ?{ (*untyped) [self: Module] -> untyped } -> nil
+    def included: (?Module? base) ?{ (*untyped) [self: Module] -> Symbol } -> nil
   end
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs
@@ -5,13 +5,13 @@ class Current
   self.@viewer_name: String?
   self.@__rbs_infer_instance: Current?
 
-  @user: ((User & User::Validated) | User)?
-  @author_name: String?
-  @account: (Account & Account::Validated)?
-  @viewer_name: String?
-
   module GeneratedAttributeMethods
-    def user: () -> ((User & User::Validated) | User)?
+    @user: ((User & User::Validated) | User)?
+    @author_name: String?
+    @account: (Account & Account::Validated)?
+    @viewer_name: String?
+
+    def user: () -> ((User & User::Validated) | User | nil)
     def user=: (((User & User::Validated) | User?) value) -> ((User & User::Validated) | User)?
     def author_name: () -> String?
     def author_name=: (String? value) -> String?

--- a/spec/expectations/models/example32.rbs
+++ b/spec/expectations/models/example32.rbs
@@ -1,9 +1,9 @@
 class Example32
-  @_bazingado_block: (^(*untyped) [self: singleton(Example32::Bar)] -> Symbol)?
-
   module Foo
-    def bazinga: (singleton(::Example32::Baz) module_included) -> (^(*untyped) [self: singleton(Example32::Bar)] -> Symbol)?
-    def bazingado: (?singleton(Example32::Bar)? base) ?{ (*untyped) [self: singleton(Example32::Bar)] -> Symbol } -> (^(*untyped) [self: singleton(Example32::Bar)] -> Symbol)?
+    @_bazingado_block: (^(*untyped) [self: singleton(Example32::Bar)] -> Symbol)?
+
+    def bazinga: (singleton(::Example32::Baz) module_included) -> (^(*untyped) [self: singleton(Example32::Bar)] -> Symbol | nil | Symbol)
+    def bazingado: (?singleton(Example32::Bar)? base) ?{ (*untyped) [self: singleton(Example32::Bar)] -> Symbol } -> (^(*untyped) [self: singleton(Example32::Bar)] -> Symbol | nil | Symbol)
   end
 
   module Baz

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -13,6 +13,7 @@ app/models/example3.rb:67:13: [error] Type `(::String | nil)` does not have meth
 app/models/example30.rb:16:6: [error] Type `::Example30::Foo` does not have method `age`
 app/models/example30.rb:9:12: [warning] Method `::Example30::Foo#age` is not declared in RBS
 app/models/example31.rb:26:8: [error] Cannot allow method body have type `::Integer` because declared as type `::Float`
+app/models/example32.rb:11:24: [warning] Cannot pass a value of type `(^(*untyped) [self: singleton(::Example32::Bar)] -> ::Symbol | nil)` as a block-pass-argument of type `^(singleton(::Example32::Bar)) [self: singleton(::Example32::Bar)] -> U(_)`
 app/models/example4.rb:14:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:22:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:27:23: [error] Type `(::String | nil)` does not have method `upcase`
@@ -28,7 +29,7 @@ app/models/included_hook.rb:60:10: [warning] Method `::IncludedHook::Sugared#fro
 app/models/included_hook.rb:66:10: [warning] Method `::IncludedHook::Sugared#badge` is not declared in RBS
 app/models/included_hook.rb:82:10: [warning] Method `::IncludedHook::Homespun#from_homespun` is not declared in RBS
 app/models/included_hook.rb:86:10: [warning] Method `::IncludedHook::Homespun#stamp` is not declared in RBS
-app/models/included_hook/home_made.rb:27:22: [warning] Cannot pass a value of type `(^(*untyped) [self: ::Module] -> untyped | nil)` as a block-pass-argument of type `^(::Module) [self: ::Module] -> U(_)`
+app/models/included_hook/home_made.rb:27:22: [warning] Cannot pass a value of type `(^(*untyped) [self: ::Module] -> ::Symbol | nil)` as a block-pass-argument of type `^(::Module) [self: ::Module] -> U(_)`
 app/models/included_hook/shared.rb:17:10: [warning] Method `::IncludedHook::Shared#from_shared` is not declared in RBS
 app/models/post/notifiable.rb:28:24: [error] Type `(::User | nil)` does not have method `full_name`
 app/models/send_dispatch.rb:107:33: [error] `public_send` cannot call `stamp` on `::SendDispatch`, which declares it private

--- a/spec/expectations/steep_current_runtime/current.rbs
+++ b/spec/expectations/steep_current_runtime/current.rbs
@@ -5,13 +5,13 @@ class Current
   self.@viewer_name: String?
   self.@__rbs_infer_instance: Current?
 
-  @user: ((User & User::Validated) | User)?
-  @author_name: String?
-  @account: (Account & Account::Validated)?
-  @viewer_name: String?
-
   module GeneratedAttributeMethods
-    def user: () -> ((User & User::Validated) | User)?
+    @user: ((User & User::Validated) | User)?
+    @author_name: String?
+    @account: (Account & Account::Validated)?
+    @viewer_name: String?
+
+    def user: () -> ((User & User::Validated) | User | nil)
     def user=: (((User & User::Validated) | User?) value) -> ((User & User::Validated) | User)?
     def author_name: () -> String?
     def author_name=: (String? value) -> String?

--- a/spec/lib/rbs_infer/signatures/rbs_builder_spec.rb
+++ b/spec/lib/rbs_infer/signatures/rbs_builder_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe RbsInfer::Signatures::RbsBuilder do
   # forgotten one is silent-wrong, not a valid empty case
   # (docs/engineering/required-threaded-deps.md). This helper supplies the
   # test-only empty defaults so examples state only what they exercise.
-  def build_rbs(builder, members, init_arg_types = {}, attr_types = {}, *rest, ivar_types: {}, singleton_ivar_types: {}, markers: [])
-    builder.build(members, init_arg_types, attr_types, *rest, ivar_types: ivar_types, singleton_ivar_types: singleton_ivar_types, markers: markers)
+  def build_rbs(builder, members, init_arg_types = {}, attr_types = {}, *rest, ivar_types: {}, singleton_ivar_types: {}, module_ivar_types: {}, markers: [])
+    builder.build(members, init_arg_types, attr_types, *rest, ivar_types: ivar_types, singleton_ivar_types: singleton_ivar_types, module_ivar_types: module_ivar_types, markers: markers)
   end
 
   describe "#has_class_methods_module?", :dummy_app do
@@ -322,6 +322,54 @@ RSpec.describe RbsInfer::Signatures::RbsBuilder do
 
     it "produces parseable RBS" do
       result = build_rbs(builder, [], {}, {}, singleton_ivar_types: { "config" => "String?" })
+
+      expect { RBS::Parser.parse_signature(result) }.not_to raise_error
+    end
+  end
+
+  # A method in a nested module writes on whoever includes or extends it, never
+  # on the enclosing class — so the module is where the slot is declared, next to
+  # the members the owner mechanism already puts there
+  # (felixefelip/rbs_infer#249).
+  describe "#build with nested-module ivars" do
+    let(:builder) { make_builder(target_class: "Outer", superclass_name: nil) }
+
+    def owned_method(name, owner)
+      RbsInfer::Inference::Member.new(
+        kind: :method, name: name, signature: "#{name}: () -> void", visibility: :public, owner: owner
+      )
+    end
+
+    it "declares them inside the owning module, not on the class" do
+      result = build_rbs(builder, [owned_method("configure", "Generated")],
+                         module_ivar_types: { "Generated" => { "setting" => "Integer?" } })
+
+      expect(result).to match(/module Generated\n\s+@setting: Integer\?/)
+      expect(result).not_to match(/^  @setting:/)
+    end
+
+    it "files each module's ivars under its own module" do
+      result = build_rbs(builder, [owned_method("a", "One"), owned_method("b", "Two")],
+                         module_ivar_types: { "One" => { "x" => "String?" }, "Two" => { "y" => "Integer?" } })
+
+      expect(result).to match(/module One\n\s+@x: String\?/)
+      expect(result).to match(/module Two\n\s+@y: Integer\?/)
+    end
+
+    # The class keeps its own, so an ivar written in both places is not moved
+    # out from under the class that also writes it.
+    it "leaves the class's own ivars where they are" do
+      result = build_rbs(builder, [owned_method("configure", "Generated")],
+                         ivar_types: { "ran" => "bool?" },
+                         module_ivar_types: { "Generated" => { "setting" => "Integer?" } })
+
+      expect(result).to match(/^  @ran: bool\?/)
+      expect(result).to match(/module Generated\n\s+@setting: Integer\?/)
+    end
+
+    it "produces parseable RBS" do
+      result = build_rbs(builder, [owned_method("configure", "Generated")],
+                         module_ivar_types: { "Generated" => { "setting" => "Integer?" } })
 
       expect { RBS::Parser.parse_signature(result) }.not_to raise_error
     end

--- a/spec/lib/rbs_infer/signatures/steep_bridge/ivar_write_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/signatures/steep_bridge/ivar_write_analyzer_spec.rb
@@ -512,11 +512,27 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
         expect(outer).not_to have_key("name")
       end
 
-      it "atribui os writes de um módulo aninhado à classe externa" do
+      # O escopo que ESCREVE é o dono. `Generated#configure` roda com `self`
+      # sendo quem inclui/estende `Generated` — nunca `Outer` — então declarar
+      # `@setting` em `Outer` inventa um slot que nenhum objeto tem, e o Steep
+      # responde `Cannot find the declaration of instance variable` no próprio
+      # write (felixefelip/rbs_infer#249).
+      #
+      # Um includer continua enxergando o slot: RBS resolve ivar por ANCESTRAIS,
+      # então declarar no módulo já serve `Outer` quando ele de fato inclui —
+      # que era o único caso que a regra antiga acertava.
+      it "não atribui os writes de um módulo aninhado à classe externa" do
         outer = bridge.ivar_write_types(nested_code, target_class: "Outer")
 
-        expect(outer).to have_key("setting")
+        expect(outer).not_to have_key("setting")
         expect(outer).to have_key("ran")
+      end
+
+      it "atribui os writes do módulo aninhado ao próprio módulo" do
+        generated = bridge.ivar_write_types(nested_code, target_class: "Outer::Generated")
+
+        expect(generated).to have_key("setting")
+        expect(generated).not_to have_key("ran")
       end
 
       it "atribui os writes da classe aninhada ao seu próprio alvo" do


### PR DESCRIPTION
Fixes `Cannot find the declaration of instance variable: @_bazingado_block` on `Example32`.

## The symptom

```
app/models/example32.rb:9:8: [error] Cannot find the declaration of instance variable: `@_bazingado_block`
└         @_bazingado_block = block
```

Invisible in the dummy because `Ruby::UnknownInstanceVariable` is off under `D::Ruby.default`, which `spec/dummy/Steepfile` uses. Enabling it reproduces exactly that.

## The cause

```rbs
class Example32
  @_bazingado_block: (^…)?      # ← declared here
  module Foo
    def bazingado: …            # ← written here, where `self` is Foo
```

`Foo` is only ever `extend`ed, so no `Example32` instance ever has that slot.

Two halves were wrong:

- **Attribution** — `LexicalScope.class_scope_match?` counted a nested *module* as the target (`namespace.drop(…).all? { |(_, kind)| kind == :module }`), so `Foo`'s writes arrived in `Example32`'s map.
- **Emission** — `ivar_types` was a flat `name → type` with no owner, emitted at the target's own indent. `def`s and constants have carried an `owner` since #22 and get routed into nested-module blocks; ivars had no such path, so even correct attribution had nowhere to go.

The module rule existed so a nested `GeneratedAttributeMethods` that the class `include`s would put its ivars on the class. **It reached the right conclusion the wrong way**: RBS resolves instance variables through *ancestors*, so declaring `@x` on the module already gives every includer `@x`. Verified rather than assumed:

```rbs
module M
  @x: Integer?
end
class C
  include M
  def read: () -> Integer?   # → "No type error detected"
end
```

What the loophole actually did was claim ivars from modules nobody includes.

## What made it more than a one-liner

**Where a slot is declared and what an instance may hold are two questions.** Declaration follows the writer. Inference wants everything reachable on an instance, which for an includer spans the module too.

Handing the inference passes the narrow map turned every `Current` reader into `-> untyped`, since those accessors live in the same nested module as the ivars they read. So the passes read the union (`reachable_ivar_types`) while the builder reads the split. Setter markers ask per scope for the same reason — reading only the class silently dropped `Example29::AfterBazingado` from the output.

## What moves

Two fixtures, both to where the writes are, with every method type preserved:

```diff
 class Current
-  @user: ((User & User::Validated) | User)?
-  @author_name: String?
-  @account: (Account & Account::Validated)?
-  @viewer_name: String?
-
   module GeneratedAttributeMethods
+    @user: ((User & User::Validated) | User)?
+    @author_name: String?
+    @account: (Account & Account::Validated)?
+    @viewer_name: String?
+
     def user: () -> ((User & User::Validated) | User)?
```

`GeneratedAttributeMethods` is where Rails actually defines those accessors.

## What improves from being visible rather than untyped

- `bazingado`'s inferred return picks up the `Symbol` its `class_eval` branch yields — a `MethodBodyTypeMismatch` that was only latent because the ivar could not be typed at all.
- The same block return sharpens `untyped` → `Symbol` in `IncludedHook::HomeMade`, the other hand-rolled concern.
- The postconditions inferrer records `may_write` / `returns_ivar` for nine methods it could not see before (`Current::GeneratedAttributeMethods` ×8, `Example32::Foo` ×1).

## Tests

**1269 examples, 0 failures** — the full suite, including the integration and steep specs, which had standing failures before this branch.

The steep baseline gains exactly one line, for `example32.rb:11`: the stored proc is `T?` and `class_eval` wants non-nil, which the `if @_bazingado_block` guard settles at runtime but Steep does not narrow through. **The identical warning was already baselined one line below for `included_hook/home_made.rb`** — this is that same known gap, now reached by a second fixture, not a new class of problem:

```diff
+app/models/example32.rb:11:24: [warning] Cannot pass a value of type `(^(*untyped) [self: singleton(::Example32::Bar)] -> ::Symbol | nil)` as a block-pass-argument …
-app/models/included_hook/home_made.rb:27:22: [warning] … `(^(*untyped) [self: ::Module] -> untyped | nil)` …
+app/models/included_hook/home_made.rb:27:22: [warning] … `(^(*untyped) [self: ::Module] -> ::Symbol | nil)` …
```

New unit coverage for both halves: `RbsBuilder` filing each module's ivars under its own module and leaving the class's own alone, and `IvarWriteAnalyzer` attributing a nested module's writes to the module rather than the enclosing class (that spec previously pinned the opposite and is rewritten with the reasoning).

## Follow-up, deliberately not here

Setter markers are still declared on the target even when the method that narrows the ivar lives in a nested module (`Example29::AfterBazingado` on `Example29`, though `bazingado` is `Foo`'s). That is the same question this PR settles for ivars, one level up. Kept working exactly as before rather than moved, so this PR changes one thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
