### PR TITLE
Re-indent a relocated block body, leaving its string data alone

### DIFF
--- a/lib/rbs_infer/project/block_reopen.rb
+++ b/lib/rbs_infer/project/block_reopen.rb
@@ -22,21 +22,42 @@ module RbsInfer::Project
   module BlockReopen
     module_function
 
+    # One level in, from whatever `class X` the body ends up under.
+    INDENT = "  "
+
+    # Every node whose bytes are a literal's own, and so are not the program's
+    # indentation to change. Listed rather than duck-typed on `content_loc`,
+    # which `CallNode` and friends do not have but `EmbeddedStatementsNode`
+    # nearly does — the question is "is this a literal", not "does it look like
+    # one".
+    LITERALS = [
+      Prism::StringNode,
+      Prism::InterpolatedStringNode,
+      Prism::XStringNode,
+      Prism::InterpolatedXStringNode,
+      Prism::RegularExpressionNode,
+      Prism::InterpolatedRegularExpressionNode,
+      Prism::SymbolNode,
+      Prism::InterpolatedSymbolNode,
+      Prism::MatchLastLineNode,
+      Prism::InterpolatedMatchLastLineNode
+    ].freeze
+
     # @return [String, nil] a top-level reopening, or nil for a block with no
     #   body — which relocates to nothing, and whose `location` would raise.
     def appended(source:, block:, kind:, target:)
       body = block.body
       return nil unless body
 
-      "#{kind} #{target}\n#{slice_with_indent(source, body)}\nend\n"
+      "#{kind} #{target}\n#{body_source(source, body, indent: INDENT)}\nend\n"
     end
 
     # The text that replaces the call, `class X` landing at the call's own
     # column — so the closing `end` is indented to match rather than to zero.
     def in_place(source:, call:, name:)
       body = call.block.body
-      body_source = body ? slice_with_indent(source, body) : ""
       indent = line_indent(source, call.location.start_offset)
+      body_source = body ? body_source(source, body, indent: indent + INDENT) : ""
 
       "class #{name}\n#{body_source}\n#{indent}end"
     end
@@ -54,7 +75,8 @@ module RbsInfer::Project
     end
 
     # The body, sliced from the start of its own LINE rather than from its first
-    # token, so the indentation the source already had survives.
+    # token so the source's own indentation comes along, then moved as a whole so
+    # its outermost line sits at `indent`.
     #
     # Slicing from the token drops the FIRST line's indentation and nothing
     # else, leaving `def` at column 0 with its own `end` still indented. Legal
@@ -62,13 +84,12 @@ module RbsInfer::Project
     # be read while debugging and that made it harder to read than the source it
     # mirrors.
     #
-    # Only the indentation is reclaimed — the body is never RE-indented, because
-    # that rewrites the contents of any heredoc or multi-line string inside it.
-    # An appended reopening is emitted at column 0 and so LOOKS like it wants
-    # re-indenting; it did, briefly (felixefelip/rbs_infer#239), and a heredoc
-    # written with a deliberate margin came out with a different string in it.
-    # Prettier output is not worth changing what the program says.
-    def slice_with_indent(source, node)
+    # The relocation is what makes the move necessary rather than cosmetic: a
+    # block written two or three scopes deep is emitted under a reopening at
+    # column 0, so every line keeps a margin that no longer corresponds to
+    # anything. `realigned` is what removes it — see there for what it will not
+    # touch, and why.
+    def body_source(source, node, indent:)
       start = node.location.start_offset
       scan = start
       scan -= 1 while scan.positive? && [" ", "\t"].include?(source.byteslice(scan - 1, 1))
@@ -77,7 +98,77 @@ module RbsInfer::Project
       # on one line would otherwise pull in the space after `do`.
       start = scan if scan.zero? || source.byteslice(scan - 1, 1) == "\n"
 
