### PR TITLE
Emit a module reopened at top level once, not once per spelling

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -665,7 +665,61 @@ module RbsInfer
     @is_module = visitor.is_module if @is_module.nil?
     @delegates = visitor.delegates
     @nested_modules = visitor.nested_modules
-    visitor.members
+    disown_promoted_modules(visitor.members)
+  end
+
+  # The members and declarations of a nested module the FILE gives a target of
+  # its own, dropped from this pass.
+  #
+  # One module, two spellings: `class A; module B; …` nests it, and
+  # `module A::B; …` written at top level in the same file reopens it. The two
+  # are the same module — Ruby merges them — but they reach the pipeline through
+  # different mechanisms. The nested one is emitted IN PLACE, inside `A`'s block,
+  # by the owner mechanism (felixefelip/rbs_infer#22); the top-level one is a
+  # declaration target of its own, and `LexicalScope` matches BOTH spellings for
+  # it, so its pass already collects everything either declaration says.
+  #
+  # Emitted from both, the file declares the module twice and every method the
+  # nested spelling wrote appears in both — which RBS rejects outright
+  # (`DuplicatedMethodDefinitionError` from `build_instance`, so it poisons the
+  # whole environment rather than the one file). Measured on a 20-line file with
+  # no DSL in it.
+  #
+  # This is the rule `LexicalScope` already states for a nested CLASS — "a nested
+  # class is its own target, so members inside one belong to that target's pass
+  # and are not this target's at all" — applied to the one case where a nested
+  # module is a target too. A module written ONLY nested has no other home and is
+  # untouched, which is every module in the dummy today.
+  def disown_promoted_modules(members)
+    promoted = promoted_module_targets
+    return members if promoted.empty?
+
+    @nested_modules = @nested_modules.reject { |owner| promoted?(owner, promoted) }
+    members.reject { |member| member.owner && promoted?(member.owner, promoted) }
+  end
+
+  # Modules under this target that the file declares at top level, fully
+  # qualified. Only that spelling can produce one: a module written nested is
+  # never promoted, which is what makes this set exactly "the modules with a
+  # second home".
+  def promoted_module_targets
+    return @promoted_module_targets if defined?(@promoted_module_targets)
+
+    discovery = RbsInfer::AST::TargetDiscovery.new
+    @parsed_target.tree.accept(discovery)
+    prefix = "#{@target_class}::"
+    @promoted_module_targets = discovery.declaration_targets
+                                        .select { |target| target[:is_module] && target[:name].start_with?(prefix) }
+                                        .map { |target| target[:name] }.to_set
+  end
+
+  # Whether an owner path — relative to this target, as members carry it — names
+  # a promoted module or something inside one. `Baz::Inner` goes with `Baz`: a
+  # module nested in a promoted one is emitted by ITS pass, the same way this
+  # target emits its own nested modules.
+  def promoted?(owner, promoted)
+    segments = owner.split("::")
+    (1..segments.size).any? { |count| promoted.include?("#{@target_class}::#{segments.take(count).join("::")}") }
   end
 
   def resolve_delegate_methods(target_members)

--- a/lib/rbs_infer/ast/target_discovery.rb
+++ b/lib/rbs_infer/ast/target_discovery.rb
@@ -73,8 +73,9 @@ module RbsInfer::AST
     # on the wrapper via
     # `ClassNameExtractor`, and adding it here would only flatten that nesting.
     def declaration_targets
-      real = @targets.reject { |t| t[:namespace] }
-      chosen = real.empty? ? real : @targets
+      kept = @targets.reject { |t| t[:namespace] && housed_elsewhere?(t) }
+      real = kept.reject { |t| t[:namespace] }
+      chosen = real.empty? ? real : kept
       chosen.map { |t| { name: t[:name], is_module: t[:is_module] } }
     end
 
@@ -98,13 +99,14 @@ module RbsInfer::AST
     end
 
     def record_declaration(node, is_module:)
