### PR TITLE
Pin the emitted RBS for every example fixture that had none

### DIFF
--- a/spec/expectations/models/example14.rbs
+++ b/spec/expectations/models/example14.rbs
@@ -1,0 +1,20 @@
+class Example14
+  @halted: true?
+  @user: Example14::User?
+
+  def run: () -> String?
+
+  private
+
+  def halt: () -> bool
+  def verify: () -> Example14::User
+  def set_user: () -> Example14::User
+end
+
+class Example14
+  class User
+    attr_reader name: String
+
+    def initialize: (name: String) -> void
+  end
+end

--- a/spec/expectations/models/example15.rbs
+++ b/spec/expectations/models/example15.rbs
@@ -1,0 +1,28 @@
+class Example15
+  @halted: true?
+
+  def run: () -> String?
+
+  private
+
+  def halt: () -> bool
+  def verify: () -> Example15::User
+  def set_user: () -> Example15::User
+end
+
+class Example15
+  class User
+    attr_reader name: String
+
+    def initialize: (name: String) -> void
+  end
+end
+
+class Example15
+  class Registry
+    self.@user: Example15::User?
+
+    def self.user: () -> Example15::User?
+    def self.user=: (User value) -> User
+  end
+end

--- a/spec/expectations/models/example16.rbs
+++ b/spec/expectations/models/example16.rbs
@@ -1,0 +1,33 @@
+class Example16
+  @halted: true?
+
+  def show: () -> String
+  def call: () -> String?
+
+  private
+
+  def authenticate: () -> (Example16::User | bool)
+  def resume: () -> Example16::User?
+  def from_token: () -> (Example16::User | bool)
+  def deny: () -> bool
+  def halt: () -> bool
+  def cookie?: () -> bool
+  def token?: () -> bool
+end
+
+class Example16
+  class User
+    attr_reader name: String
+
+    def initialize: (name: String) -> void
+  end
+end
+
+class Example16
+  class Registry
+    self.@user: Example16::User?
+
+    def self.user: () -> Example16::User?
+    def self.user=: (User value) -> User
+  end
+end

--- a/spec/expectations/models/example27.rbs
+++ b/spec/expectations/models/example27.rbs
@@ -1,0 +1,16 @@
+class Example27
+  module Foo
+    def bazinga: (singleton(::Example27::Baz) module_included) -> nil
+    def bazingado: (?singleton(Example27::Bar)? base_foo, ?message: String?) -> nil
+  end
+
+  module Baz
+    extend ::Example27::Foo
+  end
+end
+
+class Example27
+  class Bar
+    extend ::Example27::Foo
+  end
+end

--- a/spec/expectations/models/example31.rbs
+++ b/spec/expectations/models/example31.rbs
@@ -1,0 +1,29 @@
+class Example31
+  module Foo
+    attr_reader bazingado_block: untyped
+
+    def bazinga: (singleton(::Example31::Baz) module_included) -> untyped
+    def bazingado: () ?{ (*untyped) -> Symbol } -> (^(*untyped) -> Symbol)?
+  end
+
+  module Baz
+    extend ::Example31::Foo
+  end
+
+  module Age
+    def age: () -> Float
+  end
+
+  class AfterBazingado
+    attr_reader bazingado_block: (^(*untyped) -> Symbol)?
+  end
+end
+
+class Example31
+  class Bar
+    extend ::Example31::Foo
+    include ::Example31::Age
+
+    def age: () -> Float
+  end
+end

--- a/spec/expectations/models/example33.rbs
+++ b/spec/expectations/models/example33.rbs
@@ -1,0 +1,34 @@
+class Example33
+  module Foo
+    @_bazingado_block: (^(*untyped) [self: singleton(Example33::Bar) | singleton(Example33::BarOther)] -> Symbol)?
+
+    def bazinga: ((singleton(::Example33::Baz) | singleton(::Example33::BazOther)) module_included) -> (^(*untyped) [self: (singleton(Example33::Bar) | singleton(Example33::BarOther))] -> Symbol | nil | Symbol)
+    def bazingado: (?(singleton(Example33::Bar) | singleton(Example33::BarOther))? base) ?{ (*untyped) [self: (singleton(Example33::Bar) | singleton(Example33::BarOther))] -> Symbol } -> (^(*untyped) [self: (singleton(Example33::Bar) | singleton(Example33::BarOther))] -> Symbol | nil | Symbol)
+  end
+
+  module Baz
+    extend ::Example33::Foo
+  end
+
+  module BazOther
+    extend ::Example33::Foo
+  end
+end
+
+class Example33
+  class Bar
+    extend ::Example33::Foo
+
+    def age: () -> Integer
+  end
+end
+
+class Example33
+  class BarOther
+    extend ::Example33::Foo
+
+    def name: () -> String
+    def call_name_upcase: () -> String
+    def name_upcase: () -> String
+  end
+end