-      source.byteslice(start, node.location.end_offset - start)
+      text = source.byteslice(start, node.location.end_offset - start)
+      realigned(text, literal_spans(node).map { |span| (span.begin - start)...(span.end - start) }, indent)
+    end
+
+    # `text` with the shallowest line brought to `indent` and every other line
+    # moved by the same amount, so the body's own shape is preserved.
+    #
+    # What is NOT moved is any line that is string DATA. Re-indenting the whole
+    # slice rewrites the contents of any heredoc or multi-line string inside it;
+    # that shipped briefly (felixefelip/rbs_infer#239) and a heredoc written with
+    # a deliberate margin came out with a different string in it. The lesson was
+    # taken then as "never re-indent", which is stronger than the problem: the
+    # hazard is the DATA, and `literal_spans` says exactly where that is. Lines
+    # inside one are emitted byte for byte, which is also why a `<<~` margin
+    # survives — Ruby computes it from those lines alone, and they did not move.
+    #
+    # `=begin`/`=end` are the one hazard Prism does not report as a node — they
+    # are comments, and they are only comments at column 0. Rather than move them
+    # to a column where they stop being comments, the whole slice stays put.
+    def realigned(text, spans, indent)
+      lines = text.lines
+      offset = 0
+      starts = lines.map { |line| offset.tap { offset += line.bytesize } }
+
+      movable = lines.each_index.reject do |index|
+        lines[index].strip.empty? || spans.any? { |span| span.cover?(starts[index]) }
+      end
+      return text if movable.empty?
+      return text if movable.any? { |index| lines[index].start_with?("=begin", "=end") }
+
+      margin = movable.map { |index| lines[index][/\A[ \t]*/].length }.min
+      movable.each { |index| lines[index] = "#{indent}#{lines[index][margin..]}" }
+      lines.join
+    end
+
+    # A literal's span carries its OPENING and CLOSING too, not just its
+    # content: for a heredoc the closing is the terminator line, whose column is
+    # fixed for `<<X` and load-bearing for nothing in the body either way, and
+    # covering the opening costs nothing since it never starts a line the body
+    # would move.
+    #
+    # Descent stops AT a literal, so an interpolation inside one is left alone
+    # with the rest of it. Moving those lines would in fact be safe — Ruby
+    # measures a `<<~` margin against the content lines only — but "a literal is
+    # one span" needs no such argument, and the argument would have to be remade
+    # for every literal that later grows an interpolation.
+    def literal_spans(node)
+      spans = []
+      stack = [node]
+
+      until stack.empty?
+        current = stack.pop
+        if literal?(current)
+          spans << literal_span(current)
+        else
+          stack.concat(current.compact_child_nodes)
+        end
+      end
+
+      spans
+    end
+
+    def literal?(node)
+      LITERALS.any? { |type| node.is_a?(type) }
+    end
+
+    def literal_span(node)
+      opening = node.respond_to?(:opening_loc) ? node.opening_loc : nil
+      closing = node.respond_to?(:closing_loc) ? node.closing_loc : nil
+
+      (opening&.end_offset || node.location.start_offset)...(closing&.end_offset || node.location.end_offset)
     end
 
     # The whitespace between the start of `offset`'s line and `offset`, or ""

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/example28.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/example28.rb
@@ -50,13 +50,13 @@ class Example28
 end
 
 class Example28::Bar
-      validade_age
+  validade_age
 
-      def greet
-        "Hello, world!"
-      end
+  def greet
+    "Hello, world!"
+  end
 
-      def age_after_a_decade
-        age + 10
-      end
+  def age_after_a_decade
+    age + 10
+  end
 end

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/example29.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/example29.rb
@@ -74,19 +74,19 @@ class Example29
 end
 
 class Example29::Bar
-      validade_age
+  validade_age
 
-      def greet
-        "Hello, world!"
-      end
+  def greet
+    "Hello, world!"
+  end
 
-      def age_after_a_decade
-        age + 10
-      end
+  def age_after_a_decade
+    age + 10
+  end
 end
 
 class Example29::BarOther
-      def name_upcase
-        name.upcase
-      end
+  def name_upcase
+    name.upcase
+  end
 end

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/example30.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/example30.rb
@@ -26,7 +26,7 @@ module Example30
 end
 
 class Example30::Foo::AfterBuildAge
-        def age
-          25
-        end
+  def age
+    25
+  end
 end

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/example31.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/example31.rb
@@ -40,7 +40,7 @@ class Example31
 end
 
 class Example31::Bar
-      def age
-        super + 10.5
-      end
+  def age
+    super + 10.5
+  end
 end

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/example32.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/example32.rb
@@ -42,7 +42,7 @@ class Example32
 end
 
 class Example32::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/example33.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/example33.rb
@@ -58,13 +58,13 @@ class Example33
 end
 
 class Example33::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end
 
 class Example33::BarOther
-      def name_upcase
-        name.upcase
-      end
+  def name_upcase
+    name.upcase
+  end
 end

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/example34.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/example34.rb
@@ -36,7 +36,7 @@ class Example34
 end
 
 class Example34::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/example35.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/example35.rb
@@ -34,7 +34,7 @@ class Example35
 end
 
 class Example35::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/example36.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/example36.rb
@@ -36,7 +36,7 @@ class Example36
 end
 
 class Example36::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/example37.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/example37.rb
@@ -40,7 +40,7 @@ class Example37
 end
 
 class Example37::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/example38.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/example38.rb
@@ -52,13 +52,13 @@ class Example38
 end
 
 class Example38::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end
 
 class Example38::Bar
-      def name
-        "John Doe"
-      end
+  def name
+    "John Doe"
+  end
 end

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/example39.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/example39.rb
@@ -36,7 +36,7 @@ module Example39
 end
 
 class Example39::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/example40.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/example40.rb
@@ -62,13 +62,13 @@ class Example40
 end
 
 class Example40::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end
 
 class Example40::Bar
