### PR TITLE
Replay a hook's block where it is written, with no storage to look it up

### DIFF
--- a/lib/rbs_infer/project/stored_block_replay_expander.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander.rb
@@ -51,7 +51,13 @@ module RbsInfer::Project
     # the `target` it is replayed onto. Together they point Steep at this one
     # block in the real source, which a name alone cannot do once a file writes
     # the same DSL call twice — see `StoredBlockReplayImplements`.
-    Replay = Data.define(:target, :block, :kind, :call, :scope)
+    # `in_method` is the def the call sits inside, and is nil for a DSL block —
+    # `bazingado do` is written in the module body, so the scope already picks
+    # it out. A hook writes its block inside `def self.included` instead, where
+    # the call is `class_eval` on a parameter: that name says nothing about
+    # which block is meant, so the def is what tells two of them apart
+    # (felixefelip/rbs_infer#260).
+    Replay = Data.define(:target, :block, :kind, :call, :scope, :in_method)
 
     module_function
 

--- a/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
@@ -68,6 +68,18 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # either way, and `attr_reader` was only ever one spelling of reaching it.
     InwardReplay = Data.define(:owner, :method, :parameter, :ivar)
 
+    # The same replay again, with the block written where it is run instead of
+    # kept for later: `def self.included(base) = base.class_eval do … end`, which
+    # is what Ruby's own `included` hook looks like when nobody has wrapped it in
+    # a DSL (felixefelip/rbs_infer#260).
+    #
+    # No storage, so nothing to look up — the block is right there in the
+    # replaying method, and only the target is unknown. `call` and `scope` name
+    # the call the block belongs to (`class_eval`, in the module holding the
+    # hook) rather than the storage call and the module that wrote it, since
+    # there is no storage call here; both feed the `blocks:` sidecar the same way.
+    LiteralReplay = Data.define(:owner, :method, :scope, :call, :block)
+
     # `def bazinga(mod) = mod.bazingado(self)` — the hop from the method a target
     # NAMES to the method that replays. The inward direction needs it: the replay
     # runs on the source with the target passed in, so the target's own body
@@ -103,6 +115,10 @@ module RbsInfer::Project::StoredBlockReplayExpander
       @readers = []
       @replay_methods = []
       @inward_replays = []
+      # Never absorbed from another file, unlike the shapes above. This one
+      # carries a block, and the rewrite slices THIS source at the block's
+      # offsets — a block from elsewhere would cut the wrong file.
+      @literal_replays = []
       @forwards = []
       # Raw like `@extends`/`@superclasses`, for the same reason: the constant
       # is resolved once every declaration in the file is known.
@@ -205,34 +221,68 @@ module RbsInfer::Project::StoredBlockReplayExpander
     end
 
     def collect_method_shape(node)
+      owner = shape_owner(node)
+      return unless owner
+
       params = node.parameters
       block_name = params&.block&.name&.to_s
       method_name = node.name.to_s
 
       if block_name && (ivar = stored_block_ivar(node.body, block_name))
-        @storages << Storage.new(owner: current_scope, method: method_name, ivar: ivar)
+        @storages << Storage.new(owner: owner, method: method_name, ivar: ivar)
       end
 
       if (replay = replay_shape(node.body))
         parameter, reader = replay
-        @replay_methods << ReplayMethod.new(owner: current_scope, method: method_name, parameter: parameter, reader: reader)
+        @replay_methods << ReplayMethod.new(owner: owner, method: method_name, parameter: parameter, reader: reader)
       end
 
       parameters = handed_names(node.body, parameter_names(params))
 
       if (inward = inward_replay_shape(node.body, parameters))
         parameter, ivar = inward
-        @inward_replays << InwardReplay.new(owner: current_scope, method: method_name, parameter: parameter, ivar: ivar)
+        @inward_replays << InwardReplay.new(owner: owner, method: method_name, parameter: parameter, ivar: ivar)
+      end
+
+      if (literal = literal_replay_shape(node.body, parameters))
+        call, block = literal
+        @literal_replays << LiteralReplay.new(owner: owner, method: method_name, scope: current_scope,
+                                              call: call, block: block)
       end
 
       if (delegation = delegation_shape(node))
         target, callee = delegation
-        @delegations << [current_scope, method_name, target, callee]
+        @delegations << [owner, method_name, target, callee]
       end
 
       forward_shapes(node.body, parameters).each do |parameter, callee|
-        @forwards << ForwardMethod.new(owner: current_scope, method: method_name, parameter: parameter, callee: callee)
+        @forwards << ForwardMethod.new(owner: owner, method: method_name, parameter: parameter, callee: callee)
       end
+    end
+
+    # Which method table a `def` puts the method in, in the terms
+    # `dsl_providers` keys on. `def keep` goes in the module's own, reached by
+    # whoever `extend`s it; `def self.keep` goes in the SINGLETON's, reached by
+    # the subject in its own body and by its subclasses. Both used to be
+    # recorded under the lexical scope, which happened to work only because no
+    # shape yet needed telling the two apart — `IncludedHook::Hookable` does,
+    # since its `def self.included` is reached by nothing but Hookable itself
+    # (felixefelip/rbs_infer#260).
+    #
+    # `def SomeOther.foo` and `def obj.foo` answer nothing: which object that
+    # names is not a question this pass asks, so the method is not collected at
+    # all rather than filed under the wrong owner.
+    def shape_owner(node)
+      return current_scope unless node.receiver
+      return singleton_owner(current_scope) if node.receiver.is_a?(Prism::SelfNode)
+
+      nil
+    end
+
+    # No file can declare a constant by this name, so a singleton owner cannot
+    # collide with a real one.
+    def singleton_owner(name)
+      "singleton(#{name})"
     end
 
     # The names a `def` or a block binds its arguments to. One reader for both:
@@ -372,6 +422,25 @@ module RbsInfer::Project::StoredBlockReplayExpander
 
         [receiver.name.to_s, ivar.name.to_s]
       end.uniq
+      shapes.first if shapes.size == 1
+    end
+
+    # `<parameter>.class_eval do … end` — the inward replay with the block
+    # written in place rather than fetched from a slot. Same receiver rule as
+    # `inward_replay_shape` and for the same reason; what differs is only where
+    # the block comes from, so what it answers is the block itself.
+    def literal_replay_shape(body, parameters)
+      shapes = nodes(body).filter_map do |node|
+        next unless node.is_a?(Prism::CallNode)
+        call = dispatched(node)
+        next unless REPLAY_METHODS.include?(call.name)
+        receiver = call.receiver
+        next unless receiver.is_a?(Prism::LocalVariableReadNode) && parameters.include?(receiver.name.to_s)
+        block = call.block
+        next unless block.is_a?(Prism::BlockNode)
+
+        [call.name.to_s, block]
+      end
       shapes.first if shapes.size == 1
     end
 
@@ -576,7 +645,20 @@ module RbsInfer::Project::StoredBlockReplayExpander
           # both from being resolved by declaration order.
           slots = [outward_slot(applier, apply.method),
                    inward_slot(applier, apply.method, source_provider)].compact.uniq
-          next unless slots.size == 1
+          # And the third way to reach a block: not through a slot at all,
+          # because the replaying method wrote it in place. Counted together
+          # with the slots, so a file reading as both still declines.
+          literals = literal_replays_for(applier, apply.method, source_provider)
+          next unless slots.size + literals.size == 1
+
+          kind = @declaration_kinds[apply.subject]
+          next unless kind
+
+          if (literal = literals.first)
+            candidates << Replay.new(target: apply.subject, block: literal.block, kind: kind,
+                                     call: literal.call, scope: literal.scope, in_method: literal.method)
+            next
+          end
 
           storage_owner, ivar = slots.first
           # The SOURCE's provider, not the applier's: the name being looked up
@@ -587,11 +669,8 @@ module RbsInfer::Project::StoredBlockReplayExpander
           blocks = @stored_calls.select { |stored| stored.subject == source_subject && stored.method == storage_method }
           next unless blocks.size == 1
 
-          kind = @declaration_kinds[apply.subject]
-          next unless kind
-
           candidates << Replay.new(target: apply.subject, block: blocks.first.block, kind: kind,
-                                   call: storage_method, scope: blocks.first.subject)
+                                   call: storage_method, scope: blocks.first.subject, in_method: nil)
         end
       end
 
@@ -625,8 +704,14 @@ module RbsInfer::Project::StoredBlockReplayExpander
       end
       parents.compact!
 
+      # Through the SINGLETON, both of them. `keep` in a class body is a call on
+      # the class object, so it is found in `singleton(Base)` — where
+      # `def self.keep` put it — and never in `Base`'s own method table, where
+      # `extend`'s half lives. Keyed alike, an `attr_reader :body` in a class
+      # body would answer for a `def self.apply` that could not call it.
       @declarations.each do |subject|
-        superclasses(subject, parents).each { |ancestor| providers[ancestor] << subject }
+        providers[singleton_owner(subject)] << subject
+        superclasses(subject, parents).each { |ancestor| providers[singleton_owner(ancestor)] << subject }
       end
 
       # What the subject's own `self` makes callable: a class body reaches
@@ -698,6 +783,21 @@ module RbsInfer::Project::StoredBlockReplayExpander
       end.uniq
 
       slots.first if slots.size == 1
+    end
+
+    # The replays reached from `owner#method` that carry their own block. Same
+    # walk as `inward_slot` — every forward, resolved through the ARGUMENT's
+    # provider — differing only in what the keeper turns out to hold.
+    def literal_replays_for(owner, method, source_provider)
+      @forwards.filter_map do |forward|
+        next unless forward.owner == owner && forward.method == method
+
+        keeper_owner, keeper_method = keeper(source_provider, forward.callee)
+        next unless keeper_owner
+
+        replays = @literal_replays.select { |replay| replay.owner == keeper_owner && replay.method == keeper_method }
+        replays.first if replays.size == 1
+      end.uniq
     end
 
     # Where `owner#method` actually keeps things. Usually `owner` itself; one

--- a/lib/rbs_infer/project/stored_block_replay_implements.rb
+++ b/lib/rbs_infer/project/stored_block_replay_implements.rb
@@ -62,7 +62,12 @@ module RbsInfer::Project
       replays.filter_map do |replay|
         next unless replay.scope
 
-        { "call" => replay.call, "in" => "::#{replay.scope}", "implements" => "::#{replay.target}" }
+        entry = { "call" => replay.call, "in" => "::#{replay.scope}", "implements" => "::#{replay.target}" }
+        # Only for a block written inside a def. Emitting it as nil for the DSL
+        # shape would put a key in every sidecar entry ever written, to say
+        # nothing.
+        entry["method"] = replay.in_method if replay.in_method
+        entry
       end
     end
   end