--- a/spec/expectations/models/example34.rbs
+++ b/spec/expectations/models/example34.rbs
@@ -1,0 +1,21 @@
+class Example34
+  module Foo
+    @_bazingado_block: (^(*untyped) [self: singleton(Example34::Bar) | singleton(Example34::Baz) | Module] -> Symbol)?
+
+    def include: (*singleton(::Example34::Baz) modules) -> Array[singleton(Example34::Baz)]
+    def included: (?(singleton(Example34::Bar) | singleton(Example34::Baz) | Module)? base) ?{ (*untyped) [self: (singleton(Example34::Bar) | singleton(Example34::Baz) | Module)] -> Symbol } -> (^(*untyped) [self: (singleton(Example34::Bar) | singleton(Example34::Baz) | Module)] -> Symbol | nil | Symbol)
+  end
+
+  module Baz
+    extend ::Example34::Foo
+  end
+end
+
+class Example34
+  class Bar
+    extend ::Example34::Foo
+    include ::Example34::Baz
+
+    def age: () -> Integer
+  end
+end

--- a/spec/expectations/models/example35.rbs
+++ b/spec/expectations/models/example35.rbs
@@ -1,0 +1,20 @@
+class Example35
+  class Foo
+    self.@_bazingado_block: (^(*untyped) [self: singleton(Example35::Foo)] -> Symbol)?
+
+    def self.bazinga: (singleton(::Example35::Baz) module_included) -> (^(*untyped) [self: singleton(Example35::Foo)] -> Symbol | nil | Symbol)
+    def self.bazingado: (?singleton(Example35::Foo)? base) ?{ (*untyped) [self: singleton(Example35::Foo)] -> Symbol } -> (^(*untyped) [self: singleton(Example35::Foo)] -> Symbol | nil | Symbol)
+  end
+end
+
+class Example35
+  class Baz < ::Example35::Foo
+  end
+end
+
+class Example35
+  class Bar < Baz
+    def call_age: () -> Integer
+    def age: () -> Integer
+  end
+end

--- a/spec/expectations/models/example36.rbs
+++ b/spec/expectations/models/example36.rbs
@@ -1,0 +1,20 @@
+class Example36
+  class Foo
+    self.@_bazingado_block: (^(*untyped) [self: singleton(Example36::Foo)] -> Symbol)?
+
+    def self.bazinga: (*singleton(::Example36::Baz) modules) -> Array[singleton(Example36::Baz)]
+    def self.bazingado: (?singleton(Example36::Foo)? base) ?{ (*untyped) [self: singleton(Example36::Foo)] -> Symbol } -> (^(*untyped) [self: singleton(Example36::Foo)] -> Symbol | nil | Symbol)
+  end
+end
+
+class Example36
+  class Baz < ::Example36::Foo
+  end
+end
+
+class Example36
+  class Bar < Baz
+    def call_age: () -> Integer
+    def age: () -> Integer
+  end
+end

--- a/spec/expectations/models/example37.rbs
+++ b/spec/expectations/models/example37.rbs
@@ -1,0 +1,23 @@
+class Example37
+  module Foo
+    @_bazingado_block: (^(*untyped) [self: singleton(Example37::Bar)] -> Symbol)?
+
+    def bazinga: (*singleton(::Example37::Baz) modules) -> Array[singleton(Example37::Baz)]
+    def bazingado: (?singleton(Example37::Bar)? base) ?{ (*untyped) [self: singleton(Example37::Bar)] -> Symbol } -> (^(*untyped) [self: singleton(Example37::Bar)] -> Symbol | nil | Symbol)
+  end
+end
+
+class Example37
+  class Baz
+    extend ::Example37::Foo
+  end
+end
+
+class Example37
+  class Bar
+    extend ::Example37::Foo
+
+    def call_age: () -> Integer
+    def age: () -> Integer
+  end
+end