-      def name
-        "John Doe"
-      end
+  def name
+    "John Doe"
+  end
 end

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/example41.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/example41.rb
@@ -30,7 +30,7 @@ class Example41
 end
 
 class Example41::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/included_hook.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/included_hook.rb
@@ -166,24 +166,24 @@ class IncludedHookCaller
 end
 
 class IncludedHook
-        def from_hook
-          "hook"
-        end
+  def from_hook
+    "hook"
+  end
 
-        # The load-bearing half, and the store-accessor shape: `super` can only resolve
-        # if this def belongs to the HOST, whose ancestors have `IncludedHook::Slots`.
-        # It does since #260, which is what `read_slot` below measures.
-        def slot
-          super || "default"
-        end
+  # The load-bearing half, and the store-accessor shape: `super` can only resolve
+  # if this def belongs to the HOST, whose ancestors have `IncludedHook::Slots`.
+  # It does since #260, which is what `read_slot` below measures.
+  def slot
+    super || "default"
+  end
 end
 
 class IncludedHook
-      def from_homespun
-        "homespun"
-      end
+  def from_homespun
+    "homespun"
+  end
 
-      def stamp
-        super || "homespun"
-      end
+  def stamp
+    super || "homespun"
+  end
 end

--- a/spec/expectations/expanded/app/models/example28.rb
+++ b/spec/expectations/expanded/app/models/example28.rb
@@ -47,13 +47,13 @@ class Example28
 end
 
 class Example28::Bar
-      validade_age
+  validade_age
 
-      def greet
-        "Hello, world!"
-      end
+  def greet
+    "Hello, world!"
+  end
 
-      def age_after_a_decade
-        age + 10
-      end
+  def age_after_a_decade
+    age + 10
+  end
 end

--- a/spec/expectations/expanded/app/models/example29.rb
+++ b/spec/expectations/expanded/app/models/example29.rb
@@ -71,19 +71,19 @@ class Example29
 end
 
 class Example29::Bar
-      validade_age
+  validade_age
 
-      def greet
-        "Hello, world!"
-      end
+  def greet
+    "Hello, world!"
+  end
 
-      def age_after_a_decade
-        age + 10
-      end
+  def age_after_a_decade
+    age + 10
+  end
 end
 
 class Example29::BarOther
-      def name_upcase
-        name.upcase
-      end
+  def name_upcase
+    name.upcase
+  end
 end

--- a/spec/expectations/expanded/app/models/example30.rb
+++ b/spec/expectations/expanded/app/models/example30.rb
@@ -23,7 +23,7 @@ module Example30
 end
 
 class Example30::Foo::AfterBuildAge
-        def age
-          25
-        end
+  def age
+    25
+  end
 end

--- a/spec/expectations/expanded/app/models/example31.rb
+++ b/spec/expectations/expanded/app/models/example31.rb
@@ -37,7 +37,7 @@ class Example31
 end
 
 class Example31::Bar
-      def age
-        super + 10.5
-      end
+  def age
+    super + 10.5
+  end
 end

--- a/spec/expectations/expanded/app/models/example32.rb
+++ b/spec/expectations/expanded/app/models/example32.rb
@@ -39,7 +39,7 @@ class Example32
 end
 
 class Example32::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end

--- a/spec/expectations/expanded/app/models/example33.rb
+++ b/spec/expectations/expanded/app/models/example33.rb
@@ -55,13 +55,13 @@ class Example33
 end
 
 class Example33::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end
 
 class Example33::BarOther
-      def name_upcase
-        name.upcase
-      end
+  def name_upcase
+    name.upcase
+  end
 end

--- a/spec/expectations/expanded/app/models/example34.rb
+++ b/spec/expectations/expanded/app/models/example34.rb
@@ -33,7 +33,7 @@ class Example34
 end
 
 class Example34::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end

--- a/spec/expectations/expanded/app/models/example35.rb
+++ b/spec/expectations/expanded/app/models/example35.rb
@@ -31,7 +31,7 @@ class Example35
 end
 
 class Example35::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end

--- a/spec/expectations/expanded/app/models/example36.rb
+++ b/spec/expectations/expanded/app/models/example36.rb
@@ -33,7 +33,7 @@ class Example36
 end
 
 class Example36::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end

--- a/spec/expectations/expanded/app/models/example37.rb
+++ b/spec/expectations/expanded/app/models/example37.rb
@@ -37,7 +37,7 @@ class Example37
 end
 
 class Example37::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end

--- a/spec/expectations/expanded/app/models/example38.rb
+++ b/spec/expectations/expanded/app/models/example38.rb
@@ -49,13 +49,13 @@ class Example38
 end
 
 class Example38::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end
 
 class Example38::Bar
-      def name
-        "John Doe"
-      end
+  def name
+    "John Doe"
+  end
 end

--- a/spec/expectations/expanded/app/models/example39.rb
+++ b/spec/expectations/expanded/app/models/example39.rb
@@ -33,7 +33,7 @@ module Example39
 end
 
 class Example39::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end