--- a/spec/dummy/app/models/included_hook.rb
+++ b/spec/dummy/app/models/included_hook.rb
@@ -7,20 +7,22 @@
 #
 # `ClassEvalExpander` (#197) declines it, correctly for what it knows: the receiver is
 # a method PARAMETER, not a constant, so the call shape alone names no class. What
-# makes it decidable is the hook's NAME — the hosts then come from the mixin graph
-# (`MixinIndex#hosts_of`), not from the call.
+# names it is the `include Hookable` further down, read through the pseudo-code for
+# `Module#include`: that forwards to `included`, so `base` is the includer. The hook's
+# NAME is not what makes it decidable and nothing keys on it (#260) — `Arbitrary`
+# below is the proof, being the same shape under a name Ruby never calls.
 #
 # This is the plain-Ruby core of the `included do` problem: ActiveSupport::Concern is
 # sugar over exactly this shape, so a fix here is a fix there, with no framework
 # knowledge involved.
 #
-# Since #239 the defs below are emitted NOWHERE. `ClassMemberCollector` no longer
-# attributes a block's body to the module that lexically contains it — a block's `self`
-# can be rebound, so the lexical owner was never the right answer — and nothing puts it
-# on the host yet. What these snapshots pin today is therefore ABSENCE, and the Steep
-# baseline records the `does not have method` errors that follow. That is the state #216
-# has to end: not by putting the defs back on the module, which was the wrong owner all
-# along, but by landing them on the host.
+# Between #239 and #260 the defs below were emitted NOWHERE: `ClassMemberCollector`
+# stopped attributing a block's body to the module that lexically contains it — a
+# block's `self` can be rebound, so the lexical owner was never the right answer — and
+# nothing yet put it on the host. #259 and #260 finish that for two of the three shapes
+# here, the way #216 asked for: not by putting the defs back on the module, but by
+# landing them on the host. `Sugared` is the one still open, and no longer for a reason
+# about inference — see its comment.
 #
 # A plain class on purpose — nothing here is Active Record, so the fixture needs no
 # table.
@@ -34,8 +36,7 @@ class IncludedHook
 
         # The load-bearing half, and the store-accessor shape: `super` can only resolve
         # if this def belongs to the HOST, whose ancestors have `IncludedHook::Slots`.
-        # Today it belongs to nobody — the override is emitted nowhere — so `super`
-        # is never typed and a read of `slot` reaches `Slots`' plain accessor instead.
+        # It does since #260, which is what `read_slot` below measures.
         def slot
           super || "default"
         end
@@ -60,7 +61,10 @@ class IncludedHook
       end
 
       # The Concern-side criterion, over the other slot so it cannot collide with
-      # `Hookable`'s. `super` only resolves if this def belongs to the HOST.
+      # `Hookable`'s. `super` only resolves if this def belongs to the HOST, and this
+      # is the one of the three that still does not — measured (#260): the chain
+      # resolves the moment `active_support/concern.rb` is in the corpus, and the
+      # corpus is `app/ lib/ sig/`. A question about reach, not about inference.
       def badge
         super || "sugared"
       end
@@ -90,9 +94,9 @@ class IncludedHook
   # belongs to nobody. Here as the limit case, so a fix for the hook above cannot
   # quietly generalise to any `*_included` name.
   #
-  # Since #239 that is also what the snapshot shows for the real hooks above, so absence
-  # alone no longer tells the two apart. The criterion is what #216 changes: the hooks'
-  # defs land on their hosts, and this one still lands nowhere.
+  # Absence is a criterion again since #260: the real hooks above land on their host
+  # and this one still lands nowhere, which is the difference a name-based fix would
+  # have erased. Nothing calls `foo_included`, so nothing says who `base` would be.
   module Arbitrary
     def self.foo_included(base)
       base.class_eval do
@@ -112,9 +116,8 @@ end
 
 # The call sites: the slot's writer is what gives `super` a type to return, and the
 # reads are what a regression would surface as `NoMethod` rather than as a silently
-# missing method. Today `fill`'s `from_hook` and `read_shared`'s `from_shared` ARE that
-# `NoMethod` — both sit in the Steep baseline, because since #239 neither method is
-# declared anywhere.
+# missing method. `read_shared`'s `from_shared` is still that `NoMethod` and sits in the
+# Steep baseline; `fill`'s `from_hook` stopped being one in #260.
 class IncludedHookCaller
   # Writes both slots, which is what gives each `super` a type to return. Kept apart
   # from the reads below so those measure the ancestor chain rather than a local
@@ -128,10 +131,9 @@ class IncludedHookCaller
   end
 
   # The success criterion, visible in a snapshot rather than in a diagnostic: `slot`
-  # returns `super || "default"` over a `String?` slot, so this is `String` once the
-  # hook's defs belong to the host. It reads `String?` today because the override is
-  # emitted nowhere: the read resolves to `Slots#slot`, and the `|| "default"` that
-  # removes the nil is never seen.
+  # returns `super || "default"` over a `String?` slot, so this is `String` exactly
+  # when the hook's def belongs to the host. `String` since #260; before it the read
+  # resolved to `Slots#slot` and the `|| "default"` that removes the nil was never seen.
   def read_slot
     IncludedHook.new.slot
   end