--- a/spec/expectations/models/example38.rbs
+++ b/spec/expectations/models/example38.rbs
@@ -1,0 +1,33 @@
+class Example38
+  module Foo
+    @_bazingado_block: (^(*untyped) [self: singleton(Example38::Bar)] -> Symbol)?
+
+    def bazinga: (*(singleton(::Example38::Baz) | singleton(::Example38::BazOther)) modules) -> Array[(singleton(Example38::Baz) | singleton(Example38::BazOther))]
+
+    private
+
+    def bazingado: (?singleton(Example38::Bar)? base) ?{ (*untyped) [self: singleton(Example38::Bar)] -> Symbol } -> (^(*untyped) [self: singleton(Example38::Bar)] -> Symbol | nil | Symbol)
+  end
+end
+
+class Example38
+  class Baz
+    extend ::Example38::Foo
+  end
+end
+
+class Example38
+  class BazOther
+    extend ::Example38::Foo
+  end
+end
+
+class Example38
+  class Bar
+    extend ::Example38::Foo
+
+    def call_age: () -> Integer
+    def age: () -> Integer
+    def name: () -> String
+  end
+end

--- a/spec/expectations/models/example39.rbs
+++ b/spec/expectations/models/example39.rbs
@@ -1,0 +1,21 @@
+module Example39
+  module Foo
+    @_bananed_block: (^(*untyped) [self: Module] -> Symbol)?
+
+    private
+
+    def bananed: (?untyped base) ?{ (*untyped) [self: Module] -> Symbol } -> (^(*untyped) [self: Module] -> Symbol | nil | Symbol)
+  end
+
+  module Baz
+    extend ::Example39::Foo
+  end
+end
+
+module Example39
+  class Bar
+    extend ::Example39::Foo
+
+    def call_age: () -> Integer
+  end
+end

--- a/spec/expectations/models/example40.rbs
+++ b/spec/expectations/models/example40.rbs
@@ -1,0 +1,41 @@
+class Example40
+  module Foo
+    @_bazingado_holder: Example40::Bazinga?
+
+    def bazinga: (*(singleton(::Example40::Baz) | singleton(::Example40::BazOther)) modules) -> Array[(singleton(Example40::Baz) | singleton(Example40::BazOther))]
+
+    private
+
+    def bazingado: (?singleton(Example40::Bar)? base) ?{ (*untyped) -> Symbol } -> (^(*untyped) -> Symbol)?
+  end
+end
+
+class Example40
+  class Bazinga
+    @_bazingado_block: (^(*untyped) -> Symbol)?
+
+    def bazingado: (?untyped base) ?{ (*untyped) -> Symbol } -> (^(*untyped) -> Symbol)?
+  end
+end
+
+class Example40
+  class Baz
+    extend ::Example40::Foo
+  end
+end
+
+class Example40
+  class BazOther
+    extend ::Example40::Foo
+  end
+end
+
+class Example40
+  class Bar
+    extend ::Example40::Foo
+
+    def call_age: () -> Integer
+    def age: () -> Integer
+    def name: () -> String
+  end
+end

--- a/spec/expectations/models/example41.rbs
+++ b/spec/expectations/models/example41.rbs
@@ -1,0 +1,20 @@
+class Example41
+  module Foo
+    @_bazingado_block: (^(*untyped) [self: Module] -> Symbol)?
+
+    def included: (?Module? base) ?{ (*untyped) [self: Module] -> Symbol } -> (^(*untyped) [self: Module] -> Symbol | nil | Symbol)
+  end
+
+  module Baz
+    extend ::Example41::Foo
+  end
+end
+
+class Example41
+  class Bar
+    extend ::Example41::Foo
+    include ::Example41::Baz
+
+    def age: () -> Integer
+  end
+end

