### PR TITLE
Type-check the `self.@x` slot, and read a return past a block's arrow

### DIFF
--- a/lib/rbs_infer/inference/return_type_resolver.rb
+++ b/lib/rbs_infer/inference/return_type_resolver.rb
@@ -115,7 +115,7 @@ module RbsInfer::Inference
             next if m.signature =~ /->\s*untyped$/
             steep_type = steep_returns_for(m, steep_returns)[m.name]
             next unless steep_type && steep_type != "untyped" && steep_type != "nil" && steep_type != "bot"
-            current_type = m.signature[/->\s*(.+)$/, 1]&.strip
+            current_type = RbsInfer::Signatures::RbsParserUtil.return_type_of(m.signature)
             next if current_type == steep_type
             # Only override Array types (block generic correction)
             next unless current_type&.start_with?("Array[") && steep_type.start_with?("Array[")
@@ -133,7 +133,7 @@ module RbsInfer::Inference
           members.each do |m|
             next unless method_member?(m)
             next if m.name == "initialize"
-            current_type = m.signature[/->\s*(.+)$/, 1]&.strip
+            current_type = RbsInfer::Signatures::RbsParserUtil.return_type_of(m.signature)
             next unless current_type&.end_with?("?")
 
             steep_type = steep_returns_for(m, steep_returns)[m.name]
@@ -152,7 +152,7 @@ module RbsInfer::Inference
           members.each do |m|
             next unless method_member?(m)
             next if m.name == "initialize"
-            current_type = m.signature[/->\s*(.+)$/, 1]&.strip
+            current_type = RbsInfer::Signatures::RbsParserUtil.return_type_of(m.signature)
             next unless current_type&.start_with?("{") && current_type.include?("untyped")
 
             steep_type = steep_returns_for(m, steep_returns)[m.name]
@@ -196,7 +196,7 @@ module RbsInfer::Inference
             next if m.name == "initialize"
             next if setter_name?(m.name)
 
-            current_type = m.signature[/->\s*(.+)$/, 1]&.strip
+            current_type = RbsInfer::Signatures::RbsParserUtil.return_type_of(m.signature)
             next unless current_type && current_type != "untyped"
 
             steep_type = steep_returns_for(m, steep_returns)[m.name]
@@ -251,7 +251,7 @@ module RbsInfer::Inference
         # value — neither is the body's own tail type, so neither is ours to widen.
         next if m.name == "initialize" || setter_name?(m.name)
 
-        current = m.signature[/->\s*(.+)\z/, 1]&.strip
+        current = RbsInfer::Signatures::RbsParserUtil.return_type_of(m.signature)
         next if current.nil? || current == "untyped" || current == "void" || current.end_with?("?")
 
         defn = def_map(parsed_target)[m.name]
@@ -296,8 +296,17 @@ module RbsInfer::Inference
       # nilability and the fallback adds the call-sites' nominal types.
       steep_nil_only = Set.new
       module_ivar_types = Hash.new { |h, k| h[k] = {} }
+      # The `self.@x` slot, answered by the same machinery as the instance one.
+      # It used to have only the Prism fallback below, which reads literals and
+      # little else — so `@block = block` in a `def self.store` produced no
+      # declaration at all, and the proc the slot holds lost the `[self:]`
+      # binding it carries (felixefelip/rbs_infer#252).
+      steep_singleton_ivars = {}
       if @steep_bridge && parsed_target.source
-        steep_ivars = @steep_bridge.ivar_write_types(parsed_target.source, target_class: @target_class)
+        steep_singleton_ivars = @steep_bridge.ivar_write_types(parsed_target.source, target_class: @target_class,
+                                                                                     singleton: true)
+        steep_ivars = @steep_bridge.ivar_write_types(parsed_target.source, target_class: @target_class,
+                                                                          singleton: false)
         steep_ivars.each do |name, type|
           next if instance_attr_names.include?(name)
           if type == "nil"
@@ -312,7 +321,8 @@ module RbsInfer::Inference
         # since felixefelip/rbs_infer#249 it answers for that scope EXACTLY
         # rather than sweeping nested modules into their enclosing class.
         members.filter_map(&:owner).uniq.each do |owner|
-          @steep_bridge.ivar_write_types(parsed_target.source, target_class: "#{@target_class}::#{owner}")
+          @steep_bridge.ivar_write_types(parsed_target.source, target_class: "#{@target_class}::#{owner}",
+                                                               singleton: false)
                        .each do |name, type|
             next if module_attr_names[owner].include?(name) || type == "nil"
 
@@ -388,8 +398,12 @@ module RbsInfer::Inference
         end
       end
 
-      singleton_ivar_types = {}
+      # Steep first, exactly as the instance slot does it: the fallback only
+      # fills what the checker did not see.
+      singleton_ivar_types = steep_singleton_ivars.reject { |name, _| singleton_attr_names.include?(name) }
       singleton_type_sets.each do |name, type_set|
+        next if singleton_ivar_types.key?(name)
+
         # No constructor initializes a class-instance variable, so the
         # definite-init rule keys off a class-body write (where `self` is the
         # class) rather than `initialize` — nilable everywhere else.

--- a/lib/rbs_infer/signatures/rbs_parser_util.rb
+++ b/lib/rbs_infer/signatures/rbs_parser_util.rb
@@ -271,6 +271,25 @@ module RbsInfer::Signatures
       "#{method_sig[0...arrow].rstrip} -> #{wrapped}"
     end
 
