### PR TITLE
Drop the three diagnostics the ivar-guard narrowing fixes

### DIFF
--- a/spec/dummy/app/models/example32.rb
+++ b/spec/dummy/app/models/example32.rb
@@ -27,5 +27,13 @@ class Example32
     extend Example32::Foo
 
     bazinga(Example32::Baz)
+
+    def test
+      @test = "test"
+    end
+
+    def use_test
+      @test.upcase if @test
+    end
   end
 end

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -980,6 +980,15 @@ postconditions:
   effects:
     may_write:
     - "@bazingado_block"
+- class: Example32::Bar
+  method: test
+  unconditional:
+    ivars:
+      "@test": "::String"
+    self: "::Example32::Bar & ::Example32::Bar::AfterTest"
+  effects:
+    may_write:
+    - "@test"
 - class: Example32::Foo
   method: bazingado
   effects:

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/example32.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/example32.rb
@@ -30,6 +30,14 @@ class Example32
     extend Example32::Foo
 
     bazinga(Example32::Baz)
+
+    def test
+      @test = "test"
+    end
+
+    def use_test
+      @test.upcase if @test
+    end
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example32.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example32.rbs
@@ -13,8 +13,12 @@ end
 
 class Example32
   class Bar
+    @test: String?
+
     extend ::Example32::Foo
 
+    def test: () -> String
+    def use_test: () -> String?
     def age: () -> Integer
   end
 end

--- a/spec/expectations/expanded/app/models/example32.rb
+++ b/spec/expectations/expanded/app/models/example32.rb
@@ -27,6 +27,14 @@ class Example32
     extend Example32::Foo
 
     bazinga(Example32::Baz)
+
+    def test
+      @test = "test"
+    end
+
+    def use_test
+      @test.upcase if @test
+    end
   end
 end
 

--- a/spec/expectations/models/example32.rbs
+++ b/spec/expectations/models/example32.rbs
@@ -13,8 +13,12 @@ end
 
 class Example32
   class Bar
+    @test: String?
+
     extend ::Example32::Foo
 
+    def test: () -> String
+    def use_test: () -> String?
     def age: () -> Integer
   end
 end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -2,7 +2,6 @@ app/models/concerns/test/filtrable.rb:16:13: [error] Type `(::Post & ::Test::Fil
 app/models/concerns/test/filtrable.rb:16:4: [error] Type `(::Post & ::Test::Filtrable)` does not have method `asdasd`
 app/models/eval_reopen.rb:61:6: [warning] Method `::Object#by_instance_eval` is not declared in RBS
 app/models/example14.rb:15:17: [error] Type `(::Example14::User | nil)` does not have method `name`
-app/models/example15.rb:25:25: [error] Type `(::Example15::User | nil)` does not have method `name`
 app/models/example21.rb:105:31: [error] Type `(::Example21::Holder | nil)` does not have method `name`
 app/models/example21.rb:96:29: [error] Type `(::Example21::Ticket | nil)` does not have method `holder`
 app/models/example3.rb:123:11: [error] Type `(::Example3::User | nil)` does not have method `name`
@@ -13,7 +12,6 @@ app/models/example3.rb:67:13: [error] Type `(::String | nil)` does not have meth
 app/models/example30.rb:16:6: [error] Type `::Example30::Foo` does not have method `age`
 app/models/example30.rb:9:12: [warning] Method `::Example30::Foo#age` is not declared in RBS
 app/models/example31.rb:26:8: [error] Cannot allow method body have type `::Integer` because declared as type `::Float`
-app/models/example32.rb:11:24: [warning] Cannot pass a value of type `(^(*untyped) [self: singleton(::Example32::Bar)] -> ::Symbol | nil)` as a block-pass-argument of type `^(singleton(::Example32::Bar)) [self: singleton(::Example32::Bar)] -> U(_)`
 app/models/example4.rb:14:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:22:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:27:23: [error] Type `(::String | nil)` does not have method `upcase`
@@ -29,7 +27,6 @@ app/models/included_hook.rb:60:10: [warning] Method `::IncludedHook::Sugared#fro
 app/models/included_hook.rb:66:10: [warning] Method `::IncludedHook::Sugared#badge` is not declared in RBS
 app/models/included_hook.rb:82:10: [warning] Method `::IncludedHook::Homespun#from_homespun` is not declared in RBS
 app/models/included_hook.rb:86:10: [warning] Method `::IncludedHook::Homespun#stamp` is not declared in RBS
-app/models/included_hook/home_made.rb:27:22: [warning] Cannot pass a value of type `(^(*untyped) [self: ::Module] -> ::Symbol | nil)` as a block-pass-argument of type `^(::Module) [self: ::Module] -> U(_)`
 app/models/included_hook/shared.rb:17:10: [warning] Method `::IncludedHook::Shared#from_shared` is not declared in RBS
 app/models/post/notifiable.rb:28:24: [error] Type `(::User | nil)` does not have method `full_name`
 app/models/send_dispatch.rb:107:33: [error] `public_send` cannot call `stamp` on `::SendDispatch`, which declares it private


### PR DESCRIPTION
Pairs with **felixefelip/steep#146**, which teaches the checker that `if @x` narrows `@x` the way `if x` narrows a local.

## Baseline

Three entries leave `steep_baseline.txt` and **none arrives**:

```diff
-app/models/example15.rb:25:25: [error] Type `(::Example15::User | nil)` does not have method `name`
-app/models/example32.rb:11:24: [warning] Cannot pass a value of type `(^(*untyped) [self: singleton(::Example32::Bar)] -> ::Symbol | nil)` as a block-pass-argument …
-app/models/included_hook/home_made.rb:27:22: [warning] Cannot pass a value of type `(^(*untyped) [self: ::Module] -> ::Symbol | nil)` as a block-pass-argument …
```

- `example32` and `included_hook/home_made` are the two hand-rolled `ActiveSupport::Concern`s, both `base.class_eval(&@blk) if @blk`. The guard settles the nilability at runtime and now settles it for the checker too.
- `example15` had been sitting in the baseline as if unfixable. Nothing in the original report pointed at it — it fell out of the same missing `when`.

## A fixture for the narrowing itself

`Example32::Bar` gains a `use_test` written in the shape the fix is about, so the behaviour is pinned somewhere it is the subject rather than only where it happens to matter:

```ruby
def test
  @test = "test"
end

def use_test
  @test.upcase if @test
end
```

The inferred return is the evidence:

```diff
+    def test: () -> String
+    def use_test: () -> String?      # `-> untyped` before steep#146
```

`untyped` was not a formatting difference — the body could not be typed at all while `@test` stayed nilable through its own guard, so `upcase` resolved on `(::String | nil)`.

The `AfterTest` marker and its `unconditional.ivars` postcondition come along as the ordinary setter machinery reacting to a new writer; they are not part of what is being tested.

## Tests

`bundle exec rspec` — **1269 examples, 0 failures**, with steep#146 checked out.

## Ordering

Requires the steep change to be in place. Without it the baseline is short three entries and `steep_dummy_spec` reports them as regressions — so merge felixefelip/steep#146 before this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