--- a/spec/expectations/models/example42.rbs
+++ b/spec/expectations/models/example42.rbs
@@ -1,0 +1,35 @@
+class Example42
+  module Foo
+    @_bazingado_block: (^(*untyped) [self: singleton(Example42::Bar) | singleton(Example42::BarOther)] -> Symbol)?
+
+    def bazinga: (*singleton(::Example42::Baz) modules) -> Array[singleton(Example42::Baz)]
+
+    private
+
+    def bazingado: (?(singleton(Example42::Bar) | singleton(Example42::BarOther))? base) ?{ (*untyped) [self: (singleton(Example42::Bar) | singleton(Example42::BarOther))] -> Symbol } -> (^(*untyped) [self: (singleton(Example42::Bar) | singleton(Example42::BarOther))] -> Symbol | nil | Symbol)
+  end
+end
+
+class Example42
+  class Baz
+    extend ::Example42::Foo
+  end
+end
+
+class Example42
+  class Bar
+    extend ::Example42::Foo
+
+    def call_age: () -> Integer
+    def age: () -> Integer
+  end
+end
+
+class Example42
+  class BarOther
+    extend ::Example42::Foo
+
+    def call_age: () -> Integer
+    def age: () -> Integer
+  end
+end

--- a/spec/expectations/models/example43.rbs
+++ b/spec/expectations/models/example43.rbs
@@ -1,0 +1,52 @@
+class Example43
+  module Foo
+    @_bazingado_block: (^(*untyped) [self: singleton(Example43::Bar) | singleton(Example43::BarOther) | singleton(Example43::BarOther2)] -> Symbol)?
+
+    def bazinga: (*(singleton(::Example43::Baz) | singleton(::Example43::BazOther)) modules) -> Array[(singleton(Example43::Baz) | singleton(Example43::BazOther))]
+
+    private
+
+    def bazingado: (?(singleton(Example43::Bar) | singleton(Example43::BarOther) | singleton(Example43::BarOther2))? base) ?{ (*untyped) [self: (singleton(Example43::Bar) | singleton(Example43::BarOther) | singleton(Example43::BarOther2))] -> Symbol } -> (^(*untyped) [self: (singleton(Example43::Bar) | singleton(Example43::BarOther) | singleton(Example43::BarOther2))] -> Symbol | nil | Symbol)
+  end
+end
+
+class Example43
+  class Baz
+    extend ::Example43::Foo
+  end
+end
+
+class Example43
+  class BazOther
+    extend ::Example43::Foo
+  end
+end
+
+class Example43
+  class Bar
+    extend ::Example43::Foo
+
+    def call_age: () -> Integer
+    def age: () -> Integer
+  end
+end
+
+class Example43
+  class BarOther
+    extend ::Example43::Foo
+
+    def call_age: () -> Integer
+    def age: () -> Integer
+  end
+end
+
+class Example43
+  class BarOther2
+    extend ::Example43::Foo
+
+    def call_age: () -> Integer
+    def call_name: () -> String
+    def age: () -> Integer
+    def name: () -> String
+  end
+end

--- a/spec/expectations/models/example44.rbs
+++ b/spec/expectations/models/example44.rbs
@@ -1,0 +1,31 @@
+class Example44
+  module Foo
+    @_bazingado_block: (^(*untyped) [self: Module] -> Symbol)?
+
+    def included: (?Module? base) ?{ (*untyped) [self: Module] -> Symbol } -> (^(*untyped) [self: Module] -> Symbol | nil | Symbol)
+  end
+
+  module Baz
+    extend ::Example44::Foo
+  end
+end
+
+class Example44
+  class Bar
+    extend ::Example44::Foo
+    include ::Example44::Baz
+
+    def call_age: () -> Integer
+    def age: () -> Integer
+  end
+end
+
+class Example44
+  class BarOther
+    extend ::Example44::Foo
+    include ::Example44::Baz
+
+    def call_age: () -> Integer
+    def age: () -> Integer
+  end
+end

