### PR TITLE
Name every class a replayed block defines its methods on

### DIFF
--- a/lib/rbs_infer/project/stored_block_replay_implements.rb
+++ b/lib/rbs_infer/project/stored_block_replay_implements.rb
@@ -59,10 +59,11 @@ module RbsInfer::Project
 
       replays = StoredBlockReplayExpander::Collector.new(source, sources: sources).collect(parsed.value)
 
-      single_target(replays).filter_map do |replay|
+      per_block(replays).filter_map do |entries|
+        replay = entries.first
         next unless replay.scope
 
-        entry = { "call" => replay.call, "in" => "::#{replay.scope}", "implements" => "::#{replay.target}" }
+        entry = { "call" => replay.call, "in" => "::#{replay.scope}", "implements" => implements(entries) }
         # Only for a block written inside a def. Emitting it as nil for the DSL
         # shape would put a key in every sidecar entry ever written, to say
         # nothing.
@@ -71,24 +72,23 @@ module RbsInfer::Project
       end
     end
 
-    # The replays whose block has exactly one target, which is all this sidecar
-    # can speak about: `@implements` names ONE module, and the annotation rides
-    # the block's own opener — so a block replayed onto two classes has one
-    # place to put two answers and no way to choose.
+    # The replays grouped by the BLOCK they move, since that is what an entry
+    # speaks about: the annotation rides one block's opener, so every target
+    # that block is replayed onto has to be named in that one entry.
+    def per_block(replays)
+      replays.group_by { |replay| replay.block.location.start_offset }.values
+    end
+
+    # Every target the block defines its methods on. A LIST once there is more
+    # than one, which `@implements` now takes and Steep checks the body against
+    # one by one — a block replayed onto two classes runs twice, and checking it
+    # against one of them says nothing about the other (felixefelip/steep#149).
     #
-    # A real limit rather than a conservatism, and narrower than it was: the
-    # EXPANDER emits both reopenings, so the RBS declares the methods on both
-    # targets (felixefelip/rbs_infer#263). What is left undone is only
-    # `steep check` reading the real file, where those `def`s still sit
-    # lexically in the source module and get attributed to it. Expressing it
-    # would need `@implements` to take more than one module, which is a change
-    # to Steep's annotation grammar rather than to anything here.
-    #
-    # Dropped per BLOCK, not per file: another block in the same file that does
-    # decide its target is still annotated.
-    def single_target(replays)
-      by_block = replays.group_by { |replay| replay.block.location.start_offset }
-      by_block.each_value.filter_map { |entries| entries.first if entries.map(&:target).uniq.size == 1 }
+    # A lone target stays a plain string: it is what every sidecar written so
+    # far says, it reads better, and Steep takes either.
+    def implements(entries)
+      targets = entries.map { |replay| "::#{replay.target}" }.uniq
+      targets.size == 1 ? targets.first : targets
     end
   end
 end

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -279,6 +279,12 @@ app/models/example42.rb:
       | (singleton(Example42::Baz))"
     defs:
       bazinga: singleton(Example42::Bar) | singleton(Example42::BarOther)
+  blocks:
+  - call: bazingado
+    in: "::Example42::Baz"
+    implements:
+    - "::Example42::Bar"
+    - "::Example42::BarOther"
 app/models/included_hook/home_made.rb:
   modules:
   - anchor: HomeMade

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -16,7 +16,6 @@ app/models/example4.rb:14:25: [error] Type `(::String | nil)` does not have meth
 app/models/example4.rb:22:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:27:23: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:40:23: [error] Type `(::String | nil)` does not have method `upcase`
-app/models/example42.rb:25:10: [warning] Method `::Example42::Baz#age` is not declared in RBS
 app/models/example7.rb:31:28: [error] Type `(::Integer | nil)` does not have method `abs`
 app/models/example7.rb:34:27: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/included_hook.rb:110:12: [warning] Method `::IncludedHook::Arbitrary#from_arbitrary` is not declared in RBS