--- a/spec/expectations/expanded/app/models/example40.rb
+++ b/spec/expectations/expanded/app/models/example40.rb
@@ -59,13 +59,13 @@ class Example40
 end
 
 class Example40::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end
 
 class Example40::Bar
-      def name
-        "John Doe"
-      end
+  def name
+    "John Doe"
+  end
 end

--- a/spec/expectations/expanded/app/models/example41.rb
+++ b/spec/expectations/expanded/app/models/example41.rb
@@ -27,7 +27,7 @@ class Example41
 end
 
 class Example41::Bar
-      def age
-        31
-      end
+  def age
+    31
+  end
 end

--- a/spec/expectations/expanded/app/models/included_hook.rb
+++ b/spec/expectations/expanded/app/models/included_hook.rb
@@ -163,24 +163,24 @@ class IncludedHookCaller
 end
 
 class IncludedHook
-        def from_hook
-          "hook"
-        end
+  def from_hook
+    "hook"
+  end
 
-        # The load-bearing half, and the store-accessor shape: `super` can only resolve
-        # if this def belongs to the HOST, whose ancestors have `IncludedHook::Slots`.
-        # It does since #260, which is what `read_slot` below measures.
-        def slot
-          super || "default"
-        end
+  # The load-bearing half, and the store-accessor shape: `super` can only resolve
+  # if this def belongs to the HOST, whose ancestors have `IncludedHook::Slots`.
+  # It does since #260, which is what `read_slot` below measures.
+  def slot
+    super || "default"
+  end
 end
 
 class IncludedHook
-      def from_homespun
-        "homespun"
-      end
+  def from_homespun
+    "homespun"
+  end
 
-      def stamp
-        super || "homespun"
-      end
+  def stamp
+    super || "homespun"
+  end
 end