-      wrapper = namespace_wrapper?(node)
-      return if wrapper && !hosts_orphan_module?(node)
-
       name = RbsInfer::Analyzer.extract_constant_path(node.constant_path)
       return unless name && !name.empty?
 
       qualified = (@namespace + [name]).join("::")
+
+      wrapper = namespace_wrapper?(node)
+      orphans = wrapper ? orphan_modules(node, qualified) : []
+      return if wrapper && orphans.empty?
 
       # ONE target per name, however many times the file reopens it. Ruby reopens a
       # class rather than redefining it, and a target's pass already collects members
@@ -118,13 +120,13 @@ module RbsInfer::AST
       # beside the one the file already writes.
       return if @targets.any? { |t| t[:name] == qualified }
 
-      @targets << { name: qualified, is_module: is_module, namespace: wrapper }
+      @targets << { name: qualified, is_module: is_module, namespace: wrapper, orphans: orphans }
     end
 
-    # A module declared directly in `node`'s body that has something of its own
-    # to emit — so the owner mechanism has to write it into `node`'s block,
-    # because a nested module is never a target of its own. That is what makes
-    # an otherwise droppable wrapper worth keeping.
+    # The modules declared inside `node` that have something of their own to
+    # emit — so the owner mechanism has to write them into `node`'s block,
+    # because a nested module is never a target of its own. Having any is what
+    # makes an otherwise droppable wrapper worth keeping.
     #
     # Recursive, because a namespace module can host one: `module Baz` holding
     # nothing but two empty modules is a wrapper by the rule above, and dropping
@@ -132,12 +134,30 @@ module RbsInfer::AST
     # a type, and it is the only place that type can be written
     # (felixefelip/rbs_infer#268). A nested CLASS never needs this: classes are
     # targets at any depth and emit their own block.
-    def hosts_orphan_module?(node)
-      node.body.body.any? do |stmt|
-        next false unless stmt.is_a?(Prism::ModuleNode)
+    #
+    # NAMES rather than a yes/no, because "is this module homeless" cannot be
+    # settled here: the file may reopen it at top level FURTHER DOWN, which
+    # gives it a target and a home of its own. That answer only exists once the
+    # walk is over, so the names travel to `declaration_targets`.
+    def orphan_modules(node, qualified)
+      node.body.body.flat_map do |stmt|
+        next [] unless stmt.is_a?(Prism::ModuleNode)
 
-        !namespace_wrapper?(stmt) || hosts_orphan_module?(stmt)
+        name = RbsInfer::Analyzer.extract_constant_path(stmt.constant_path)
+        next [] unless name && !name.empty?
+
+        child = "#{qualified}::#{name}"
+        namespace_wrapper?(stmt) ? orphan_modules(stmt, child) : [child]
       end
+    end
+
+    # Whether every module a wrapper is kept for has a target of its own, which
+    # is what a `module A::B` written at top level gives one. Then the wrapper is
+    # housing nobody: the module is emitted by its own pass, and keeping the
+    # wrapper would emit an empty block beside it — the very thing
+    # `namespace_wrapper?` exists to avoid.
+    def housed_elsewhere?(target)
+      target[:orphans].any? && target[:orphans].all? { |name| @targets.any? { |t| t[:name] == name } }
     end
 
     # A declaration whose body is nothing but other class/module declarations

--- a/spec/dummy/app/models/example49.rb
+++ b/spec/dummy/app/models/example49.rb
@@ -1,0 +1,25 @@
+class Example49
+  module Baz
+    def color
+      "yellow"
+    end
+  end
+
+  class Bar
+    extend Example49::Baz
+
+    def self.call_color
+      color.upcase
+    end
+
+    def self.call_age
+      age + 10
+    end
+  end
+end
+
+module Example49::Baz
+  def age
+    31
+  end
+end

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -350,6 +350,11 @@ app/models/example48.rb:
   - anchor: Foo
     annotations:
     - "# @type instance: singleton(Example48::Baz)"