--- a/spec/lib/rbs_infer/project/stored_block_replay_implements_spec.rb
+++ b/spec/lib/rbs_infer/project/stored_block_replay_implements_spec.rb
@@ -94,11 +94,12 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayImplements do
     expect(entries.map { |entry| entry["line"] }).not_to include(17)
   end
 
-  # `@implements` names one module and rides the block's own opener, so there is
-  # one place to put an answer and two answers to put there. The EXPANDER emits
-  # both reopenings all the same (felixefelip/rbs_infer#263) — only the sidecar
-  # half declines.
-  it "says nothing about a block replayed onto more than one target" do
+  # One entry, naming both — the annotation rides the block's single opener, so
+  # every target that block reaches has to be named there. Steep takes a list
+  # and checks the body against each (felixefelip/steep#149); it used to be told
+  # nothing at all, and `steep check` then attributed the `def`s to the module
+  # the block is written in.
+  it "names every target a block is replayed onto" do
     source = dsl + <<~RUBY
       module Src
         extend DSL
@@ -116,11 +117,13 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayImplements do
       end
     RUBY
 
-    expect(described_class.blocks_for(source: source, sources: NO_SOURCES)).to eq([])
+    expect(described_class.blocks_for(source: source, sources: NO_SOURCES))
+      .to eq([{ "call" => "keep", "in" => "::Src", "implements" => ["::First", "::Second"] }])
   end
 
-  # Per block, not per file: the one that does decide its target is still named.
-  it "keeps annotating the blocks that do decide a single target" do
+  # A lone target stays a plain string — what every sidecar written before the
+  # list says, and what Steep still takes.
+  it "keeps a single target as a string rather than a one-element list" do
     source = dsl + <<~RUBY
       module Shared
         extend DSL
@@ -149,7 +152,8 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayImplements do
     RUBY
 
     expect(described_class.blocks_for(source: source, sources: NO_SOURCES))
-      .to eq([{ "call" => "keep", "in" => "::Lone", "implements" => "::Third" }])
+      .to eq([{ "call" => "keep", "in" => "::Shared", "implements" => ["::First", "::Second"] },
+              { "call" => "keep", "in" => "::Lone", "implements" => "::Third" }])
   end
 
   it "returns nothing for a file with no replay" do


### PR DESCRIPTION
Companion to felixefelip/steep#149, which is where the actual capability lands.

## What was left over from #263

#263 made a stored block replayed onto two classes emit **both** reopenings, so the RBS declares the methods on both:

```rbs
class Example42::Bar
  def age: () -> Integer
end
class Example42::BarOther
  def age: () -> Integer
end
```

But the `blocks:` sidecar had to stay quiet about that block. `@implements` named one module, and the annotation rides the block's single opener line — two targets, one slot, two answers, no way to choose. So `steep check` read the real file, where the `def` still sits lexically inside `Baz`, and reported:

```
app/models/example42.rb:25:10: [warning] Method `::Example42::Baz#age` is not declared in RBS
```

## What changed

felixefelip/steep#149 gives `@implements` a list and checks the block body **once per definee**, so the entry can now say what the expander already knew. `StoredBlockReplayImplements` groups replays per block — that is what an entry speaks about — and names every target that block reaches:

```yaml
blocks:
- call: bazingado
  in: "::Example42::Baz"
  implements:
  - "::Example42::Bar"
  - "::Example42::BarOther"
```

A lone target stays a plain **string** rather than becoming a one-element list: it is what every sidecar written so far says, it reads better, and Steep takes either. That keeps every existing entry in `.steep_module_self_types.yml` byte-identical.

## Result

The dummy's Steep baseline loses exactly one line and gains none:

```diff
-app/models/example42.rb:25:10: [warning] Method `::Example42::Baz#age` is not declared in RBS
```

`example42` is now fully typed end to end — the expander relocates the block to both classes, the RBS declares `age` and `call_age: () -> Integer` on both, and the checker agrees.

## Verification

- `bundle exec rspec` — 1362 examples, 0 failures.
- Two updated unit specs pin the two spellings: a multi-target block gets a list, a single-target block keeps its string.
- Requires the paired Steep change; without it the list would reach an `@implements` that cannot read one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)