--- a/spec/lib/rbs_infer/project/block_reopen_spec.rb
+++ b/spec/lib/rbs_infer/project/block_reopen_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rbs_infer"
+
+# The relocating half of the rewrite. `ClassEvalExpander` leaves a block where it stands,
+# so its body is already at the column it belongs at; the two expanders that MOVE one emit
+# it under a reopening at column 0, and it arrives carrying the margin of wherever it was
+# written — two or three scopes in, for the shapes that need relocating at all.
+#
+# Bringing it back is a rewrite of the source's own bytes, and that is the whole risk here:
+# some of those bytes are string DATA, where a column is not layout but content.
+# felixefelip/rbs_infer#239 re-indented the lot and changed what a heredoc said, which
+# nothing caught — a heredoc's contents reach no inferred type, and nothing in the dummy
+# has one inside a moved block, so the `.expanded/` snapshots had none to show. Hence this
+# file, and hence the assertions RUN both versions: comparing strings would only say the
+# bytes are what I expected, where `eval` says the program still means what it meant.
+#
+# Bodies below are written at the column they really sit at, with `<<-` rather than `<<~`
+# so nothing strips it. The margin is the input.
+RSpec.describe RbsInfer::Project::BlockReopen do
+  # `base.class_eval do … end` nested two scopes deep — the `included`-hook shape, and the
+  # margin the relocation has to remove.
+  def hook(body)
+    "class A\n  module B\n    def self.included(base)\n      base.class_eval do\n#{body}      end\n    end\n  end\nend\n"
+  end
+
+  def relocated(body)
+    source = hook(body)
+    call = nil
+    Prism.parse(source).value.breadth_first_search do |node|
+      call = node if node.is_a?(Prism::CallNode) && node.name == :class_eval
+      false
+    end
+
+    described_class.appended(source: source, block: call.block, kind: "class", target: "Host")
+  end
+
+  # What `check` returns from the program as WRITTEN, and from the program as expanded.
+  # Equal is the whole point: relocation is a move, not an edit, and only running both can
+  # say whether a given byte was layout or content.
+  def both_ways(body)
+    eval("#{hook(body)}\nclass Written; include A::B; end")
+    eval(relocated(body))
+
+    [Written.new.check, Host.new.check]
+  ensure
+    %i[A Written Host].each { |name| Object.send(:remove_const, name) if Object.const_defined?(name, false) }
+  end
+
+  it "brings a moved body back to one level in" do
+    body = <<-RUBY
+        def check
+          "hook"
+        end
+    RUBY
+
+    expect(relocated(body)).to eq("class Host\n  def check\n    \"hook\"\n  end\nend\n")
+  end
+
+  it "keeps the body's own shape while moving it" do
+    body = <<-RUBY
+        def check
+          if 1 > 0
+            "yes"
+          end
+        end
+    RUBY
+
+    expect(relocated(body)).to eq("class Host\n  def check\n    if 1 > 0\n      \"yes\"\n    end\n  end\nend\n")
+  end
+
+  # `<<~` measures its margin against its own content lines, so leaving them alone is what
+  # makes the result identical. Moving them all by the same amount would work here too —
+  # it is the two below that make "leave the data alone" the rule rather than "shift it
+  # uniformly", and this one is here so the common case is covered by the rule that has to
+  # hold for them.
+  it "does not touch a squiggly heredoc" do
+    written, expanded = both_ways(<<-RUBY)
+        def check
+          <<~SQL
+            SELECT 1
+              FROM t
+          SQL
+        end
+    RUBY
+
+    expect(expanded).to eq(written)
+    expect(expanded).to eq("SELECT 1\n  FROM t\n")
+  end
+
+  # Here the margin IS the content, and a `<<-` terminator's column is free — so the
+  # terminator moving while its content does not would be legal, and still wrong.
+  it "does not touch a dash heredoc's deliberate margin" do
+    written, expanded = both_ways(<<-RUBY)
+        def check
+          <<-RAW
+      indented on purpose
+          RAW
+        end
+    RUBY
+
+    expect(expanded).to eq(written)
+    expect(expanded).to eq("      indented on purpose\n")
+  end
+
+  # A plain heredoc's terminator must be at column 0, so moving that line is a SyntaxError
+  # rather than merely a different string.
+  it "leaves a plain heredoc's terminator at column 0" do
+    written, expanded = both_ways(<<-RUBY)
+        def check
+          <<RAW
+      literal
+RAW
+        end
+    RUBY
+
+    expect(expanded).to eq(written)
+    expect(expanded).to eq("      literal\n")
+  end
+
+  it "does not touch a multi-line string" do
+    written, expanded = both_ways(<<-RUBY)
+        def check
+          "one
+        two"
+        end
+    RUBY
+
+    expect(expanded).to eq(written)
+    expect(expanded).to eq("one\n        two")
+  end
+
+  # A literal is ONE span, interpolations and all. Moving an interpolation's lines happens
+  # to be safe — Ruby measures a `<<~` margin against the content lines only, so this
+  # string survives either way — which is why the bytes are asserted too: what is pinned
+  # is the rule as implemented, that descent stops at the literal rather than at its parts.
+  it "does not touch an interpolation inside a heredoc" do
+    body = <<-'RUBY'
+        def check
+          <<~TXT
+            a#{
+              1 + 1
+            }b
+              indented
+          TXT
+        end
+    RUBY
+
+    written, expanded = both_ways(body)
+    expect(expanded).to eq(written)
+    expect(expanded).to eq("a2b\n  indented\n")
+    expect(relocated(body)).to include("\n            a\#{\n              1 + 1\n            }b\n")
+  end
+
+  # The one hazard Prism reports as a comment rather than a node — and `=begin` is only a
+  # comment at column 0, so there is nowhere to move it to. The whole body stays put, which
+  # is the old behaviour and still valid Ruby.
+  it "declines to move a body containing an embdoc comment" do
+    body = <<-RUBY
+        def other
+          1
+        end
+=begin
+not code
+=end
+        def check
+          "embdoc"
+        end
+    RUBY
+
+    expect(relocated(body)).to include("\n=begin\nnot code\n=end\n")
+    expect(relocated(body)).to include("\n        def check\n")
+    expect(both_ways(body).uniq).to eq(["embdoc"])
+  end
+end

--- a/spec/lib/rbs_infer/project/class_eval_expander_spec.rb
+++ b/spec/lib/rbs_infer/project/class_eval_expander_spec.rb
@@ -16,8 +16,10 @@ RSpec.describe RbsInfer::Project::ClassEvalExpander do
   # The `.expanded/` sidecar is read while debugging, so the rewrite keeps the source's
   # own layout: the body is sliced from the start of its LINE (not from its first
   # token, which dropped the first line's indentation and nothing else) and the closing
-  # `end` is aligned to the call it replaces. Nothing is RE-indented — that would
-  # rewrite the contents of a heredoc in the body.
+  # `end` is aligned to the call it replaces. An in-place rewrite puts `class Foo` where
+  # `Foo.class_eval do` stood, so the body is already one level in and the re-indent
+  # BlockReopen does has nothing to move — the heredoc here says so directly, and is the
+  # in-place half of the guarantee `block_reopen_spec.rb` pins for the relocating one.
   it "keeps the source layout, including a nested call and a heredoc" do
     expect(expand("class Wrap\n  Foo.class_eval do\n    def bar\n      1\n    end\n  end\nend\n"))
       .to eq("class Wrap\n  class Foo\n    def bar\n      1\n    end\n  end\nend\n")
@@ -27,10 +29,10 @@ RSpec.describe RbsInfer::Project::ClassEvalExpander do
   end
 
   # A body opening on the same line as `do` has no indentation to reclaim, and must not