@@ -139,13 +141,13 @@ class IncludedHookCaller
   # The same criterion for the sugared half, over a slot with a UNIQUE name: `tag` was
   # borrowed from the dummy's Tag model closely enough to pick up a type from
   # elsewhere, which made the two halves look asymmetric when they are not.
-  # Both read `String?` today, for the same reason `read_slot` does, and both have to
-  # become `String` — one fix, or the two shapes have been treated as two problems.
+  # The last one still reading `String?`, and the only criterion here left open.
   def read_badge
     IncludedHook.new.badge
   end
 
-  # And for the hand-rolled sugar. Three criteria, one fix.
+  # And for the hand-rolled sugar. `String` since #259, which unblocked it by reading
+  # both of `Module#include`'s forwards instead of declining the pair as ambiguous.
   def read_stamp
     IncludedHook.new.stamp
   end

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -304,6 +304,10 @@ app/models/included_hook.rb:
     - "# @type self: singleton(IncludedHook) & singleton(IncludedHook::Sugared)"
     - "# @type instance: IncludedHook & IncludedHook::Sugared"
   blocks:
+  - call: class_eval
+    in: "::IncludedHook::Hookable"
+    implements: "::IncludedHook"
+    method: included
   - call: included
     in: "::IncludedHook::Homespun"
     implements: "::IncludedHook"

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/included_hook.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/included_hook.rb
@@ -10,20 +10,22 @@
 #
 # `ClassEvalExpander` (#197) declines it, correctly for what it knows: the receiver is
 # a method PARAMETER, not a constant, so the call shape alone names no class. What
-# makes it decidable is the hook's NAME — the hosts then come from the mixin graph
-# (`MixinIndex#hosts_of`), not from the call.
+# names it is the `include Hookable` further down, read through the pseudo-code for
+# `Module#include`: that forwards to `included`, so `base` is the includer. The hook's
+# NAME is not what makes it decidable and nothing keys on it (#260) — `Arbitrary`
+# below is the proof, being the same shape under a name Ruby never calls.
 #
 # This is the plain-Ruby core of the `included do` problem: ActiveSupport::Concern is
 # sugar over exactly this shape, so a fix here is a fix there, with no framework
 # knowledge involved.
 #
-# Since #239 the defs below are emitted NOWHERE. `ClassMemberCollector` no longer
-# attributes a block's body to the module that lexically contains it — a block's `self`
-# can be rebound, so the lexical owner was never the right answer — and nothing puts it
-# on the host yet. What these snapshots pin today is therefore ABSENCE, and the Steep
-# baseline records the `does not have method` errors that follow. That is the state #216
-# has to end: not by putting the defs back on the module, which was the wrong owner all
-# along, but by landing them on the host.
+# Between #239 and #260 the defs below were emitted NOWHERE: `ClassMemberCollector`
+# stopped attributing a block's body to the module that lexically contains it — a
+# block's `self` can be rebound, so the lexical owner was never the right answer — and
+# nothing yet put it on the host. #259 and #260 finish that for two of the three shapes
+# here, the way #216 asked for: not by putting the defs back on the module, but by
+# landing them on the host. `Sugared` is the one still open, and no longer for a reason
+# about inference — see its comment.
 #
 # A plain class on purpose — nothing here is Active Record, so the fixture needs no
 # table.
@@ -37,8 +39,7 @@ class IncludedHook
 
         # The load-bearing half, and the store-accessor shape: `super` can only resolve
         # if this def belongs to the HOST, whose ancestors have `IncludedHook::Slots`.
-        # Today it belongs to nobody — the override is emitted nowhere — so `super`
-        # is never typed and a read of `slot` reaches `Slots`' plain accessor instead.
+        # It does since #260, which is what `read_slot` below measures.
         def slot
           super || "default"
         end
@@ -63,7 +64,10 @@ class IncludedHook
       end
 
       # The Concern-side criterion, over the other slot so it cannot collide with
-      # `Hookable`'s. `super` only resolves if this def belongs to the HOST.
+      # `Hookable`'s. `super` only resolves if this def belongs to the HOST, and this
+      # is the one of the three that still does not — measured (#260): the chain
+      # resolves the moment `active_support/concern.rb` is in the corpus, and the
+      # corpus is `app/ lib/ sig/`. A question about reach, not about inference.
       def badge
         super || "sugared"
       end
@@ -93,9 +97,9 @@ class IncludedHook
   # belongs to nobody. Here as the limit case, so a fix for the hook above cannot
   # quietly generalise to any `*_included` name.
   #
-  # Since #239 that is also what the snapshot shows for the real hooks above, so absence
-  # alone no longer tells the two apart. The criterion is what #216 changes: the hooks'
-  # defs land on their hosts, and this one still lands nowhere.
+  # Absence is a criterion again since #260: the real hooks above land on their host
+  # and this one still lands nowhere, which is the difference a name-based fix would
+  # have erased. Nothing calls `foo_included`, so nothing says who `base` would be.
   module Arbitrary
     def self.foo_included(base)
       base.class_eval do
@@ -115,9 +119,8 @@ end
 
 # The call sites: the slot's writer is what gives `super` a type to return, and the
 # reads are what a regression would surface as `NoMethod` rather than as a silently