--- a/spec/expectations/models/example45.rbs
+++ b/spec/expectations/models/example45.rbs
@@ -1,0 +1,30 @@
+class Example45
+  module Foo
+    @_banana_block: (^(*untyped) [self: Class] -> Symbol)?
+
+    def banana_class_method: () ?{ (*untyped) [self: Class] -> Symbol } -> (^(*untyped) [self: Class] -> Symbol)?
+    def included: (Module base) -> Symbol?
+  end
+
+  module Baz
+    extend ::Example45::Foo
+  end
+end
+
+class Example45
+  class Bar
+    include ::Example45::Baz
+
+    def self.call_age: () -> Integer
+    def self.age: () -> Integer
+  end
+end
+
+class Example45
+  class BarOther
+    include ::Example45::Baz
+
+    def self.call_age: () -> Integer
+    def self.age: () -> Integer
+  end
+end

--- a/spec/expectations/models/example46.rbs
+++ b/spec/expectations/models/example46.rbs
@@ -1,0 +1,17 @@
+class Example46
+  module Baz
+  end
+
+  module Baz::BananaWritten
+  end
+
+  module Baz::BananaDynamic
+  end
+end
+
+class Example46
+  class Bar
+    def written: () -> singleton(Example46::Baz::BananaWritten)
+    def dynamic: () -> singleton(Example46::Baz::BananaDynamic)
+  end
+end

--- a/spec/expectations/models/example47.rbs
+++ b/spec/expectations/models/example47.rbs
@@ -1,0 +1,22 @@
+class Example47
+  module Foo
+    def banana_class_method: () ?{ (*untyped) -> Symbol } -> untyped
+  end
+
+  module Baz
+    extend ::Example47::Foo
+  end
+
+  module Baz::BananaMethods
+    def color: () -> String
+  end
+end
+
+class Example47
+  class Bar
+    extend ::Example47::Baz::BananaMethods
+
+    def self.call_color: () -> String
+    def self.call_age: () -> untyped
+  end
+end

--- a/spec/expectations/models/example48.rbs
+++ b/spec/expectations/models/example48.rbs
@@ -1,0 +1,22 @@
+class Example48
+  module Foo
+    def included: (Module base) -> Module
+  end
+
+  module Baz
+    extend ::Example48::Foo
+  end
+
+  module Baz::BananaMethods
+    def age: () -> Integer
+  end
+end
+
+class Example48
+  class Bar
+    extend ::Example48::Baz::BananaMethods
+    include ::Example48::Baz
+
+    def self.call_age: () -> Integer
+  end
+end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -157,6 +157,90 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     assert_snapshot("models/example49", target_file: "app/models/example49.rb")
   end
 