-  # pull in the space after `do`.
-  it "leaves a single-line body alone" do
+  # pull in the space after `do` — it is indented like any other, from a margin of zero.
+  it "does not pull in the space after `do` for a single-line body" do
     expect(expand("Foo.class_eval do def bar; 1; end end\n"))
-      .to eq("class Foo\ndef bar; 1; end\nend\n")
+      .to eq("class Foo\n  def bar; 1; end\nend\n")
   end
 
   it "rewrites module_eval the same way" do

--- a/spec/lib/rbs_infer/project/self_class_eval_expander_spec.rb
+++ b/spec/lib/rbs_infer/project/self_class_eval_expander_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RbsInfer::Project::SelfClassEvalExpander do
 
     # The body keeps its source indentation: re-indenting it to the reopening's
     # column reads better and rewrites the contents of any heredoc inside it.
-    expect(expanded).to include("class Foo::AfterBuild\n      def age\n        25\n      end\nend")
+    expect(expanded).to include("class Foo::AfterBuild\n  def age\n    25\n  end\nend")
     expect(Prism.parse(expanded).success?).to be(true)
   end
 

--- a/spec/lib/rbs_infer/project/stored_block_replay_expander_spec.rb
+++ b/spec/lib/rbs_infer/project/stored_block_replay_expander_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
     # The body keeps the indentation it had in the source. Re-indenting it to
     # the reopening's column reads better and rewrites the contents of any
     # heredoc inside it, so the reopening wears the source's margin instead.
-    expect(expanded).to include("class Wrap::Target\n      def installed")
+    expect(expanded).to include("class Wrap::Target\n  def installed")
     expect(expanded.scan("def installed").size).to eq(2)
     expect(Prism.parse(expanded).success?).to be(true)
   end
@@ -107,7 +107,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
 
     # A one-line block (`keep { … }`) has no margin of its own to reclaim, so
     # its body arrives exactly as written.
-    expect(expanded).to include("module Wrap::Target\ndef installed; end")
+    expect(expanded).to include("module Wrap::Target\n  def installed; end")
     expect(Prism.parse(expanded).success?).to be(true)
   end
 
@@ -155,7 +155,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
     it "moves the block onto the target the replay was handed" do
       expanded = expand(concern)
 
-      expect(expanded).to include("class Wrap::Target\n      def installed")
+      expect(expanded).to include("class Wrap::Target\n  def installed")
       expect(expanded.scan("def installed").size).to eq(2)
       expect(Prism.parse(expanded).success?).to be(true)
     end
@@ -265,7 +265,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
       expanded = expand(inherited)
 
       expect(inherited).not_to include("extend")
-      expect(expanded).to include("class Wrap::Target\n      def installed")
+      expect(expanded).to include("class Wrap::Target\n  def installed")
       expect(expanded.scan("def installed").size).to eq(2)
       expect(Prism.parse(expanded).success?).to be(true)
     end
@@ -273,7 +273,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
     # Ruby's ancestry is transitive, so this pass's has to be: `Target < Source`
     # reaches `keep` through `Source`, exactly as a direct subclass would.
     it "reaches a DSL inherited through an intermediate class" do
-      expect(expand(inherited(target_super: "Source"))).to include("class Wrap::Target\n      def installed")
+      expect(expand(inherited(target_super: "Source"))).to include("class Wrap::Target\n  def installed")
     end
 
     it "declines when the target never asks for the replay" do
@@ -346,15 +346,15 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
     it "moves every named module's block onto the target" do
       expanded = expand(splat)
 
-      expect(expanded).to include("class Wrap::Target\n      def installed_first")
-      expect(expanded).to include("class Wrap::Target\n      def installed_second")
+      expect(expanded).to include("class Wrap::Target\n  def installed_first")
+      expect(expanded).to include("class Wrap::Target\n  def installed_second")
       expect(Prism.parse(expanded).success?).to be(true)
     end
 
     it "resolves a single argument through the same iteration" do
       expanded = expand(splat(sources: %w[First], applied: "apply(First)"))
 
-      expect(expanded).to include("class Wrap::Target\n      def installed_first")
+      expect(expanded).to include("class Wrap::Target\n  def installed_first")
       expect(expanded).not_to include("installed_second")
     end
 
@@ -366,14 +366,14 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
     it "does not depend on which method does the yielding" do
       %w[each map select each_with_index reverse_each each_entry tap].each do |iteration|
         expect(expand(splat(iteration: iteration)))
-          .to include("class Wrap::Target\n      def installed_first"), "#{iteration} was not read"
+          .to include("class Wrap::Target\n  def installed_first"), "#{iteration} was not read"
       end
     end
 
     it "reads a name bound anywhere in the block's parameters" do
       source = splat.sub("{ |mod| mod.keep(self) }", "{ |index, mod| mod.keep(self) }")
 
-      expect(expand(source)).to include("class Wrap::Target\n      def installed_first")
+      expect(expand(source)).to include("class Wrap::Target\n  def installed_first")
     end
 
     it "adds nothing on a second pass over its own output" do