+app/models/example49.rb:
+  modules:
+  - anchor: Baz
+    annotations:
+    - "# @type instance: singleton(Example49::Bar)"
 app/models/included_hook/home_made.rb:
   modules:
   - anchor: HomeMade

--- a/spec/dummy/sig/rbs_infer/app/models/example49.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example49.rbs
@@ -1,0 +1,15 @@
+class Example49
+  class Bar
+    extend ::Example49::Baz
+
+    def self.call_color: () -> String
+    def self.call_age: () -> Integer
+  end
+end
+
+class Example49
+  module Baz
+    def color: () -> String
+    def age: () -> Integer
+  end
+end

--- a/spec/expectations/models/example49.rbs
+++ b/spec/expectations/models/example49.rbs
@@ -1,0 +1,15 @@
+class Example49
+  class Bar
+    extend ::Example49::Baz
+
+    def self.call_color: () -> String
+    def self.call_age: () -> Integer
+  end
+end
+
+class Example49
+  module Baz
+    def color: () -> String
+    def age: () -> Integer
+  end
+end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -141,6 +141,22 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
                     target_file: "app/models/included_hook/slots.rb")
   end
 
+  # One module written both ways in one file: `class Example49; module Baz` nests it
+  # and `module Example49::Baz` reopens it at top level. Ruby merges the two, and so
+  # must the RBS — emitted from both mechanisms, the file declared `Baz` twice with
+  # `color` in each copy, which RBS rejects outright
+  # (`DuplicatedMethodDefinitionError`, raised by `build_instance` and so poisoning
+  # the whole environment rather than this file).
+  #
+  # The whole FILE, with no `target_class`: the bug lives in the multi-target path,
+  # which is what decides how many blocks a file emits and is skipped entirely when a
+  # single target is named. Its symptom is a second declaration, so a snapshot is
+  # what states it directly — the Steep baseline would catch the regression only as
+  # an environment-wide failure that names no file.
+  it "Example49 (a module reopened at top level) is declared once, not once per spelling" do
+    assert_snapshot("models/example49", target_file: "app/models/example49.rb")
+  end
+
   # `send` with a literal symbol reaching a PRIVATE method — how MRI itself invokes the
   # mixin hooks (`rb_funcall` ignores visibility, and `included`/`append_features` are
   # private on `Module`), which is why the `Module#include` pseudo-code spells them that

--- a/spec/lib/rbs_infer/ast/target_discovery_spec.rb
+++ b/spec/lib/rbs_infer/ast/target_discovery_spec.rb
@@ -309,4 +309,70 @@ RSpec.describe RbsInfer::AST::TargetDiscovery do
 
     expect(d.include_targets).to be_empty
   end