-# missing method. Today `fill`'s `from_hook` and `read_shared`'s `from_shared` ARE that
-# `NoMethod` — both sit in the Steep baseline, because since #239 neither method is
-# declared anywhere.
+# missing method. `read_shared`'s `from_shared` is still that `NoMethod` and sits in the
+# Steep baseline; `fill`'s `from_hook` stopped being one in #260.
 class IncludedHookCaller
   # Writes both slots, which is what gives each `super` a type to return. Kept apart
   # from the reads below so those measure the ancestor chain rather than a local
@@ -131,10 +134,9 @@ class IncludedHookCaller
   end
 
   # The success criterion, visible in a snapshot rather than in a diagnostic: `slot`
-  # returns `super || "default"` over a `String?` slot, so this is `String` once the
-  # hook's defs belong to the host. It reads `String?` today because the override is
-  # emitted nowhere: the read resolves to `Slots#slot`, and the `|| "default"` that
-  # removes the nil is never seen.
+  # returns `super || "default"` over a `String?` slot, so this is `String` exactly
+  # when the hook's def belongs to the host. `String` since #260; before it the read
+  # resolved to `Slots#slot` and the `|| "default"` that removes the nil was never seen.
   def read_slot
     IncludedHook.new.slot
   end
@@ -142,13 +144,13 @@ class IncludedHookCaller
   # The same criterion for the sugared half, over a slot with a UNIQUE name: `tag` was
   # borrowed from the dummy's Tag model closely enough to pick up a type from
   # elsewhere, which made the two halves look asymmetric when they are not.
-  # Both read `String?` today, for the same reason `read_slot` does, and both have to
-  # become `String` — one fix, or the two shapes have been treated as two problems.
+  # The last one still reading `String?`, and the only criterion here left open.
   def read_badge
     IncludedHook.new.badge
   end
 
-  # And for the hand-rolled sugar. Three criteria, one fix.
+  # And for the hand-rolled sugar. `String` since #259, which unblocked it by reading
+  # both of `Module#include`'s forwards instead of declining the pair as ambiguous.
   def read_stamp
     IncludedHook.new.stamp
   end
@@ -161,6 +163,19 @@ class IncludedHookCaller
   def read_shared
     IncludedHookFirst.new.from_shared
   end
+end
+
+class IncludedHook
+        def from_hook
+          "hook"
+        end
+
+        # The load-bearing half, and the store-accessor shape: `super` can only resolve
+        # if this def belongs to the HOST, whose ancestors have `IncludedHook::Slots`.
+        # It does since #260, which is what `read_slot` below measures.
+        def slot
+          super || "default"
+        end
 end
 
 class IncludedHook

--- a/spec/dummy/sig/rbs_infer/app/models/included_hook.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/included_hook.rbs
@@ -20,13 +20,15 @@ class IncludedHook
   include Sugared
   include Homespun
 
+  def from_hook: () -> String
+  def slot: () -> String
   def from_homespun: () -> String
   def stamp: () -> String
 end
 
 class IncludedHookCaller
   def fill: () -> String
-  def read_slot: () -> String?
+  def read_slot: () -> String
   def read_badge: () -> String?
   def read_stamp: () -> String
   def read_shared: () -> Integer

--- a/spec/expectations/expanded/app/models/included_hook.rb
+++ b/spec/expectations/expanded/app/models/included_hook.rb
@@ -7,20 +7,22 @@
 #
 # `ClassEvalExpander` (#197) declines it, correctly for what it knows: the receiver is
 # a method PARAMETER, not a constant, so the call shape alone names no class. What
-# makes it decidable is the hook's NAME — the hosts then come from the mixin graph
-# (`MixinIndex#hosts_of`), not from the call.
+# names it is the `include Hookable` further down, read through the pseudo-code for
+# `Module#include`: that forwards to `included`, so `base` is the includer. The hook's
+# NAME is not what makes it decidable and nothing keys on it (#260) — `Arbitrary`
+# below is the proof, being the same shape under a name Ruby never calls.
 #
 # This is the plain-Ruby core of the `included do` problem: ActiveSupport::Concern is
 # sugar over exactly this shape, so a fix here is a fix there, with no framework
 # knowledge involved.
 #
-# Since #239 the defs below are emitted NOWHERE. `ClassMemberCollector` no longer
-# attributes a block's body to the module that lexically contains it — a block's `self`
-# can be rebound, so the lexical owner was never the right answer — and nothing puts it
-# on the host yet. What these snapshots pin today is therefore ABSENCE, and the Steep
-# baseline records the `does not have method` errors that follow. That is the state #216
-# has to end: not by putting the defs back on the module, which was the wrong owner all
-# along, but by landing them on the host.
+# Between #239 and #260 the defs below were emitted NOWHERE: `ClassMemberCollector`
+# stopped attributing a block's body to the module that lexically contains it — a
+# block's `self` can be rebound, so the lexical owner was never the right answer — and
+# nothing yet put it on the host. #259 and #260 finish that for two of the three shapes
+# here, the way #216 asked for: not by putting the defs back on the module, but by
+# landing them on the host. `Sugared` is the one still open, and no longer for a reason
+# about inference — see its comment.
 #
 # A plain class on purpose — nothing here is Active Record, so the fixture needs no
 # table.