+    # The method's OWN return type: the text past the LAST top-level `->`,
+    # or nil when the signature has no return arrow.
+    #
+    # A block clause carries an arrow of its own (`?{ () -> Symbol } -> T`),
+    # and a leftmost-matching `/->\s*(.+)$/` reads THAT one — handing back
+    # `Symbol } -> T`, a string nothing downstream can compare or substitute.
+    # Every guard reading it then fails open, so the passes that correct a
+    # declaration contradicting its body silently skipped any method that takes
+    # a block: `bazingado`'s return kept a proc type without the `[self:]`
+    # binding its body actually returns, and the corrector written for exactly
+    # that (felixefelip/rbs_infer#191) never got a parseable type to test
+    # (felixefelip/rbs_infer#252).
+    def return_type_of(method_sig)
+      arrow = last_top_level_arrow_index(method_sig)
+      return nil unless arrow
+
+      method_sig[(arrow + 2)..]&.strip
+    end
+
     # Index of the last `->` sitting at bracket depth 0, or nil. Used to
     # locate the real return arrow past nested proc/block arrows.
     def last_top_level_arrow_index(str)

--- a/lib/rbs_infer/signatures/steep_bridge.rb
+++ b/lib/rbs_infer/signatures/steep_bridge.rb
@@ -258,8 +258,8 @@ module RbsInfer::Signatures
       candidates.uniq
     end
 
-    def ivar_write_types(source_code, target_class:)
-      steep_bridge_ivar_write_analyzer.ivar_write_types(source_code, target_class: target_class)
+    def ivar_write_types(source_code, target_class:, singleton:)
+      steep_bridge_ivar_write_analyzer.ivar_write_types(source_code, target_class: target_class, singleton: singleton)
     end
 
     def ivar_write_types_per_method(source_code, target_class:)

--- a/lib/rbs_infer/signatures/steep_bridge/ivar_write_analyzer.rb
+++ b/lib/rbs_infer/signatures/steep_bridge/ivar_write_analyzer.rb
@@ -27,7 +27,14 @@ class RbsInfer::Signatures::SteepBridge
     # scope) of `target_class`, the emitted type gets `| nil`
     # (definite-initialization rule). The narrowing is then reabsorbed by
     # steep#16 within methods that explicitly assign before reading.
-    def ivar_write_types(source_code, target_class:)
+    #
+    # `singleton:` picks WHICH of the class's two ivar scopes to answer for.
+    # `false` is the instance `@x`; `true` is the class-instance `self.@x`
+    # written by `def self.x` / `class << self` / the class body. They are
+    # different slots, so they are different questions — and asking the wrong
+    # one silently returns `{}` rather than failing, which is why the argument
+    # is required rather than defaulted (felixefelip/rbs_infer#252).
+    def ivar_write_types(source_code, target_class:, singleton:)
       typing = @steep_bridge.type_check(source_code)
       return {} unless typing
 
@@ -35,7 +42,7 @@ class RbsInfer::Signatures::SteepBridge
       return {} unless source_node
 
       type_sets = Hash.new { |h, k| h[k] = RbsInfer::Inference::IvarTypeSet.new }
-      initialized = collect_initialized_ivars(source_node, target_class: target_class)
+      initialized = collect_initialized_ivars(source_node, target_class: target_class, singleton: singleton)
       attr_writer_to_ivar = collect_attr_writers(source_node)
       # Only writes lexically inside `target_class` count. A single file can
       # define several classes (initializers, `lib/*_ext.rb`, the dummy-app
@@ -43,7 +50,7 @@ class RbsInfer::Signatures::SteepBridge
       # like `initialize` — pool into each other (felixefelip/rbs_infer#38).
       # `each_typing` enumerates the whole file, so we filter it by node
       # identity against the set of writes that belong to `target_class`.
-      in_scope = collect_scoped_write_node_ids(source_node, attr_writer_to_ivar, target_class)
+      in_scope = collect_scoped_write_node_ids(source_node, attr_writer_to_ivar, target_class, singleton)
       masgn_values = collect_masgn_target_values(source_node)
 
       typing.each_typing do |node, type|
@@ -150,9 +157,14 @@ class RbsInfer::Signatures::SteepBridge
     # decide whether `nil` is added to the union — so it must be scoped to
     # the same class the writes are, or an `@x` initialized in a *sibling*
     # class in the same file would wrongly suppress the `| nil` here.
-    def collect_initialized_ivars(node, target_class:)
+    #
+    # `singleton: true` asks the same question of the `self.@x` slot, where the
+    # only definite initialization available is a class-body write: no
+    # constructor runs for a class-instance variable, so `initialize` says
+    # nothing about it and is not walked (felixefelip/rbs_infer#252).
+    def collect_initialized_ivars(node, target_class:, singleton:)
       result = Set.new