+  # One module, two spellings: `class A; module B` nests it and `module A::B`
+  # reopens it at top level. Ruby merges the two; the pipeline used to emit both
+  # — the nested one in place, inside `A`'s block, and the top-level one as a
+  # target of its own — so every method the nested spelling wrote was declared
+  # twice and RBS rejected the file (`DuplicatedMethodDefinitionError`).
+  #
+  # The top-level target is the one that keeps everything: `LexicalScope` matches
+  # BOTH spellings for it, so its pass collects what either declaration says.
+  context "a module the file writes both nested and at top level" do
+    def two_spellings(extra: "")
+      <<~RUBY
+        class ZzBoth
+          module Baz
+            def color; end
+          end
+          #{extra}
+        end
+
+        module ZzBoth::Baz
+          def age; end
+        end
+      RUBY
+    end
+
+    it "gives it one target" do
+      expect(discover(two_spellings).declaration_targets)
+        .to eq([{ name: "ZzBoth::Baz", is_module: true }])
+    end
+
+    # `ZzBoth` was kept only to host a module that had nowhere else to go. With
+    # the module housed by its own target it is a pure namespace again, and
+    # emitting it would add the empty block `namespace_wrapper?` exists to avoid.
+    it "drops the wrapper that was only housing it" do
+      expect(discover(two_spellings).declaration_targets.map { |t| t[:name] })
+        .not_to include("ZzBoth")
+    end
+
+    # The wrapper's other reasons to exist are untouched.
+    it "keeps the wrapper when it hosts a module with no other home" do
+      names = discover(two_spellings(extra: "module Other; def x; end; end")).declaration_targets.map { |t| t[:name] }
+
+      expect(names).to include("ZzBoth")
+    end
+
+    it "keeps a sibling class of its own" do
+      names = discover(two_spellings(extra: "class Bar; def x; end; end")).declaration_targets.map { |t| t[:name] }
+
+      expect(names).to include("ZzBoth::Bar", "ZzBoth::Baz")
+    end
+  end
+
+  # A module written only nested is emitted in place by the owner mechanism and
+  # is not a target — the rule this is all built on, unchanged.
+  it "gives a module written only nested no target of its own" do
+    d = discover(<<~RUBY)
+      class ZzOnce
+        module Baz
+          def color; end
+        end
+        def own; end
+      end
+    RUBY
+
+    expect(d.declaration_targets).to eq([{ name: "ZzOnce", is_module: false }])
+  end
+
 end


### PR DESCRIPTION
`class A; module B; …` and `module A::B; …` written in the same file are one module — Ruby merges them — but they reached the pipeline through two mechanisms that did not know about each other:

* the **nested** spelling is emitted IN PLACE, inside `A`'s block, by the owner mechanism (#22);
* the **top-level** spelling is a declaration target of its own, and `LexicalScope` matches *both* paths for it, so its pass already collects everything either declaration says.

Emitted from both, the file declares the module twice and every method the nested spelling wrote appears in both copies. RBS rejects that outright. Measured on the new fixture, before the fix:

```
RBS::DuplicatedMethodDefinitionError: ::Example49::Baz#color has duplicated
definitions in example49.rbs:18:4...18:27
```

`build_instance` raises for that type, so it poisons the whole environment rather than just the one file — the same failure `TargetDiscovery` already guards against for a class reopened twice, which is where the rule for classes is written down.

## The fix is that rule, extended

`LexicalScope` already states it for classes:

> a nested class is its own target, so members inside one belong to that target's pass and are not this target's at all

A nested module now gets the same treatment in the one case where it, too, has a target: when the file also declares it at top level. The enclosing pass disowns it — members and declaration both — and its own target emits it, complete.

The wrapper half goes along. `Example49` was kept as a target only to house a module with nowhere else to go; with the module housed by its own target, keeping the wrapper emits exactly the empty block `namespace_wrapper?` exists to avoid. That answer cannot be reached during the walk — the file may reopen the module *further down* — so `hosts_orphan_module?` now reports the orphans' NAMES and `declaration_targets` decides once the walk is over.

## Measured

`example49` is the fixture, and it needs no DSL — 24 lines of plain Ruby:

```rbs
 class Example49
-  module Baz
-    def color: () -> String
-  end
-end
-
-class Example49
   class Bar
     extend ::Example49::Baz
     def self.call_color: () -> String
     def self.call_age: () -> Integer
   end
 end

 class Example49
   module Baz
     def color: () -> String
     def age: () -> Integer
   end
 end
```

A module written only nested is untouched — which is every module in the dummy today. Nothing in the generated RBS moves, and the fixture adds **no** Steep diagnostic, so the baseline is unchanged. 5 new `TargetDiscovery` examples cover the one-target rule, the dropped wrapper, and the two ways a wrapper still earns its place. Full suite green (1421 examples).

## Why now

Found while scoping gap 2 of #268, whose replay is the first to relocate a block onto a MODULE and would have emitted invalid RBS on arrival. The bug is older and reproduces with no DSL involved, so it lands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012eSFCZnXyb2MXWHVYrTL1z