@@ -34,8 +36,7 @@ class IncludedHook
 
         # The load-bearing half, and the store-accessor shape: `super` can only resolve
         # if this def belongs to the HOST, whose ancestors have `IncludedHook::Slots`.
-        # Today it belongs to nobody — the override is emitted nowhere — so `super`
-        # is never typed and a read of `slot` reaches `Slots`' plain accessor instead.
+        # It does since #260, which is what `read_slot` below measures.
         def slot
           super || "default"
         end
@@ -60,7 +61,10 @@ class IncludedHook
       end
 
       # The Concern-side criterion, over the other slot so it cannot collide with
-      # `Hookable`'s. `super` only resolves if this def belongs to the HOST.
+      # `Hookable`'s. `super` only resolves if this def belongs to the HOST, and this
+      # is the one of the three that still does not — measured (#260): the chain
+      # resolves the moment `active_support/concern.rb` is in the corpus, and the
+      # corpus is `app/ lib/ sig/`. A question about reach, not about inference.
       def badge
         super || "sugared"
       end
@@ -90,9 +94,9 @@ class IncludedHook
   # belongs to nobody. Here as the limit case, so a fix for the hook above cannot
   # quietly generalise to any `*_included` name.
   #
-  # Since #239 that is also what the snapshot shows for the real hooks above, so absence
-  # alone no longer tells the two apart. The criterion is what #216 changes: the hooks'
-  # defs land on their hosts, and this one still lands nowhere.
+  # Absence is a criterion again since #260: the real hooks above land on their host
+  # and this one still lands nowhere, which is the difference a name-based fix would
+  # have erased. Nothing calls `foo_included`, so nothing says who `base` would be.
   module Arbitrary
     def self.foo_included(base)
       base.class_eval do
@@ -112,9 +116,8 @@ end
 
 # The call sites: the slot's writer is what gives `super` a type to return, and the
 # reads are what a regression would surface as `NoMethod` rather than as a silently
-# missing method. Today `fill`'s `from_hook` and `read_shared`'s `from_shared` ARE that
-# `NoMethod` — both sit in the Steep baseline, because since #239 neither method is
-# declared anywhere.
+# missing method. `read_shared`'s `from_shared` is still that `NoMethod` and sits in the
+# Steep baseline; `fill`'s `from_hook` stopped being one in #260.
 class IncludedHookCaller
   # Writes both slots, which is what gives each `super` a type to return. Kept apart
   # from the reads below so those measure the ancestor chain rather than a local
@@ -128,10 +131,9 @@ class IncludedHookCaller
   end
 
   # The success criterion, visible in a snapshot rather than in a diagnostic: `slot`
-  # returns `super || "default"` over a `String?` slot, so this is `String` once the
-  # hook's defs belong to the host. It reads `String?` today because the override is
-  # emitted nowhere: the read resolves to `Slots#slot`, and the `|| "default"` that
-  # removes the nil is never seen.
+  # returns `super || "default"` over a `String?` slot, so this is `String` exactly
+  # when the hook's def belongs to the host. `String` since #260; before it the read
+  # resolved to `Slots#slot` and the `|| "default"` that removes the nil was never seen.
   def read_slot
     IncludedHook.new.slot
   end
@@ -139,13 +141,13 @@ class IncludedHookCaller
   # The same criterion for the sugared half, over a slot with a UNIQUE name: `tag` was
   # borrowed from the dummy's Tag model closely enough to pick up a type from
   # elsewhere, which made the two halves look asymmetric when they are not.
-  # Both read `String?` today, for the same reason `read_slot` does, and both have to
-  # become `String` — one fix, or the two shapes have been treated as two problems.
+  # The last one still reading `String?`, and the only criterion here left open.
   def read_badge
     IncludedHook.new.badge
   end
 
-  # And for the hand-rolled sugar. Three criteria, one fix.
+  # And for the hand-rolled sugar. `String` since #259, which unblocked it by reading
+  # both of `Module#include`'s forwards instead of declining the pair as ambiguous.
   def read_stamp
     IncludedHook.new.stamp
   end
@@ -158,6 +160,19 @@ class IncludedHookCaller
   def read_shared
     IncludedHookFirst.new.from_shared
   end
+end
+
+class IncludedHook
+        def from_hook
+          "hook"
+        end
+
+        # The load-bearing half, and the store-accessor shape: `super` can only resolve
+        # if this def belongs to the HOST, whose ancestors have `IncludedHook::Slots`.
+        # It does since #260, which is what `read_slot` below measures.
+        def slot
+          super || "default"
+        end
 end
 
 class IncludedHook

--- a/spec/expectations/models/included_hook.rbs
+++ b/spec/expectations/models/included_hook.rbs
@@ -20,13 +20,15 @@ class IncludedHook
   include Sugared
   include Homespun
 
+  def from_hook: () -> String
+  def slot: () -> String
   def from_homespun: () -> String
   def stamp: () -> String
 end
 
 class IncludedHookCaller
   def fill: () -> String
-  def read_slot: () -> String?
+  def read_slot: () -> String
   def read_badge: () -> String?
   def read_stamp: () -> String
   def read_shared: () -> Integer

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -18,13 +18,10 @@ app/models/example4.rb:27:23: [error] Type `(::String | nil)` does not have meth
 app/models/example4.rb:40:23: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example7.rb:31:28: [error] Type `(::Integer | nil)` does not have method `abs`
 app/models/example7.rb:34:27: [error] Type `(::String | nil)` does not have method `upcase`