+  it "example14 (a halt check whose establisher always runs) matches expected RBS" do
+    assert_snapshot("models/example14", target_file: "app/models/example14.rb")
+  end
+
+  it "example15 (the same, established through a class-level registry) matches expected RBS" do
+    assert_snapshot("models/example15", target_file: "app/models/example15.rb")
+  end
+
+  it "example16 (the authentication chain in the shape an app writes it) matches expected RBS" do
+    assert_snapshot("models/example16", target_file: "app/models/example16.rb")
+  end
+
+  it "example27 (nil defaults on a DSL method whose parameters arrive by two routes) matches expected RBS" do
+    assert_snapshot("models/example27", target_file: "app/models/example27.rb")
+  end
+
+  it "example31 (a replayed block whose `super` resolves against the includer's chain) matches expected RBS" do
+    assert_snapshot("models/example31", target_file: "app/models/example31.rb")
+  end
+
+  it "example33 (two DSL pairs in one file, each block belonging to its own source) matches expected RBS" do
+    assert_snapshot("models/example33", target_file: "app/models/example33.rb")
+  end
+
+  it "example34 (`Module#include` reopened by the DSL, replaying `included do`) matches expected RBS" do
+    assert_snapshot("models/example34", target_file: "app/models/example34.rb")
+  end
+
+  it "example35 (a `def self.` DSL reached by inheritance) matches expected RBS" do
+    assert_snapshot("models/example35", target_file: "app/models/example35.rb")
+  end
+
+  it "example36 (the same, with an applier taking `*modules`) matches expected RBS" do
+    assert_snapshot("models/example36", target_file: "app/models/example36.rb")
+  end
+
+  it "example37 (a `*modules` applier reached by `extend`) matches expected RBS" do
+    assert_snapshot("models/example37", target_file: "app/models/example37.rb")
+  end
+
+  it "example38 (an applier reaching a private storage through `send`) matches expected RBS" do
+    assert_snapshot("models/example38", target_file: "app/models/example38.rb")
+  end
+
+  it "example39 (an applier written as a core reopening in another file) matches expected RBS" do
+    assert_snapshot("models/example39", target_file: "app/models/example39.rb")
+  end
+
+  it "example40 (a DSL that delegates to a holder object it memoizes) matches expected RBS" do
+    assert_snapshot("models/example40", target_file: "app/models/example40.rb")
+  end
+
+  it "example41 (a hand-rolled `included do`, hook and storage in one method) matches expected RBS" do
+    assert_snapshot("models/example41", target_file: "app/models/example41.rb")
+  end
+
+  it "example42 (one source applied by two classes) matches expected RBS" do
+    assert_snapshot("models/example42", target_file: "app/models/example42.rb")
+  end
+
+  it "example43 (three appliers over two sources, one applying both) matches expected RBS" do
+    assert_snapshot("models/example43", target_file: "app/models/example43.rb")
+  end
+
+  it "example44 (`included do` with the deref in each includer) matches expected RBS" do
+    assert_snapshot("models/example44", target_file: "app/models/example44.rb")
+  end
+
+  it "example45 (a replay onto the target's singleton, landing class methods) matches expected RBS" do
+    assert_snapshot("models/example45", target_file: "app/models/example45.rb")
+  end
+
+  it "example46 (a constant filled with a fresh module, written and `const_set`) matches expected RBS" do
+    assert_snapshot("models/example46", target_file: "app/models/example46.rb")
+  end
+
+  it "example47 (`const_get(:X).module_eval(&block)`, the gap #268 still has open) matches expected RBS" do
+    assert_snapshot("models/example47", target_file: "app/models/example47.rb")
+  end
+
+  it "example48 (`base.extend(const_get(:X))` in a hook, landing the extend on the host) matches expected RBS" do
+    assert_snapshot("models/example48", target_file: "app/models/example48.rb")
+  end
+
   # `send` with a literal symbol reaching a PRIVATE method — how MRI itself invokes the
   # mixin hooks (`rb_funcall` ignores visibility, and `included`/`append_features` are
   # private on `Module`), which is why the `Module#include` pseudo-code spells them that


### PR DESCRIPTION
Everything from `example33` up, plus five older gaps (14, 15, 16, 27, 31), had no RBS expectation — twenty-one fixtures, most of them the stored-block replay family that #251 through #268 were written against. They were pinned only by `steep_baseline.txt` and by the generated copy under `spec/dummy/sig/rbs_infer/` that no spec compares.

## Why the baseline is the wrong pin for these

It records **diagnostics**. The failure these fixtures exist to catch is a type quietly degrading to `untyped`, or a method landing on the wrong class — neither of which Steep reports at all. If the replay stopped firing, `def self.age` would simply leave `Example45::Bar` and nothing would go red: a class that declares no method and never calls it is not an error anywhere.

`example49` showed the other half of the problem. Its duplicated declaration surfaced only as an RBS `DuplicatedMethodDefinitionError` that names no file and takes the whole environment down with it (#274) — a true failure, and useless as a signal about which fixture moved.

## Shape

The whole FILE in every case, with no `target_class`. These are multi-target fixtures — a DSL module, its sources, its appliers — and naming a single target skips the path that decides how many blocks a file emits, which is where several of them broke.

One `it` per fixture, from a table naming what each shape varies, so a failure says which fixture and what it is about:

```ruby
"example40" => "a DSL that delegates to a holder object it memoizes",
"example41" => "a hand-rolled `included do`, hook and storage in one method",
"example42" => "one source applied by two classes",
```

## Two of them record a gap, on purpose

`example47`'s `call_age: () -> untyped` is gap 2 of #268, still open, and its `age` is still missing from `BananaMethods`. Recording that is the point — a snapshot is how a gap stops moving without anyone noticing, and the PR that closes it will show the fix in the diff instead of having to argue it.

## Verification

Generated with `UPDATE_EXPECTATIONS=1`, then re-run clean to confirm they reproduce. Integration 123 examples, full suite 1443 examples, 0 failures. No production code touched; nothing in the generated RBS moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012eSFCZnXyb2MXWHVYrTL1z