@@ -399,7 +399,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
       source = splat.sub("modules.reverse_each { |mod| mod.keep(self) }",
                          "modules.each { |group| group.each { |mod| mod.keep(self) } }")
 
-      expect(expand(source)).to include("class Wrap::Target\n      def installed_first")
+      expect(expand(source)).to include("class Wrap::Target\n  def installed_first")
     end
   end
 
@@ -449,27 +449,27 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
     it "reads through `send` to the method it dispatches" do
       expanded = expand(dispatched)
 
-      expect(expanded).to include("class Wrap::Target\n      def installed")
+      expect(expanded).to include("class Wrap::Target\n  def installed")
       expect(Prism.parse(expanded).success?).to be(true)
     end
 
     it "reads `public_send` and `__send__` the same way" do
       ["mod.public_send(:keep, self)", "mod.__send__(:keep, self)"].each do |call|
         expect(expand(dispatched(call: call)))
-          .to include("class Wrap::Target\n      def installed"), "#{call} was not read"
+          .to include("class Wrap::Target\n  def installed"), "#{call} was not read"
       end
     end
 
     it "reads a string name as well as a symbol" do
       expect(expand(dispatched(call: 'mod.send("keep", self)')))
-        .to include("class Wrap::Target\n      def installed")
+        .to include("class Wrap::Target\n  def installed")
     end
 
     # Visibility is not something this pass reads — `send` is what hid the
     # call, not `private`. The public spelling resolves identically.
     it "does not depend on the method being private" do
       expect(expand(dispatched(visibility: "public")))
-        .to include("class Wrap::Target\n      def installed")
+        .to include("class Wrap::Target\n  def installed")
     end
 
     it "adds nothing on a second pass over its own output" do
@@ -491,7 +491,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
     it "reads a `class_eval` dispatched through `send`" do
       source = dispatched.sub("base.class_eval(&@body)", "base.send(:class_eval, &@body)")
 
-      expect(expand(source)).to include("class Wrap::Target\n      def installed")
+      expect(expand(source)).to include("class Wrap::Target\n  def installed")
     end
   end
 
@@ -543,7 +543,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
     it "follows the delegation to the object that keeps the block" do
       expanded = expand(delegated)
 
-      expect(expanded).to include("class Wrap::Target\n      def installed")
+      expect(expanded).to include("class Wrap::Target\n  def installed")
       expect(Prism.parse(expanded).success?).to be(true)
     end
 
@@ -552,17 +552,17 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
     # alike, and renaming the held method changes nothing about the program.
     it "does not depend on the two methods sharing a name" do
       expect(expand(delegated(kept: "keep_or_replay")))
-        .to include("class Wrap::Target\n      def installed")
+        .to include("class Wrap::Target\n  def installed")
     end
 
     it "reads a plain assignment as well as a memoization" do
       expect(expand(delegated(memo: "@holder = Holder.new")))
-        .to include("class Wrap::Target\n      def installed")
+        .to include("class Wrap::Target\n  def installed")
     end
 
     it "resolves the held class through the enclosing namespace" do
       expect(expand(delegated(memo: "@holder ||= Wrap::Holder.new")))
-        .to include("class Wrap::Target\n      def installed")
+        .to include("class Wrap::Target\n  def installed")
     end
 
     it "adds nothing on a second pass over its own output" do
@@ -657,7 +657,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
     it "reads an applier reopened on `Module` in another file" do
       expanded = expand(concern, sources: project(Module: core_applier))
 
-      expect(expanded).to include("class Wrap::Target\n      def installed")
+      expect(expanded).to include("class Wrap::Target\n  def installed")
       expect(Prism.parse(expanded).success?).to be(true)
     end
 
@@ -669,7 +669,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
 
     it "reads a `Class` reopening for a class body" do
       expect(expand(concern, sources: project(Class: core_applier(name: "Class"))))
-        .to include("class Wrap::Target\n      def installed")
+        .to include("class Wrap::Target\n  def installed")
     end
 
     # `Class`'s instance methods are not in a MODULE's body, so a module target
@@ -694,7 +694,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
       RUBY
 
       expect(expand(source, sources: project("Elsewhere::Applier": declared)))
-        .to include("class Wrap::Target\n      def installed")
+        .to include("class Wrap::Target\n  def installed")
     end
 
     # A deliberate limit, not an oversight. `expand` gates on the source naming
@@ -735,7 +735,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
       expanded = expand(concern, sources: project(Module: elsewhere))
 
       expect(expanded).not_to include("elsewhere_only")
-      expect(expanded).to include("class Wrap::Target\n      def installed")
+      expect(expanded).to include("class Wrap::Target\n  def installed")
     end
 
     it "adds nothing on a second pass over its own output" do
@@ -749,7 +749,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
     # rather than listed — a hand-written `%w[Module Class]` stops here.
     it "reads an applier reopened further up the chain" do
       expect(expand(concern, sources: project(Object: core_applier(name: "Object"))))