-app/models/included_hook.rb:105:12: [warning] Method `::IncludedHook::Arbitrary#from_arbitrary` is not declared in RBS
-app/models/included_hook.rb:133:11: [error] Type `::IncludedHook` does not have method `from_hook`
-app/models/included_hook.rb:165:26: [error] Type `::IncludedHookFirst` does not have method `from_shared`
-app/models/included_hook.rb:31:12: [warning] Method `::IncludedHook::Hookable#from_hook` is not declared in RBS
-app/models/included_hook.rb:39:12: [warning] Method `::IncludedHook::Hookable#slot` is not declared in RBS
-app/models/included_hook.rb:60:10: [warning] Method `::IncludedHook::Sugared#from_sugar` is not declared in RBS
-app/models/included_hook.rb:66:10: [warning] Method `::IncludedHook::Sugared#badge` is not declared in RBS
+app/models/included_hook.rb:109:12: [warning] Method `::IncludedHook::Arbitrary#from_arbitrary` is not declared in RBS
+app/models/included_hook.rb:167:26: [error] Type `::IncludedHookFirst` does not have method `from_shared`
+app/models/included_hook.rb:61:10: [warning] Method `::IncludedHook::Sugared#from_sugar` is not declared in RBS
+app/models/included_hook.rb:70:10: [warning] Method `::IncludedHook::Sugared#badge` is not declared in RBS
 app/models/included_hook/shared.rb:17:10: [warning] Method `::IncludedHook::Shared#from_shared` is not declared in RBS
 app/models/post/notifiable.rb:28:24: [error] Type `(::User | nil)` does not have method `full_name`
 app/models/send_dispatch.rb:107:33: [error] `public_send` cannot call `stamp` on `::SendDispatch`, which declares it private

--- a/spec/lib/rbs_infer/project/stored_block_replay_expander_spec.rb
+++ b/spec/lib/rbs_infer/project/stored_block_replay_expander_spec.rb
@@ -930,4 +930,123 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
       expect(expand(source)).to be_nil
     end
   end
+
+  # Ruby's own `included` hook with no DSL wrapped around it: the block is
+  # written where it runs instead of being kept for later, so there is no
+  # storage step to look it up through (felixefelip/rbs_infer#260).
+  context "a replay whose block is written in the hook itself" do
+    def hook(name: "included", applied: "include(Hookable)")
+      <<~RUBY
+        class Module
+          def include(*modules)
+            modules.reverse_each do |mod|
+              mod.send(:append_features, self)
+              mod.send(:included, self)
+            end
+            self
+          end
+        end
+
+        class Host
+          module Hookable
+            def self.#{name}(base)
+              base.class_eval do
+                def from_hook
+                  "hook"
+                end
+              end
+            end
+          end
+
+          #{applied}
+        end
+      RUBY
+    end
+
+    it "moves the block onto the class that includes the hook" do
+      expanded = expand(hook)
+
+      expect(expanded).to include("class Host\n        def from_hook")
+      expect(Prism.parse(expanded).success?).to be(true)
+    end
+
+    it "keeps the block where it was written, with nothing stored anywhere" do
+      expect(hook).not_to include("&block")
+      expect(hook).not_to include("@")
+    end
+
+    it "adds nothing on a second pass over its own output" do
+      expect(expand(expand(hook))).to be_nil
+    end
+
+    # The `include` is the only thing that says who `base` is. Ruby calls no
+    # hook named `after_included`, so nothing does.
+    it "declines a hook under a name nothing calls" do
+      expect(expand(hook(name: "after_included"))).to be_nil
+    end
+
+    it "declines when nothing includes the module" do
+      expect(expand(hook(applied: "# nothing"))).to be_nil
+    end
+
+    # `def self.included` is reached by Hookable and by nothing else. Recording
+    # it as an instance method would offer it to whoever extends the module,
+    # which is a different table entirely.
+    it "does not offer the hook to a module that extends it" do
+      source = hook(applied: "# nothing").sub("class Host", <<~EXTENDER)
+        class Extender
+          extend Host::Hookable
+        end
+
+        class Host
+      EXTENDER
+
+      expect(expand(source)).to be_nil
+    end
+  end
+
+  # A `def self.` DSL is reached through the singleton, so it answers for the
+  # module itself and for its subclasses — never for a module that `extend`s it,
+  # whose calls land in the instance table instead.
+  context "the table a `def self.` DSL is found in" do
+    def singleton_dsl(relation: "class Target < Wrap::Base")
+      <<~RUBY
+        class Wrap
+          class Base
+            def self.apply(mod)
+              mod.keep(self)
+            end
+
+            def self.keep(base = nil, &block)
+              if base.nil?
+                @body = block
+              else
+                base.class_eval(&@body) if @body
+              end
+            end
+          end
+
+          class Source < Base
+            keep do
+              def installed
+                "yes"
+              end
+            end
+          end
+        end
+
+        #{relation}
+          apply(Wrap::Source)
+        end
+      RUBY
+    end
+
+    it "answers for a subclass" do
+      expect(expand(singleton_dsl)).to include("class Target\n      def installed")
+    end
+
+    it "declines for a module that extends it instead" do
+      expect(expand(singleton_dsl(relation: "class Target\n  extend Wrap::Base"))).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Closes the `Hookable` third of #216. Needs felixefelip/steep#147.