-      walk_ivar_init_targets(node, in_init: false, in_class_body: false,
+      walk_ivar_init_targets(node, in_init: false, in_class_body: false, singleton: singleton,
                                    namespace: [], target_class: target_class, result: result)
       result
     end
@@ -160,28 +172,34 @@ class RbsInfer::Signatures::SteepBridge
     # Walks `node` looking for `:ivasgn` targets that count as definite
     # initialization (inside `def initialize` or directly in a class body
     # outside any method). Does not descend into non-initialize defs.
-    def walk_ivar_init_targets(node, in_init:, in_class_body:, namespace:, target_class:, result:)
+    def walk_ivar_init_targets(node, in_init:, in_class_body:, singleton:, namespace:, target_class:, result:)
       return unless node.is_a?(::Parser::AST::Node)
 
       case node.type
       when :class, :module
         body = node.type == :class ? node.children[2] : node.children[1]
-        walk_ivar_init_targets(body, in_init: false, in_class_body: true,
+        walk_ivar_init_targets(body, in_init: false, in_class_body: true, singleton: singleton,
                                      namespace: RbsInfer::Signatures::SteepBridge::LexicalScope.push_namespace(namespace, node),
                                      target_class: target_class, result: result) if body
       when :sclass
         body = node.children[1]
-        walk_ivar_init_targets(body, in_init: false, in_class_body: true,
+        walk_ivar_init_targets(body, in_init: false, in_class_body: true, singleton: singleton,
                                      namespace: namespace, target_class: target_class, result: result) if body
       when :def
-        if node.children[0] == :initialize
+        # `initialize` initializes the INSTANCE slot. A class-instance variable
+        # has no constructor at all, so when answering for `self.@x` this says
+        # nothing and walking it would let an instance `@x = ...` wrongly
+        # suppress the singleton slot's `| nil`.
+        if node.children[0] == :initialize && !singleton
           body = node.children[2]
-          walk_ivar_init_targets(body, in_init: true, in_class_body: false,
+          walk_ivar_init_targets(body, in_init: true, in_class_body: false, singleton: singleton,
                                        namespace: namespace, target_class: target_class, result: result) if body
         end
       when :defs
         # def self.X — singleton method, skip; ivar there is class-instance
-        # variable, not relevant for instance ivar initialization.
+        # variable, not relevant for instance ivar initialization. Nor for the
+        # singleton slot's: a method body is not definite initialization in
+        # either scope, which is the whole point of the rule.
       when :ivasgn
         if (in_init || in_class_body) && RbsInfer::Signatures::SteepBridge::LexicalScope.class_scope_match?(namespace,
                                                                                                             target_class)
@@ -191,7 +209,7 @@ class RbsInfer::Signatures::SteepBridge
         # also walk RHS for nested classes (`@x = Class.new { @y = ... }` is
         # exotic but harmless to descend)
         rhs = node.children[1]
-        walk_ivar_init_targets(rhs, in_init: in_init, in_class_body: in_class_body,
+        walk_ivar_init_targets(rhs, in_init: in_init, in_class_body: in_class_body, singleton: singleton,
                                     namespace: namespace, target_class: target_class, result: result) if rhs
       when :send
         receiver, method_name, *args = node.children
@@ -214,19 +232,19 @@ class RbsInfer::Signatures::SteepBridge
           result << ivar unless ivar.empty?
         end
         node.children.each do |c|
-          walk_ivar_init_targets(c, in_init: in_init, in_class_body: in_class_body,
+          walk_ivar_init_targets(c, in_init: in_init, in_class_body: in_class_body, singleton: singleton,
                                     namespace: namespace, target_class: target_class, result: result)
         end
       when :begin
         node.children.each do |c|
-          walk_ivar_init_targets(c, in_init: in_init, in_class_body: in_class_body,
+          walk_ivar_init_targets(c, in_init: in_init, in_class_body: in_class_body, singleton: singleton,
                                     namespace: namespace, target_class: target_class, result: result)
         end
       else
         # Descend through everything else (if/case/blocks/etc.) while
         # keeping the current scope flags.
         node.children.each do |c|
-          walk_ivar_init_targets(c, in_init: in_init, in_class_body: in_class_body,
+          walk_ivar_init_targets(c, in_init: in_init, in_class_body: in_class_body, singleton: singleton,
                                     namespace: namespace, target_class: target_class, result: result)
         end
       end
@@ -287,66 +305,70 @@ class RbsInfer::Signatures::SteepBridge
     # object-ids (not the nodes) sidesteps `Parser::AST::Node`'s
     # structural `==`, which would conflate two identical writes in
     # different classes.
-    def collect_scoped_write_node_ids(node, attr_writer_to_ivar, target_class, namespace: [], in_def: false,
-                                      result: Set.new)
+    #
+    # `singleton` picks which of the two slots to answer for, and the walk
+    # tracks which one each write lands in with `on_singleton` — literally "is
+    # `self` the class here". It is true in a class body, in `def self.x`, and
+    # in a `class << self` body; false in an instance method. A write counts
+    # only when that answer matches what the caller asked for.
+    #
+    # This replaced a flat `in_def` flag that refused to descend into `:sclass`
+    # and `:defs` at all. Refusing kept singleton writes out of the instance map
+    # correctly, but it also meant nothing ever type-checked them: the class
+    # scope was answered by a Prism fallback that can read a literal and little
+    # else, so `@block = block` in a `def self.store` produced no declaration at
+    # all and the proc type it holds lost its `[self:]` binding
+    # (felixefelip/rbs_infer#252).
+    def collect_scoped_write_node_ids(node, attr_writer_to_ivar, target_class, singleton, namespace: [],
+                                      in_sclass: false, on_singleton: true, result: Set.new)
       return result unless node.is_a?(::Parser::AST::Node)
+
+      collect = lambda do |child, **overrides|
+        collect_scoped_write_node_ids(child, attr_writer_to_ivar, target_class, singleton,
+                                      **{ namespace: namespace, in_sclass: in_sclass, on_singleton: on_singleton,
+                                          result: result }.merge(overrides))
+      end
+      # A write belongs to the caller's question when the `self` it runs against
+      # is the one they asked about, and it is lexically in the target class.
+      in_scope = on_singleton == singleton &&
+                 RbsInfer::Signatures::SteepBridge::LexicalScope.class_scope_match?(namespace, target_class)
 
       case node.type
       when :class, :module
         body = node.type == :class ? node.children[2] : node.children[1]
-        collect_scoped_write_node_ids(body, attr_writer_to_ivar, target_class,
-                                      namespace: RbsInfer::Signatures::SteepBridge::LexicalScope.push_namespace(namespace, node),
-                                      in_def: false, result: result) if body
-      when :sclass, :defs
-        # Singleton scope (`class << self` / `def self.x`): `self` is the class,
-        # so every `@x = ...` inside is a class-instance variable (`self.@x`),
-        # never an instance ivar. Don't descend — these writes must not land in
-        # the instance-ivar map (felixefelip/rbs_infer#86). The Prism path in
-        # ReturnTypeResolver collects them separately.
+        collect.call(body, namespace: RbsInfer::Signatures::SteepBridge::LexicalScope.push_namespace(namespace, node),
+                           in_sclass: false, on_singleton: true) if body
+      when :sclass
+        # `class << self` — `self` is the singleton class, and the instance
+        # methods defined inside it run with the class as `self`.
+        collect.call(node.children[1], in_sclass: true, on_singleton: true) if node.children[1]
+      when :defs
+        # `def self.x` — `self` is the class, so `@x = ...` here is `self.@x`.
+        # `(defs (self) :name (args) body)` carries the receiver, so the body is
+        # one child further along than a `:def`'s.
+        collect.call(node.children[3], in_sclass: false, on_singleton: true) if node.children[3]
       when :def
-        body = node.children[2]
-        collect_scoped_write_node_ids(body, attr_writer_to_ivar, target_class,
-                                      namespace: namespace, in_def: true, result: result) if body
+        # An instance method's `self` is an instance — unless the `def` is
+        # inside `class << self`, where the instance IS the class.
+        collect.call(node.children[2], in_sclass: false, on_singleton: in_sclass) if node.children[2]
       when :ivasgn
-        # Only writes inside an instance method are instance ivars. A bare
-        # `@x = v` in the class body (`in_def` false) is a class-instance
-        # variable — `self` is the class there too (felixefelip/rbs_infer#86).
-        result << node.object_id if in_def && RbsInfer::Signatures::SteepBridge::LexicalScope.class_scope_match?(
-          namespace, target_class
-        )
-        node.children.each do |c|
-          collect_scoped_write_node_ids(c, attr_writer_to_ivar, target_class, namespace: namespace, in_def: in_def,
-                                                                              result: result)
-        end
+        result << node.object_id if in_scope
+        node.children.each { |c| collect.call(c) }
       when :or_asgn, :and_asgn
         # `@x ||= v` / `@x &&= v`: the write `each_typing` will key on is this
         # whole node, not its argument-less inner `:ivasgn`, so collect this
         # id (felixefelip/rbs_infer#85).
-        if in_def && node.children[0].type == :ivasgn && RbsInfer::Signatures::SteepBridge::LexicalScope.class_scope_match?(
-          namespace, target_class
-        )
-          result << node.object_id
-        end
-        node.children.each do |c|
-          collect_scoped_write_node_ids(c, attr_writer_to_ivar, target_class, namespace: namespace, in_def: in_def,
-                                                                              result: result)
-        end
+        result << node.object_id if in_scope && node.children[0].type == :ivasgn
+        node.children.each { |c| collect.call(c) }
       when :send
         receiver, method_name = node.children[0], node.children[1]
-        if in_def && attr_writer_to_ivar.key?(method_name) &&
-           (receiver.nil? || (receiver.respond_to?(:type) && receiver.type == :self)) &&
-           RbsInfer::Signatures::SteepBridge::LexicalScope.class_scope_match?(namespace, target_class)
+        if in_scope && attr_writer_to_ivar.key?(method_name) &&
+           (receiver.nil? || (receiver.respond_to?(:type) && receiver.type == :self))
           result << node.object_id
         end
-        node.children.each do |c|
-          collect_scoped_write_node_ids(c, attr_writer_to_ivar, target_class, namespace: namespace, in_def: in_def,
-                                                                              result: result)
-        end
+        node.children.each { |c| collect.call(c) }
       else
-        node.children.each do |c|
-          collect_scoped_write_node_ids(c, attr_writer_to_ivar, target_class, namespace: namespace, in_def: in_def,
-                                                                              result: result)
-        end
+        node.children.each { |c| collect.call(c) }
       end
 
       result

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -1004,6 +1004,11 @@ postconditions:
   effects:
     may_write:
     - "@_bazingado_block"
+- class: Example35::Foo
+  method: bazingado
+  effects:
+    may_write:
+    - "@_bazingado_block"
 - class: Example3::Foo
   method: user=
   unconditional:

--- a/spec/dummy/sig/rbs_infer/app/models/example13.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example13.rbs
@@ -4,7 +4,7 @@ end
 
 class Example13
   class Registry
-    self.@registry_instance: Registry?
+    self.@registry_instance: Example13::Registry?
 
     module GeneratedAttributes
       attr_accessor user: (Example13Viewer | nil)?

--- a/spec/dummy/sig/rbs_infer/app/models/example15.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example15.rbs
@@ -20,7 +20,7 @@ end
 
 class Example15
   class Registry
-    self.@user: User?
+    self.@user: Example15::User?
 
     def self.user: () -> Example15::User?
     def self.user=: (User value) -> User

--- a/spec/dummy/sig/rbs_infer/app/models/example16.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example16.rbs
@@ -25,7 +25,7 @@ end
 
 class Example16
   class Registry
-    self.@user: User?
+    self.@user: Example16::User?
 
     def self.user: () -> Example16::User?
     def self.user=: (User value) -> User

--- a/spec/dummy/sig/rbs_infer/app/models/example3.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example3.rbs
@@ -16,7 +16,7 @@ end
 
 class Example3
   class Foo
-    self.@foo_instance: Foo?
+    self.@foo_instance: Example3::Foo?
 
     module GeneratedAttributes
       attr_accessor user: (Example3::User | nil)?

--- a/spec/dummy/sig/rbs_infer/app/models/example35.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example35.rbs
@@ -1,7 +1,9 @@
 class Example35
   class Foo
-    def self.bazinga: (singleton(::Example35::Baz) module_included) -> (^(*untyped) -> Symbol)?
-    def self.bazingado: (?singleton(Example35::Foo)? base) ?{ (*untyped) [self: singleton(Example35::Foo)] -> Symbol } -> (^(*untyped) -> Symbol)?
+    self.@_bazingado_block: (^(*untyped) [self: singleton(Example35::Foo)] -> Symbol)?
+
+    def self.bazinga: (singleton(::Example35::Baz) module_included) -> (^(*untyped) [self: singleton(Example35::Foo)] -> Symbol | nil | Symbol)
+    def self.bazingado: (?singleton(Example35::Foo)? base) ?{ (*untyped) [self: singleton(Example35::Foo)] -> Symbol } -> (^(*untyped) [self: singleton(Example35::Foo)] -> Symbol | nil | Symbol)
   end
 end
 

--- a/spec/expectations/models/example13.rbs
+++ b/spec/expectations/models/example13.rbs
@@ -4,7 +4,7 @@ end
 
 class Example13
   class Registry
-    self.@registry_instance: Registry?
+    self.@registry_instance: Example13::Registry?
 
     module GeneratedAttributes
       attr_accessor user: (Example13Viewer | nil)?

--- a/spec/expectations/models/example3.rbs
+++ b/spec/expectations/models/example3.rbs
@@ -16,7 +16,7 @@ end
 
 class Example3
   class Foo
-    self.@foo_instance: Foo?
+    self.@foo_instance: Example3::Foo?
 
     module GeneratedAttributes
       attr_accessor user: (Example3::User | nil)?

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -13,7 +13,6 @@ app/models/example30.rb:16:6: [error] Type `::Example30::Foo` does not have meth
 app/models/example30.rb:9:12: [warning] Method `::Example30::Foo#age` is not declared in RBS
 app/models/example31.rb:26:8: [error] Cannot allow method body have type `::Integer` because declared as type `::Float`
 app/models/example34.rb:21:10: [warning] Method `::Example34::Baz#age` is not declared in RBS
-app/models/example35.rb:7:13: [error] Cannot allow method body have type `(^(*untyped) [self: singleton(::Example35::Foo)] -> ::Symbol | nil)` because declared as type `(^(*untyped) -> ::Symbol | nil)`
 app/models/example4.rb:14:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:22:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:27:23: [error] Type `(::String | nil)` does not have method `upcase`

--- a/spec/lib/rbs_infer/signatures/rbs_parser_util_spec.rb
+++ b/spec/lib/rbs_infer/signatures/rbs_parser_util_spec.rb
@@ -597,6 +597,36 @@ RSpec.describe RbsInfer::Signatures::RbsParserUtil do
     end
   end
 
+  # The passes that CORRECT a declaration contradicting its body all start by
+  # reading the declared return. A leftmost-matching `/->\s*(.+)$/` reads a
+  # block clause's arrow instead, so every one of them silently skipped any
+  # method taking a block (felixefelip/rbs_infer#252).
+  describe ".return_type_of" do
+    it "reads past a block clause's own arrow" do
+      sig = "bazingado: (?singleton(Bar)? base) ?{ (*untyped) [self: singleton(Bar)] -> Symbol } -> " \
+            "(^(*untyped) -> Symbol)?"
+
+      expect(described_class.return_type_of(sig)).to eq("(^(*untyped) -> Symbol)?")
+    end
+
+    it "reads past a proc-typed parameter's arrow" do
+      expect(described_class.return_type_of("m: (^(String) -> void callback) -> Integer")).to eq("Integer")
+    end
+
+    it "reads past the arrow inside the returned proc" do
+      expect(described_class.return_type_of("m: () -> (^(*untyped) [self: singleton(Bar)] -> Symbol)?"))
+        .to eq("(^(*untyped) [self: singleton(Bar)] -> Symbol)?")
+    end
+
+    it "reads a plain return" do
+      expect(described_class.return_type_of("m: (String name) -> Integer")).to eq("Integer")
+    end
+
+    it "answers nil when there is no return arrow" do
+      expect(described_class.return_type_of("attr_reader name: String")).to be_nil
+    end
+  end
+
   describe ".require_block" do
     it "adopts the callee's block: required, and shaped like theirs" do
       expect(described_class.require_block("m: () ?{ (*untyped) -> untyped } -> untyped", ["String", "Integer"]))

--- a/spec/lib/rbs_infer/signatures/steep_bridge/ivar_write_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/signatures/steep_bridge/ivar_write_analyzer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
         end
       RUBY
 
-      result = bridge.ivar_write_types(code, target_class: "Foo")
+      result = bridge.ivar_write_types(code, target_class: "Foo", singleton: false)
       expect(result["x"]).to eq("String")
     end
 
@@ -32,7 +32,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
         end
       RUBY
 
-      result = bridge.ivar_write_types(code, target_class: "Foo")
+      result = bridge.ivar_write_types(code, target_class: "Foo", singleton: false)
       expect(result["x"]).to eq("String?")
     end
 
@@ -49,7 +49,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
         end
       RUBY
 
-      result = bridge.ivar_write_types(code, target_class: "Foo")
+      result = bridge.ivar_write_types(code, target_class: "Foo", singleton: false)
       expect(result["x"]).to eq("String?")
     end
 
@@ -62,7 +62,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
         end
       RUBY
 
-      result = bridge.ivar_write_types(code, target_class: "Foo")
+      result = bridge.ivar_write_types(code, target_class: "Foo", singleton: false)
       expect(result["x"]).to eq("String?")
     end
 
@@ -78,7 +78,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
         end
       RUBY
 
-      result = bridge.ivar_write_types(code, target_class: "Foo")
+      result = bridge.ivar_write_types(code, target_class: "Foo", singleton: false)
       expect(result).not_to have_key("count")
     end
 
@@ -95,7 +95,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
         end
       RUBY
 
-      result = bridge.ivar_write_types(code, target_class: "Foo")
+      result = bridge.ivar_write_types(code, target_class: "Foo", singleton: false)
       expect(result["x"]).to eq("((Comment & Comment::Validated) | Comment)?")
     end
 
@@ -112,7 +112,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
         end
       RUBY
 
-      result = bridge.ivar_write_types(code, target_class: "Foo")
+      result = bridge.ivar_write_types(code, target_class: "Foo", singleton: false)
       expect(result["x"]).to eq("Comment | (Comment & Comment::Validated)")
     end
 
@@ -129,7 +129,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
         end
       RUBY
 
-      result = bridge.ivar_write_types(code, target_class: "Foo")
+      result = bridge.ivar_write_types(code, target_class: "Foo", singleton: false)
       expect(result["x"]).to eq("(Comment & Comment::Validated)?")
     end
 
@@ -144,7 +144,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
         end
       RUBY
 
-      result = bridge.ivar_write_types(code, target_class: "Foo")
+      result = bridge.ivar_write_types(code, target_class: "Foo", singleton: false)
       expect(result["x"]).to eq("String?")
     end
 
@@ -163,7 +163,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
         end
       RUBY
 
-      result = bridge.ivar_write_types(code, target_class: "Foo")
+      result = bridge.ivar_write_types(code, target_class: "Foo", singleton: false)
       expect(result["x"]).to eq("Comment | (Comment & Comment::Validated)")
     end
 
@@ -178,7 +178,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
         end
       RUBY
 
-      result = bridge.ivar_write_types(code, target_class: "Foo")
+      result = bridge.ivar_write_types(code, target_class: "Foo", singleton: false)
       expect(result["x"]).to eq("String")
     end
 
@@ -195,7 +195,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
         end
       RUBY
 
-      result = bridge.ivar_write_types(code, target_class: "Foo")
+      result = bridge.ivar_write_types(code, target_class: "Foo", singleton: false)
       expect(result["x"]).to eq("String?")
     end
 
@@ -210,7 +210,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
         end
       RUBY
 
-      result = bridge.ivar_write_types(code, target_class: "Foo")
+      result = bridge.ivar_write_types(code, target_class: "Foo", singleton: false)
       # class-body ivasgn is class-instance variable scope; method
       # ivasgn is instance scope. Per the issue, we treat the class-body
       # write as initialized for the same name (best-effort).
@@ -226,7 +226,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
         end
       RUBY
 
-      result = bridge.ivar_write_types(code, target_class: "Foo")
+      result = bridge.ivar_write_types(code, target_class: "Foo", singleton: false)
       # Only `nil` was observed; nilable, no concrete type. The emitter
       # returns "nil" which is a valid RBS type.
       expect(result["x"]).to eq("nil")
@@ -470,10 +470,10 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
       # assigned in Beta#configure outside init — so it is nilable *for
       # Beta*. Without scoping, Alpha's initialize would suppress the `?`
       # and Alpha's "String" would merge in.
-      alpha = bridge.ivar_write_types(code, target_class: "Alpha")
+      alpha = bridge.ivar_write_types(code, target_class: "Alpha", singleton: false)
       expect(alpha["shared"]).to eq("String")
 
-      beta = bridge.ivar_write_types(code, target_class: "Beta")
+      beta = bridge.ivar_write_types(code, target_class: "Beta", singleton: false)
       expect(beta["shared"]).to eq("Integer?")
       expect(beta).not_to have_key("only_alpha")
     end
@@ -507,7 +507,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
       end
 
       it "não atribui os writes de uma classe aninhada à classe externa" do
-        outer = bridge.ivar_write_types(nested_code, target_class: "Outer")
+        outer = bridge.ivar_write_types(nested_code, target_class: "Outer", singleton: false)
 
         expect(outer).not_to have_key("name")
       end
@@ -522,21 +522,21 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
       # então declarar no módulo já serve `Outer` quando ele de fato inclui —
       # que era o único caso que a regra antiga acertava.
       it "não atribui os writes de um módulo aninhado à classe externa" do
-        outer = bridge.ivar_write_types(nested_code, target_class: "Outer")
+        outer = bridge.ivar_write_types(nested_code, target_class: "Outer", singleton: false)
 
         expect(outer).not_to have_key("setting")
         expect(outer).to have_key("ran")
       end
 
       it "atribui os writes do módulo aninhado ao próprio módulo" do
-        generated = bridge.ivar_write_types(nested_code, target_class: "Outer::Generated")
+        generated = bridge.ivar_write_types(nested_code, target_class: "Outer::Generated", singleton: false)
 
         expect(generated).to have_key("setting")
         expect(generated).not_to have_key("ran")
       end
 
       it "atribui os writes da classe aninhada ao seu próprio alvo" do
-        user = bridge.ivar_write_types(nested_code, target_class: "Outer::User")
+        user = bridge.ivar_write_types(nested_code, target_class: "Outer::User", singleton: false)
 
         expect(user).to have_key("name")
         expect(user).not_to have_key("ran")
@@ -555,7 +555,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
           end
         RUBY
 
-        result = bridge.ivar_write_types(code, target_class: "Foo")
+        result = bridge.ivar_write_types(code, target_class: "Foo", singleton: false)
         expect(result["name"]).to eq("String")
         expect(result["size"]).to eq("Integer")
       end
@@ -573,7 +573,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
           end
         RUBY
 
-        result = bridge.ivar_write_types(code, target_class: "Foo")
+        result = bridge.ivar_write_types(code, target_class: "Foo", singleton: false)
         expect(result["name"]).to eq("String")
       end
 
@@ -586,10 +586,108 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::IvarWriteAnalyzer, :dummy_app 
           end
         RUBY
 
-        result = bridge.ivar_write_types(code, target_class: "Foo")
+        result = bridge.ivar_write_types(code, target_class: "Foo", singleton: false)
         expect(result).not_to have_key("a")
         expect(result).not_to have_key("b")
       end
+    end
+  end
+
+  # A class has two ivar scopes, and they are different slots: the instance
+  # `@x` and the class-instance `self.@x` a `def self.x` / `class << self` /
+  # the class body writes. `singleton:` says which one to answer for. Before
+  # felixefelip/rbs_infer#252 the singleton one had no answer at all — the walk
+  # refused to descend into `:defs` and `:sclass`, so nothing type-checked those
+  # writes and the fallback that covered them reads literals and little else.
+  describe "#ivar_write_types with singleton: true" do
+    it "types a write in a `def self.x`, which the instance scope does not see" do
+      code = <<~RUBY
+        class Foo
+          def self.store
+            @cached = "hello"
+          end
+        end
+      RUBY
+
+      expect(bridge.ivar_write_types(code, target_class: "Foo", singleton: true)["cached"]).to eq("String?")
+      expect(bridge.ivar_write_types(code, target_class: "Foo", singleton: false)).not_to have_key("cached")
+    end
+
+    it "types a write in a `class << self` method the same way" do
+      code = <<~RUBY
+        class Foo
+          class << self
+            def store
+              @cached = 3
+            end
+          end
+        end
+      RUBY
+
+      expect(bridge.ivar_write_types(code, target_class: "Foo", singleton: true)["cached"]).to eq("Integer?")
+      expect(bridge.ivar_write_types(code, target_class: "Foo", singleton: false)).not_to have_key("cached")
+    end
+
+    it "leaves an instance method's write to the instance scope" do
+      code = <<~RUBY
+        class Foo
+          def store
+            @cached = "hello"
+          end
+        end
+      RUBY
+
+      expect(bridge.ivar_write_types(code, target_class: "Foo", singleton: true)).not_to have_key("cached")
+      expect(bridge.ivar_write_types(code, target_class: "Foo", singleton: false)["cached"]).to eq("String?")
+    end
+
+    # A class-instance variable has no constructor, so the only definite
+    # initialization it can have is the class body — and `initialize` writing
+    # the same NAME is a different slot that must not suppress the `| nil`.
+    it "takes a class-body write as definite initialization" do
+      code = <<~RUBY
+        class Foo
+          @cached = "hello"
+        end
+      RUBY
+
+      expect(bridge.ivar_write_types(code, target_class: "Foo", singleton: true)["cached"]).to eq("String")
+    end
+
+    it "does not let `initialize` suppress the singleton slot's nilability" do
+      code = <<~RUBY
+        class Foo
+          def initialize
+            @cached = "hello"
+          end
+
+          def self.store
+            @cached = "world"
+          end
+        end
+      RUBY
+
+      expect(bridge.ivar_write_types(code, target_class: "Foo", singleton: true)["cached"]).to eq("String?")
+      expect(bridge.ivar_write_types(code, target_class: "Foo", singleton: false)["cached"]).to eq("String")
+    end
+
+    it "keeps a sibling class's singleton write out" do
+      code = <<~RUBY
+        class Foo
+          def self.store
+            @cached = "hello"
+          end
+        end
+
+        class Bar
+          def self.store
+            @cached = 3
+          end
+        end
+      RUBY
+
+      expect(bridge.ivar_write_types(code, target_class: "Foo", singleton: true)["cached"]).to eq("String?")
+      expect(bridge.ivar_write_types(code, target_class: "Bar", singleton: true)["cached"]).to eq("Integer?")
     end
   end
 


### PR DESCRIPTION
## The bug

`example35`'s `bazingado` was declared returning a proc **without** the `[self:]` binding its body actually returns:

```
app/models/example35.rb:7:13: [error] Cannot allow method body have type
  `(^(*untyped) [self: singleton(::Example35::Foo)] -> ::Symbol | nil)`
because declared as type `(^(*untyped) -> ::Symbol | nil)`
```

Two independent causes. Both were measured, not inferred.

> Note: the request named example34, but example34 keeps its binding in both positions (`[self: Module]` on the parameter and in the return). The loss is example35's — the class/`def self.` spelling of the same fixture.

## Cause 1 — the `self.@x` slot was never type-checked

Probing the two spellings side by side is what pinned it:

| | `ivar_write_types(…, "Foo")` |
|---|---|
| example34 (`module Foo`, instance `def`) | `{"_bazingado_block" => "(^(*untyped) [self: Module] -> Symbol)?"}` |
| example35 (`class Foo`, `def self.`) | `{}` |

`collect_scoped_write_node_ids` refused to descend into `:sclass` and `:defs`. That kept singleton writes out of the instance map correctly, but it also meant **nothing ever type-checked them**: the class scope was left to a Prism fallback that reads literals and little else. So `@_bazingado_block = block` produced no declaration at all, and the proc the slot holds lost its binding.

The walk now descends and tracks `on_singleton` — literally *"is `self` the class here"*: true in a class body, in `def self.x`, and in a `class << self` body; false in an instance method. A write counts when that matches what the caller asked for.

`singleton:` is **required**, not defaulted, per `docs/engineering/required-threaded-deps.md`: asking the wrong scope returns `{}` rather than failing, which is exactly how this went unnoticed.

The definite-initialization rule follows the same split — a class-instance variable has no constructor, so only a class-body write initializes it and `initialize` is not walked. An instance `@x = ...` must not suppress the singleton slot's `| nil`.

## Cause 2 — a return type read from the block's arrow

Cause 1 alone did not fix it. The declaration was still emitted without the binding, because `improve_method_return_types` took its answer from the method's **own previous RBS** rather than from Steep:

```
[class_return_types] bazingado="(^(*untyped) -> Symbol)?"        ← read back from our own last output
[steep returns]      bazingado="(^(*untyped) [self: …] -> Symbol | nil | Symbol)"   ← correct
```

There is already a pass for precisely this — the `#191` "a return type is a ratchet" corrector. It never fired, and the reason is a one-character-class bug: it starts by reading the declared return with `m.signature[/->\s*(.+)$/, 1]`, a **leftmost** match. For a method with a block clause the first `->` is the *block's*:

```
(?singleton(Foo)? base) ?{ (*untyped) [self: singleton(Foo)] -> Symbol } -> (^(*untyped) -> Symbol)?
                                                                ^^ matched this one
```

so `current_type` came back as `"Symbol } -> (^(*untyped) -> Symbol)?"` — a string no comparison or substitution can do anything with. Every guard reading it failed open, so **all four correction passes silently skipped any method taking a block**. `accepts?` was in fact answering `false` for the real pair; it was simply never handed it.

`RbsParserUtil` already had the depth-aware `last_top_level_arrow_index` backing `parenthesize_return_type`. It now also backs a new `return_type_of`, and all five sites use it.

## Effect

`Example35::Foo` before → after:

```rbs
 class Foo
+  self.@_bazingado_block: (^(*untyped) [self: singleton(Example35::Foo)] -> Symbol)?
+
-  def self.bazinga: (…) -> (^(*untyped) -> Symbol)?
-  def self.bazingado: (…) ?{ … } -> (^(*untyped) -> Symbol)?
+  def self.bazinga: (…) -> (^(*untyped) [self: singleton(Example35::Foo)] -> Symbol | nil | Symbol)
+  def self.bazingado: (…) ?{ … } -> (^(*untyped) [self: singleton(Example35::Foo)] -> Symbol | nil | Symbol)
 end
```

which is the shape example34 already had. The baseline **loses that error and gains none**. Fixed point reached after two regeneration passes.

Collateral, all improvements: four singleton ivars elsewhere move from the Prism fallback's bare names to Steep's qualified ones (`Registry?` → `Example13::Registry?`, `User?` → `Example15::User?`), and `Example35::Foo#bazingado` gains a `may_write` postcondition now that the slot is declared.

## Tests

- Six specs for `ivar_write_types(singleton: true)`: `def self.x`, `class << self`, the instance write staying in the instance scope, a class-body write as definite init, `initialize` not suppressing the singleton slot's nilability, and sibling-class isolation.
- Five for `RbsParserUtil.return_type_of`: past a block clause's arrow, past a proc-typed parameter's arrow, past the arrow inside a returned proc, a plain return, and no arrow at all.
- The 23 existing `ivar_write_types` specs now state `singleton: false` explicitly, which reads better than the default did.

Full suite: **1286 examples, 0 failures.**

## Still open

`example34.rb:21` — `Method ::Example34::Baz#age is not declared in RBS`. Different cause (its apply method is `include`, a real Ruby method, while its storage method is `included`), untouched here and still in the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)