### PR TITLE
Bound `ClassEvalExpander`'s passes by what the file writes, not by ten

### DIFF
--- a/lib/rbs_infer/project/class_eval_expander.rb
+++ b/lib/rbs_infer/project/class_eval_expander.rb
@@ -36,18 +36,27 @@ module RbsInfer::Project
   # call shape as an implicit `@implements` so `super` inside the block resolves
   # against the receiver's ancestors.
   module ClassEvalExpander
-    # A block nested inside another match is rewritten on a later pass, once the outer
-    # one has become an ordinary class body. Replacing both at once would corrupt the
-    # source: the offsets of the inner match are inside the outer's replaced range.
-    MAX_PASSES = 10
-
     module_function
 
     # Returns the expanded source, or nil when there is nothing to rewrite.
+    #
+    # A block nested inside another match is rewritten on a later pass, once the outer
+    # one has become an ordinary class body. Replacing both at once would corrupt the
+    # source: the offsets of the inner match are inside the outer's replaced range.
+    # Only NESTING costs a pass — any number of non-overlapping calls are rewritten
+    # together (measured: fifteen siblings, one pass).
+    #
+    # The bound is what the source writes, not a constant. A fixed ten looked like a
+    # guard and was a depth limit: measured, eleven nested reopenings came out still
+    # holding a `class_eval`, which is both a wrong answer and an output this expander
+    # wants to rewrite again — the non-idempotent result `SourceExpanders` asks an
+    # expander not to produce (felixefelip/rbs_infer#269 fixed the same shape in
+    # `ConstantDeclarationExpander`). Bounding by the count still terminates if some
+    # future rewrite stops reducing, which is what a ceiling is really for.
     def expand(source)
       result = nil
 
-      MAX_PASSES.times do
+      ReopeningCall.count(source).times do
         expanded = expand_once(result || source)
         break unless expanded
 

--- a/lib/rbs_infer/project/reopening_call.rb
+++ b/lib/rbs_infer/project/reopening_call.rb
@@ -27,6 +27,18 @@ module RbsInfer::Project
       METHODS.any? { |name| source.include?(name) }
     end
 
+    # How many the source writes — the same question `possible?` asks, counted.
+    #
+    # It is an upper bound on the passes a rewriting expander can need: a pass
+    # consumes at least one of these and the reopening it emits carries none
+    # (the body is moved byte for byte, so no rewrite can manufacture one), so
+    # the count strictly decreases. Loose on purpose — a `class_eval` this
+    # expander declines, or the word inside a comment, only inflates a ceiling
+    # the loop stops short of anyway.
+    def count(source)
+      METHODS.sum { |name| source.scan(name).size }
+    end
+
     # The call shape, receiver aside. The STRING form (`class_eval "def x; end"`)
     # is excluded by requiring a block and no arguments: its body is not source
     # this can read, and is the genuinely undecidable case the README reserves

--- a/spec/lib/rbs_infer/project/class_eval_expander_spec.rb
+++ b/spec/lib/rbs_infer/project/class_eval_expander_spec.rb
@@ -90,6 +90,27 @@ RSpec.describe RbsInfer::Project::ClassEvalExpander do
     expect(Prism.parse(expanded).success?).to be(true)
   end
 
+  # Only nesting costs a pass, and the pass bound comes from the source — so
+  # depth has no ceiling to hit. A fixed ten stopped at eleven nested reopenings
+  # and returned a file still holding a `class_eval`: wrong, and an output this
+  # expander wanted to rewrite again.
+  it "converges however deep the nesting goes" do
+    source = "def leaf\n  1\nend\n"
+    12.downto(1) { |i| source = "C#{i}.class_eval do\n#{source}end\n" }
+    expanded = expand(source)
+
+    expect(expanded).not_to include("class_eval")
+    expect(expanded).to include("class C12")
+    expect(expand(expanded)).to be_nil
+  end
+
+  # The other half of the same claim: what costs a pass is nesting, not count.
+  it "rewrites any number of non-overlapping calls in one pass" do
+    source = (1..15).map { |i| "C#{i}.class_eval do\n  def m#{i}; 1; end\nend\n" }.join
+
+    expect(described_class.expand_once(source)).not_to include("class_eval")
+  end
+
   describe "declines" do
     # `instance_eval`'s default definee is the receiver's SINGLETON class, so
     # rewriting it to `class X` would attribute the def to the instance side — the


### PR DESCRIPTION
The same defect #269 fixed in `ConstantDeclarationExpander`, in the expander it was copied from.

`MAX_PASSES = 10` looked like a guard and was a depth limit. Measured, against `C1.class_eval do C2.class_eval do … end end` nested N deep:

| depth | converges? | `class_eval` left over? |
|---|---|---|
| 3 | yes | no |
| 10 | yes | no |
| **11** | **no** | **yes** |
| 12 | **no** | **yes** |

Past the ceiling the expander returns a half-rewritten file — a wrong answer, and an output it wants to rewrite again, which is the non-idempotent result `SourceExpanders` explicitly asks an expander not to produce.

## The bound

`ReopeningCall.count` sits beside the `possible?` that asks the same question unquantified. It is an honest upper bound: a pass consumes at least one reopening, and the `class X … end` it emits carries none — the body is moved byte for byte by `BlockReopen`, so no rewrite can manufacture one — so the count strictly decreases.

Loose on purpose. A `class_eval` this expander declines (non-constant receiver, the string form) or the word inside a comment only inflates a ceiling the loop stops short of anyway, since it breaks as soon as a pass rewrites nothing. And it still terminates if some future rewrite stopped reducing, which is what a ceiling is really for.

## What costs a pass

Nesting, and only nesting — the second new example pins it: fifteen non-overlapping calls are rewritten **together**, because `outermost` already returns all of them and `apply_replacements` applies them back to front in one go. So the pass count tracks depth, never breadth.

## Tests

`bundle exec rspec` — 1391 examples, 0 failures. Two new examples: depth 12 converges and is idempotent (exactly where ten stopped), and the fifteen-sibling single pass.

No output changes below eleven nested reopenings, so the dummy needed no regeneration and no snapshot moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tbd58sK9A8yTcomRVLVmWT