`IncludedHook::Hookable` is Ruby's own `included` hook with no DSL wrapped around it:

```ruby
def self.included(base)
  base.class_eval do
    def from_hook = "hook"
    def slot = super || "default"
  end
end
```

## Why it declined

Two mechanisms could have taken it and both said no, each on its own grounds:

- **`ClassEvalExpander` (#197)** requires a constant receiver, and `base` is a parameter. Still true, still correct.
- **This pass** moves a block that was *handed to* the module and kept. `Hookable`'s is a literal in the replaying method, so there is no storage step for the join to walk. Measured: `@stored_calls` had `Sugared` and `Homespun` and nothing for `Hookable`; `@inward_replays` had only `HomeMade#included`.

Isolated to one variable — same hook, same `include`, block stored instead of written inline:

```
literal block in the hook body (as written): declined
same hook, block stored instead:             EXPANDED
```

## The fix

Nothing was missing but that step. #259 supplied the last real link by reading `Module#include`'s forward to `included`; from there the target comes from the `include Hookable` call site exactly as it does for the stored shape. So this is a third way to reach a block, not a new mechanism:

- `literal_replay_shape` matches `<parameter>.class_eval do … end`, same receiver rule as `inward_replay_shape` and for the same reason. What differs is only where the block comes from, so what it answers is the block.
- `literal_replays_for` walks the same forwards `inward_slot` walks, resolved through the argument's provider; only the keeper's contents differ.
- `resolve_replays` counts literals **alongside** slots, so a file reading as both still declines rather than being settled by declaration order.

Deliberately never absorbed from another file, unlike every other shape: this one carries a block, and the rewrite slices *this* source at the block's offsets. A block from elsewhere would cut the wrong file.

## The owner had to be fixed first

`def self.included` is reached through Hookable's **singleton** — by Hookable itself, and by a subclass. `def included` is reached by whoever `extend`s the module. Two different method tables, and both were filed under the lexical scope, which worked only while no shape needed telling them apart. `Hookable` does: its hook is reached by nothing but Hookable.

Singleton defs are now owned by `singleton(X)`, and the superclass edge in `dsl_providers` points there too — which is where `def self.keep` actually lives, and what the inheritance fixture has always relied on. Keyed alike, an `attr_reader :body` in a class body would answer for a `def self.apply` that could not call it. Two specs pin the split: a subclass resolves, a module that `extend`s the same class does not.

## The Steep half

The RBS side landed on its own, but two warnings stayed:

```
Method `::IncludedHook::Hookable#from_hook` is not declared in RBS
Method `::IncludedHook::Hookable#slot` is not declared in RBS
```

Steep's `find_block_calls` matched **receiverless** block calls only, so the `@implements` entry could not be placed and Steep kept attributing the defs to `Hookable`. felixefelip/steep#147 adds an optional `method:` key that lifts the receiver rule and discriminates by the enclosing def; this emits it:

```yaml
- call: class_eval
  in: "::IncludedHook::Hookable"
  method: included
  implements: "::IncludedHook"
```

`method:` is omitted for the DSL shape, where the scope already picks the block out.

## Result

```diff
 class IncludedHook
+  def from_hook: () -> String
+  def slot: () -> String
   def from_homespun: () -> String
   def stamp: () -> String

 class IncludedHookCaller
-  def read_slot: () -> String?
+  def read_slot: () -> String
```

`slot` is `String` because `super || "default"` finally has an ancestor to resolve against — the #216 criterion, and it matches the process: `IncludedHook.instance_method(:slot).owner` is `IncludedHook`.

Three baseline errors leave and none appear:

```
- app/models/included_hook.rb:133:11: [error] Type `::IncludedHook` does not have method `from_hook`
- app/models/included_hook.rb:31:12:  [warning] Method `::IncludedHook::Hookable#from_hook` is not declared in RBS
- app/models/included_hook.rb:39:12:  [warning] Method `::IncludedHook::Hookable#slot` is not declared in RBS
```

`Arbitrary` still lands nowhere, which is the point of it: nothing calls `foo_included`, so nothing says who `base` would be. Absence tells the two apart again — a name-based fix would have erased that difference.

## Fixture comments rewritten

`included_hook.rb`'s comments were its specification and had gone stale: they predicted the criterion would be the hook's NAME with hosts from `MixinIndex#hosts_of`, and asserted the defs are "emitted NOWHERE". Neither holds. They now say where each of the three shapes stands and why, including the one still open.

## Where #216 stands

- `Hookable` (plain `def self.included`) — this PR
- `Homespun` (hand-rolled `included do`) — #259
- `Sugared` (`ActiveSupport::Concern`) — **not an inference gap any more.** Measured: the chain resolves as things stand the moment `active_support/concern.rb` is in the corpus, and the corpus is `app/ lib/ sig/`. It works for the same reason #259 does — Concern's `append_features` is the replay and `included` the storage, so `Module#include`'s two forwards are exactly the case that used to be rejected as ambiguous. Whether gem sources enter the corpus is a scope decision, not an inference one.

8 new specs; 1227 unit examples and 1348 in the full suite, 0 failures. The dummy reaches a fixed point and no unrelated expectation moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