-        .to include("class Wrap::Target\n      def installed")
+        .to include("class Wrap::Target\n  def installed")
     end
 
     describe "the chain it consults" do
@@ -815,7 +815,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
     it "resolves the forwarded callee against the argument's provider" do
       expanded = expand(split)
 
-      expect(expanded).to include("class Wrap::Target\n      def installed")
+      expect(expanded).to include("class Wrap::Target\n  def installed")
       expect(Prism.parse(expanded).success?).to be(true)
     end
 
@@ -904,7 +904,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
     it "reads the forward that reaches a replay" do
       expanded = expand(two)
 
-      expect(expanded).to include("class Wrap::Target\n      def installed")
+      expect(expanded).to include("class Wrap::Target\n  def installed")
       expect(Prism.parse(expanded).success?).to be(true)
     end
 
@@ -966,7 +966,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
     it "moves the block onto the class that includes the hook" do
       expanded = expand(hook)
 
-      expect(expanded).to include("class Host\n        def from_hook")
+      expect(expanded).to include("class Host\n  def from_hook")
       expect(Prism.parse(expanded).success?).to be(true)
     end
 
@@ -1042,7 +1042,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
     end
 
     it "answers for a subclass" do
-      expect(expand(singleton_dsl)).to include("class Target\n      def installed")
+      expect(expand(singleton_dsl)).to include("class Target\n  def installed")
     end
 
     it "declines for a module that extends it instead" do


### PR DESCRIPTION
The `.expanded/` sidecar exists to be read while debugging, and the relocating expanders were emitting bodies like this:

```ruby
class IncludedHook
        def from_hook
          "hook"
        end
end
```

## Why the margin was there

`ClassEvalExpander` leaves a block where it stands, so its body is already at the column it belongs at. The two expanders that MOVE one — `StoredBlockReplayExpander`, `SelfClassEvalExpander` — emit it under a reopening at column 0, and it arrives with the margin of wherever it was written. For the shapes that need relocating at all, that is two or three scopes in.

## Why it was left alone

Re-indenting the slice shipped briefly in #239 and changed what a heredoc said. Nothing caught it: a heredoc's contents reach no inferred type, and nothing in the dummy has one inside a moved block, so the snapshots had none to show. The lesson was written into `BlockReopen` as "the body is never RE-indented".

That is stronger than the problem. The hazard is string DATA, where a column is content rather than layout — and Prism says exactly where that is. So lines inside a literal are now emitted byte for byte and every other line moves. A `<<~` margin survives for the reason it should: Ruby measures it against those lines, and they did not move.

Three cases make "leave the data alone" the rule rather than "shift it uniformly", since a uniform shift would be correct for `<<~` alone:

- `<<-RAW` — the margin IS the content, and the terminator's column is free, so the terminator moving while its content does not is legal and still wrong.
- `<<RAW` — the terminator must be at column 0, so moving that line is a SyntaxError rather than a different string.
- `"one\n  two"` — no terminator to key on at all.

Descent stops AT a literal, so an interpolation inside one comes along with it. Moving those lines would in fact be safe — Ruby measures the margin against the content lines only — but "a literal is one span" needs no such argument, and the argument would have to be remade for every literal that later grows an interpolation.

`=begin`/`=end` are the one hazard Prism reports as a comment rather than a node, and they are only comments at column 0. There is nowhere to move them to, so a body containing one stays put — the old behaviour, still valid Ruby.

## Result

```diff
 class IncludedHook
-        def from_hook
-          "hook"
-        end
+  def from_hook
+    "hook"
+  end
 end
```

15 expanded snapshots, every one a relocation. `eval_reopen.rb` and `post/taggable.rb` do not move, which is the in-place path confirming it was already right — the same `indent:` argument runs for it, and `class Foo` landing where `Foo.class_eval do` stood leaves it nothing to do.

No inferred RBS changes and no Steep baseline entry moves. Full suite 1356 examples, 0 failures.

## The spec that was missing

`block_reopen_spec.rb` is new: the relocating half had no unit spec, which is half of why #239 was silent. Its assertions RUN both versions rather than compare strings — `eval` the program as written, `eval` the program as expanded, and compare what the method returns. A string assertion only says the bytes are what I expected; this says the program still means what it meant. Verified to have teeth: with the guard disabled, 4 of the 8 fail.

The bodies are written at the column they really sit at, with `<<-` rather than `<<~` so nothing strips it — the margin is the input. My first draft of the helper auto-indented them, which is the bug under test, and the plain-heredoc case failed with a SyntaxError until the helper stopped doing it.

One test in `class_eval_expander_spec.rb` changed name and expectation: a single-line body (`Foo.class_eval do def bar; 1; end end`) now lands at one level in like any other. What it was pinning — that the slice must not pull in the space after `do` — still holds and is still what it checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
