### PR TITLE
Derive the self of a module a hook hands to the host

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -98,7 +98,8 @@ module RbsInfer
     # `class_eval`/`module_eval` on another. The contextual expander moves its
     # body to that statically resolved receiver before the ordinary collector
     # attributes the `def`s to the lexical source object (rbs_infer#238).
-    replay_expanded = RbsInfer::Project::StoredBlockReplayExpander.expand(source, sources: @corpus.constant_sources)
+    replay_expanded = RbsInfer::Project::StoredBlockReplayExpander.expand(source, sources: @corpus.constant_sources,
+                                                                          mixin_index: mixin_index)
     if replay_expanded
       @expanded_source = replay_expanded
       source = replay_expanded

--- a/lib/rbs_infer/extensions/rails/module_self_type_generator.rb
+++ b/lib/rbs_infer/extensions/rails/module_self_type_generator.rb
@@ -111,7 +111,8 @@ module RbsInfer
         # for — so it is the only half that needs the extractor, and a file with
         # no primary declaration can still contribute the first half.
         def blocks_for(abs, rel, source)
-          RbsInfer::Project::StoredBlockReplayImplements.blocks_for(source: source, sources: constant_sources) +
+          RbsInfer::Project::StoredBlockReplayImplements.blocks_for(source: source, sources: constant_sources,
+                                                                     mixin_index: mixin_index) +
             class_methods_blocks_for(abs, rel, source)
         end
 

--- a/lib/rbs_infer/project/block_reopen.rb
+++ b/lib/rbs_infer/project/block_reopen.rb
@@ -43,6 +43,12 @@ module RbsInfer::Project
       Prism::InterpolatedMatchLastLineNode
     ].freeze
 
+    # @param annotations [Array<String>] `@type` comment lines to place at the
+    #   top of the reopening's body. A block moved into a module the host is
+    #   HANDED runs its bodies on the host's class object, and nothing in the
+    #   reopening says so — see `StoredBlockReplayExpander#annotations_for`.
+    #   Empty for every other relocation, which needs none.
+    #
     # @param singleton [Boolean] whether the block was replayed onto the
     #   target's SINGLETON — `Target.singleton_class.class_eval` rather than
     #   `Target.class_eval` — in which case the body is nested one level deeper,
@@ -55,11 +61,15 @@ module RbsInfer::Project
     #
     # @return [String, nil] a top-level reopening, or nil for a block with no
     #   body — which relocates to nothing, and whose `location` would raise.
-    def appended(source:, block:, kind:, target:, singleton:)
+    def appended(source:, block:, kind:, target:, singleton:, annotations: [])
       body = block.body
       return nil unless body
 
-      return "#{kind} #{target}\n#{body_source(source, body, indent: INDENT)}\nend\n" unless singleton
+      lines = annotations.map { |annotation| "#{INDENT}#{annotation}" }
+
+      unless singleton
+        return ["#{kind} #{target}", *lines, body_source(source, body, indent: INDENT), "end\n"].join("\n")
+      end
 
       # `class << self` rather than rewriting each `def x` into `def self.x`:
       # the body is moved BYTE FOR BYTE everywhere else in this module — that is
@@ -67,6 +77,7 @@ module RbsInfer::Project
       # one spelling that needs no edit inside it.
       [
         "#{kind} #{target}",
+        *lines,
         "#{INDENT}class << self",
         body_source(source, body, indent: INDENT * 2),
         "#{INDENT}end",

--- a/lib/rbs_infer/project/stored_block_replay_expander.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander.rb
@@ -81,7 +81,13 @@ module RbsInfer::Project
     # target and differ only in that, which is the difference between the RBS
     # reading `def age` and reading `def self.age`
     # (felixefelip/rbs_infer#267).
-    Replay = Data.define(:target, :block, :kind, :call, :scope, :in_method, :source, :singleton)
+    # `extended` says the target is reached by EXTENDING whoever mixes the
+    # scope in, rather than by being the scope itself: a hook in the scope's
+    # provider chain hands its base this very module. It changes nothing about
+    # where the block's `def`s go — that is `target` — and everything about the
+    # `self` they run with, which is then the host's class object rather than an
+    # instance of the module (felixefelip/rbs_infer#268).
+    Replay = Data.define(:target, :block, :kind, :call, :scope, :in_method, :source, :singleton, :extended)
 
     module_function
 
@@ -90,7 +96,7 @@ module RbsInfer::Project
     # `ConstantSources::NONE` as the explicit way to say "no project": defaulted,
     # a caller that forgot it would quietly resolve less
     # (docs/engineering/required-threaded-deps.md).
-    def expand(source, sources:)
+    def expand(source, sources:, mixin_index:)
       # This file's own text is no longer the whole question. A concern writes
       # `base.class_eval do … end` in its own file and the `include` naming the
       # target is written in the host, which mentions no eval — so gating on the
@@ -110,10 +116,10 @@ module RbsInfer::Project
       extensions = collector.extensions
       return nil if replays.empty? && extensions.empty?
 
-      apply_replays(source, replays, extensions)
+      apply_replays(source, replays, extensions, mixin_index)
     end
 
-    def apply_replays(source, replays, extensions)
+    def apply_replays(source, replays, extensions, mixin_index)
       # A body-less block (`keep do end`) relocates to nothing, and asking it
       # for a location raises. Drop it before the uniqueness check reads one.
       replays = replays.select { |replay| replay.block.body }
@@ -141,13 +147,56 @@ module RbsInfer::Project
       # against the file being expanded cuts unrelated text.
       virtual_reopens = replays.filter_map do |replay|
         BlockReopen.appended(source: replay.source, block: replay.block, kind: replay.kind, target: replay.target,
-                             singleton: replay.singleton)
+                             singleton: replay.singleton, annotations: annotations_for(replay, mixin_index))
       end
       virtual_reopens += extensions.map { |extension| extension_reopen(extension) }
       virtual_reopens = BlockReopen.missing_from(source, virtual_reopens)
       return nil if virtual_reopens.empty?
 
       [source, virtual_reopens.join("\n")].join("\n")
+    end
+
+    # The `@type instance:` line a relocated block needs, or none.
+    #
+    # A block moved onto a class needs nothing: its `def`s are members of that
+    # class and their self is an instance of it, which the reopening already
+    # says. One moved into a module the host is HANDED — a hook doing
+    # `base.extend(M)` — needs it: those bodies run on the host's class object,
+    # and without saying so every call they make to one of the host's own class
+    # methods resolves to nothing (felixefelip/rbs_infer#268).
+    #
+    # Written into the reopening rather than injected afterwards, because the
+    # reopening is where it belongs and because `ModuleSelfTypes.inject` cannot
+    # place it: its anchor puts lines inside a NESTED module's body, and this
+    # one is compact and top-level, so the annotation would land at end of file
+    # bound to nothing.
+    def annotations_for(replay, mixin_index)
+      parts = running_selves(replay, mixin_index)
+      return [] if parts.empty?
+
+      ["# @type instance: #{union(parts)}"]
+    end
+
+    # The selves a handed-out module's methods run with — `singleton(<host>) & <module>`,
+    # one per class the mixin graph says mixes the scope in.
+    #
+    # Both terms earn their place. The singleton is where the host's own class
+    # methods live, which is what these bodies reach for; the module keeps calls
+    # BETWEEN the block's own methods resolving, whether or not the host's RBS
+    # ends up naming it.
+    #
+    # One derivation, two consumers: this is also what the `blocks:` sidecar
+    # records for `steep check`, and the two must not disagree about the self a
+    # method has (see `StoredBlockReplayImplements`).
+    def running_selves(replay, mixin_index)
+      return [] unless replay.extended
+
+      mixin_index.hosts_of(replay.scope).map { |host| "singleton(::#{host}) & ::#{replay.target}" }
+    end
+
+    # An intersection is only legal bare, so a union of them parenthesizes each.
+    def union(parts)
+      parts.size == 1 ? parts.first : parts.map { |part| "(#{part})" }.join(" | ")
     end
 
     # The reopening an inward `extend` stands for. Not a `BlockReopen`: there is

--- a/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
@@ -1025,7 +1025,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
         replays = @resolved_own_replays.select { |own| own.owner == provider && own.method == stored.method }
         next unless replays.size == 1
 
-        replay_where_written(stored, replays.first)
+        replay_where_written(stored, replays.first, providers)
       end.uniq
 
       # Two providers answering one call with two different targets is one
@@ -1040,7 +1040,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # `self` inside the DSL method is the SUBJECT — the class or module whose
     # body wrote the call — so that is both the target when the DSL replays onto
     # its own `self` and the namespace a `const_get` is looked up under.
-    def replay_where_written(stored, own)
+    def replay_where_written(stored, own, providers)
       target = own.name ? named_constant(own, stored.subject) : stored.subject
       return nil unless target
 
@@ -1052,7 +1052,26 @@ module RbsInfer::Project::StoredBlockReplayExpander
       return nil unless kind
 
       Replay.new(target: target, block: stored.block, kind: kind, call: stored.method,
-                 scope: stored.subject, in_method: nil, source: stored.source, singleton: own.singleton)
+                 scope: stored.subject, in_method: nil, source: stored.source, singleton: own.singleton,
+                 extended: handed_to_hosts?(target, stored.subject, providers))
+    end
+
+    # Whether a hook in `subject`'s provider chain hands this very module to
+    # whoever mixes the subject in — `base.extend(const_get(:X))`, the other half
+    # of what a concern does.
+    #
+    # Read from the SUBJECT's side, where the `include` naming the hosts is
+    # written in their files rather than this one: what this file can say is that
+    # the module is handed out, and to whom is the mixin graph's answer. Both
+    # halves are needed and neither is a guess — the extend is read off the
+    # provider's own source, exactly as `resolve_extensions` reads it from the
+    # host's side.
+    def handed_to_hosts?(target, subject, providers)
+      owners = providers.select { |_, subjects| subjects.include?(subject) }.keys
+
+      @resolved_inward_extends.any? do |extension|
+        owners.include?(extension.owner) && named_constant(extension, subject) == target
+      end
     end
 
     # The one block `apply` relocates, or nil when the file does not decide it.
@@ -1272,7 +1291,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
       if (literal = literals.first)
         return Replay.new(target: apply.subject, block: literal.block, kind: kind,
                           call: literal.call, scope: literal.scope, in_method: literal.method,
-                          source: literal.source, singleton: literal.singleton)
+                          source: literal.source, singleton: literal.singleton, extended: false)
       end
 
       storage_owner, ivar, singleton = slots.first
@@ -1286,7 +1305,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
 
       Replay.new(target: apply.subject, block: blocks.first.block, kind: kind,
                  call: storage_method, scope: blocks.first.subject, in_method: nil,
-                 source: blocks.first.source, singleton: singleton)
+                 source: blocks.first.source, singleton: singleton, extended: false)
     end
 
     # Which classes/modules can call each owner's DSL, as `owner => subjects`.

--- a/lib/rbs_infer/project/stored_block_replay_implements.rb
+++ b/lib/rbs_infer/project/stored_block_replay_implements.rb
@@ -46,12 +46,19 @@ module RbsInfer::Project
     # line measured against the real file no longer points at the same call by
     # the time the block entries are read. A scope survives that rewrite.
     #
-    # No `self` key: `@implements <Target>` already runs the block's `def`
-    # bodies with an instance of `<Target>` as self, which is what a
-    # `class_eval`ed def gets at runtime. The `class_methods do` entries need
-    # that key because their self is the INCLUDER's singleton, a type the
-    # `@implements` module does not name.
-    def blocks_for(source:, sources:)
+    # A `self` key only where `@implements` is not the whole answer. For a
+    # `class_eval`ed block it is: the bodies run with an instance of `<Target>`,
+    # which is what they get at run time. For a block whose target is HANDED to
+    # the host — a hook doing `base.extend(M)` — it is not: the bodies run on
+    # the host's class object, where the host's own class methods live, and
+    # naming only `M` type-checks them against a self they never have.
+    #
+    # `mixin_index` is required for that, with no default. The hosts are the
+    # other half of the answer and they are written in THEIR files, not this
+    # one; a caller that forgot to thread it would emit an entry that is right
+    # about the module and silent about the self, which is the silent-wrong case
+    # (docs/engineering/required-threaded-deps.md).
+    def blocks_for(source:, sources:, mixin_index:)
       return [] unless source.include?("class_eval") || source.include?("module_eval")
 
       parsed = Prism.parse(source)
@@ -64,6 +71,9 @@ module RbsInfer::Project
         next unless replay.scope
 
         entry = { "call" => replay.call, "in" => "::#{replay.scope}", "implements" => implements(entries) }
+        if (running_self = handed_self(entries, mixin_index))
+          entry["self"] = running_self
+        end
         # Only for a block written inside a def. Emitting it as nil for the DSL
         # shape would put a key in every sidecar entry ever written, to say
         # nothing.
@@ -115,6 +125,23 @@ module RbsInfer::Project
     # so the singleton half of a `class_methods`-shaped DSL had no annotation to
     # write and its `def`s were read where they are written
     # (felixefelip/rbs_infer#267).
+    # The self a handed-out module's methods actually run with, for `steep
+    # check` to read.
+    #
+    # `StoredBlockReplayExpander.running_selves` is the derivation, called
+    # rather than repeated: the expander writes the same answer into the
+    # reopening it emits, and the two must not disagree about the self one
+    # method has. Nothing when no replay here is handed out, and nothing when
+    # the mixin graph names no host — an unmixed module's methods run with a
+    # self this pass cannot state, and naming the module alone would be a wrong
+    # answer rather than a partial one.
+    def handed_self(entries, mixin_index)
+      parts = entries.flat_map { |replay| StoredBlockReplayExpander.running_selves(replay, mixin_index) }.uniq
+      return nil if parts.empty?
+
+      StoredBlockReplayExpander.union(parts)
+    end
+
     def name_for(replay)
       replay.singleton ? "singleton(::#{replay.target})" : "::#{replay.target}"
     end

--- a/spec/dummy/sig/generated/.steep_contracts.yml
+++ b/spec/dummy/sig/generated/.steep_contracts.yml
@@ -133,23 +133,6 @@ methods:
           kind: self
         method: ticket
     enforced: false
-  Example53::Baz#age:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: origin
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: origin
-        chain:
-        - length
-    enforced: false
   Post#author_name:
     requires:
     - kind: not_nil

--- a/spec/dummy/sig/generated/.steep_module_self_types.yml
+++ b/spec/dummy/sig/generated/.steep_module_self_types.yml
@@ -392,6 +392,7 @@ app/models/example52.rb:
   - call: banana_class_method
     in: "::Example52::Baz"
     implements: "::Example52::Baz::BananaMethods"
+    self: singleton(::Example52::Bar) & ::Example52::Baz::BananaMethods
 app/models/example53.rb:
   modules:
   - anchor: Baz
@@ -404,6 +405,7 @@ app/models/example53.rb:
   - call: banana_class_method
     in: "::Example53::Baz"
     implements: "::Example53::Baz::BananaMethods"
+    self: singleton(::Example53::Bar) & ::Example53::Baz::BananaMethods
 app/models/included_hook/home_made.rb:
   modules:
   - anchor: HomeMade

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/example52.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/example52.rb
@@ -33,6 +33,7 @@ class Example52
 end
 
 module Example52::Baz::BananaMethods
+  # @type instance: singleton(::Example52::Bar) & ::Example52::Baz::BananaMethods
   def age
     31
   end

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/example53.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/example53.rb
@@ -37,6 +37,7 @@ class Example53
 end
 
 module Example53::Baz::BananaMethods
+  # @type instance: singleton(::Example53::Bar) & ::Example53::Baz::BananaMethods
   def age
     origin.length + 31
   end

--- a/spec/dummy/sig/rbs_infer/app/models/example53.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example53.rbs
@@ -15,14 +15,14 @@ class Example53
     include ::Example53::Baz
 
     def self.origin: () -> String
-    def self.call_age: () -> untyped
+    def self.call_age: () -> Integer
   end
 end
 
 class Example53
   module Baz
     module BananaMethods
-      def age: () -> untyped
+      def age: () -> Integer
     end
   end
 end

--- a/spec/expectations/expanded/app/models/example52.rb
+++ b/spec/expectations/expanded/app/models/example52.rb
@@ -30,6 +30,7 @@ class Example52
 end
 
 module Example52::Baz::BananaMethods
+  # @type instance: singleton(::Example52::Bar) & ::Example52::Baz::BananaMethods
   def age
     31
   end

--- a/spec/expectations/expanded/app/models/example53.rb
+++ b/spec/expectations/expanded/app/models/example53.rb
@@ -34,6 +34,7 @@ class Example53
 end
 
 module Example53::Baz::BananaMethods
+  # @type instance: singleton(::Example53::Bar) & ::Example53::Baz::BananaMethods
   def age
     origin.length + 31
   end

--- a/spec/expectations/models/example53.rbs
+++ b/spec/expectations/models/example53.rbs
@@ -15,14 +15,14 @@ class Example53
     include ::Example53::Baz
 
     def self.origin: () -> String
-    def self.call_age: () -> untyped
+    def self.call_age: () -> Integer
   end
 end
 
 class Example53
   module Baz
     module BananaMethods
-      def age: () -> untyped
+      def age: () -> Integer
     end
   end
 end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -16,7 +16,6 @@ app/models/example4.rb:14:25: [error] Type `(::String | nil)` does not have meth
 app/models/example4.rb:22:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:27:23: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:40:23: [error] Type `(::String | nil)` does not have method `upcase`
-app/models/example53.rb:19:8: [error] Type `::Example53::Baz::BananaMethods` does not have method `origin`
 app/models/example7.rb:31:28: [error] Type `(::Integer | nil)` does not have method `abs`
 app/models/example7.rb:34:27: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/included_hook.rb:110:12: [warning] Method `::IncludedHook::Arbitrary#from_arbitrary` is not declared in RBS

--- a/spec/expectations/steep_contracts.yml
+++ b/spec/expectations/steep_contracts.yml
@@ -133,23 +133,6 @@ methods:
           kind: self
         method: ticket
     enforced: false
-  Example53::Baz#age:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: origin
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: origin
-        chain:
-        - length
-    enforced: false
   Post#author_name:
     requires:
     - kind: not_nil

--- a/spec/lib/rbs_infer/project/stored_block_replay_expander_spec.rb
+++ b/spec/lib/rbs_infer/project/stored_block_replay_expander_spec.rb
@@ -7,8 +7,15 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
   # The seam takes `sources:` with no default, so a caller cannot forget to
   # thread it. These examples describe one file with no project behind it, so
   # they say so explicitly (docs/engineering/required-threaded-deps.md).
-  def expand(source, sources: RbsInfer::Project::ConstantSources::NONE)
-    described_class.expand(source, sources: sources)
+  # `mixin_index` is required too, and for the same reason: the `self` a
+  # handed-out module's methods run with is half this file's answer and half the
+  # graph's. These examples describe one file with no project around it, so they
+  # say "nobody mixes anything in" explicitly.
+  NO_HOSTS = Object.new
+  def NO_HOSTS.hosts_of(_name) = []
+
+  def expand(source, sources: RbsInfer::Project::ConstantSources::NONE, mixin_index: NO_HOSTS)
+    described_class.expand(source, sources: sources, mixin_index: mixin_index)
   end
 
   it "moves a stored block into the class that replays it" do

--- a/spec/lib/rbs_infer/project/stored_block_replay_implements_spec.rb
+++ b/spec/lib/rbs_infer/project/stored_block_replay_implements_spec.rb
@@ -6,6 +6,19 @@ require "rbs_infer"
 RSpec.describe RbsInfer::Project::StoredBlockReplayImplements do
   NO_SOURCES = RbsInfer::Project::ConstantSources::NONE
 
+  # The mixin graph is the other half of the `self` answer, and these examples
+  # describe one file with no project around it — so they say "nobody mixes
+  # anything in" explicitly rather than leaving the seam unthreaded.
+  NO_HOSTS = Object.new
+  def NO_HOSTS.hosts_of(_name) = []
+
+  # A graph that does, for the examples about the handed-out shape.
+  def hosts(table)
+    index = Object.new
+    index.define_singleton_method(:hosts_of) { |name| table.fetch(name, []) }
+    index
+  end
+
   # The chain the expander recognizes: one storage method, one reader, one
   # stored block, one constant target. Same shape as `Example28`.
   def dsl(reader: "attr_reader :body")
@@ -33,7 +46,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayImplements do
       end
     RUBY
 
-    expect(described_class.blocks_for(source: source, sources: NO_SOURCES))
+    expect(described_class.blocks_for(source: source, sources: NO_SOURCES, mixin_index: NO_HOSTS))
       .to eq([{ "call" => "keep", "in" => "::Src", "implements" => "::Target" }])
   end
 
@@ -63,7 +76,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayImplements do
       end
     RUBY
 
-    expect(described_class.blocks_for(source: source, sources: NO_SOURCES)).to eq(
+    expect(described_class.blocks_for(source: source, sources: NO_SOURCES, mixin_index: NO_HOSTS)).to eq(
       [{ "call" => "keep", "in" => "::SrcA", "implements" => "::First" },
        { "call" => "keep", "in" => "::SrcB", "implements" => "::Second" }]
     )
@@ -88,7 +101,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayImplements do
       end
     RUBY
 
-    entries = described_class.blocks_for(source: source, sources: NO_SOURCES)
+    entries = described_class.blocks_for(source: source, sources: NO_SOURCES, mixin_index: NO_HOSTS)
 
     expect(entries).to eq([{ "call" => "keep", "in" => "::Src", "implements" => "::Target" }])
     expect(entries.map { |entry| entry["line"] }).not_to include(17)
@@ -117,7 +130,7 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayImplements do
       end
     RUBY
 
-    expect(described_class.blocks_for(source: source, sources: NO_SOURCES))
+    expect(described_class.blocks_for(source: source, sources: NO_SOURCES, mixin_index: NO_HOSTS))
       .to eq([{ "call" => "keep", "in" => "::Src", "implements" => ["::First", "::Second"] }])
   end
 
@@ -151,20 +164,20 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayImplements do
       end
     RUBY
 
-    expect(described_class.blocks_for(source: source, sources: NO_SOURCES))
+    expect(described_class.blocks_for(source: source, sources: NO_SOURCES, mixin_index: NO_HOSTS))
       .to eq([{ "call" => "keep", "in" => "::Shared", "implements" => ["::First", "::Second"] },
               { "call" => "keep", "in" => "::Lone", "implements" => "::Third" }])
   end
 
   it "returns nothing for a file with no replay" do
-    expect(described_class.blocks_for(source: "class Foo\n  def bar = 1\nend\n", sources: NO_SOURCES)).to eq([])
+    expect(described_class.blocks_for(source: "class Foo\n  def bar = 1\nend\n", sources: NO_SOURCES, mixin_index: NO_HOSTS)).to eq([])
   end
 
   # The substring gate: no `class_eval`/`module_eval` anywhere means no parse.
   it "does not parse a file that cannot contain a replay" do
     expect(Prism).not_to receive(:parse)
 
-    expect(described_class.blocks_for(source: "class Foo; end\n", sources: NO_SOURCES)).to eq([])
+    expect(described_class.blocks_for(source: "class Foo; end\n", sources: NO_SOURCES, mixin_index: NO_HOSTS)).to eq([])
   end
 
   # A block replayed onto the target's SINGLETON defines `Target.age`, so the
@@ -192,7 +205,85 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayImplements do
       end
     RUBY
 
-    expect(described_class.blocks_for(source: source, sources: NO_SOURCES))
+    expect(described_class.blocks_for(source: source, sources: NO_SOURCES, mixin_index: NO_HOSTS))
       .to eq([{ "call" => "keep", "in" => "::Src", "implements" => "singleton(::Target)" }])
   end
+  # A module the DSL builds and a hook HANDS to the host: the block's `def`s land
+  # in the module, but they run on the host's class object, where the host's own
+  # class methods live. `@implements` alone would check them against a self they
+  # never have.
+  context "a target the hook hands to the host" do
+    def concern
+      <<~RUBY
+        class Module
+          def include(*modules)
+            modules.reverse_each do |mod|
+              mod.send(:append_features, self)
+              mod.send(:included, self)
+            end
+            self
+          end
+        end
+
+        module Wrap
+          module DSL
+            def keep(&block)
+              const_set(:Methods, Module.new).module_eval(&block)
+            end
+
+            def included(base)
+              base.extend(const_get(:Methods))
+            end
+          end
+
+          module Source
+            extend Wrap::DSL
+
+            keep do
+              def age; 31; end
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "names the host's singleton intersected with the module" do
+      entries = described_class.blocks_for(source: concern, sources: NO_SOURCES,
+                                           mixin_index: hosts("Wrap::Source" => ["Wrap::Host"]))
+
+      expect(entries).to eq(
+        [{ "call" => "keep", "in" => "::Wrap::Source", "implements" => "::Wrap::Source::Methods",
+           "self" => "singleton(::Wrap::Host) & ::Wrap::Source::Methods" }]
+      )
+    end
+
+    it "unions the hosts when the module is mixed into several" do
+      entries = described_class.blocks_for(source: concern, sources: NO_SOURCES,
+                                           mixin_index: hosts("Wrap::Source" => ["Wrap::One", "Wrap::Two"]))
+
+      expect(entries.first["self"])
+        .to eq("(singleton(::Wrap::One) & ::Wrap::Source::Methods) | (singleton(::Wrap::Two) & ::Wrap::Source::Methods)")
+    end
+
+    # An unmixed module's methods run with a self this pass cannot state, and
+    # naming the module alone would be the wrong answer rather than a partial one.
+    it "says nothing when the graph names no host" do
+      entries = described_class.blocks_for(source: concern, sources: NO_SOURCES, mixin_index: NO_HOSTS)
+
+      expect(entries.first).not_to have_key("self")
+      expect(entries.first["implements"]).to eq("::Wrap::Source::Methods")
+    end
+
+    # The `class_eval`ed block keeps its old answer: `@implements` is the self
+    # its bodies get at run time, and there is no host to hand anything to.
+    it "leaves a replay nobody hands out without a self" do
+      source = concern.sub("base.extend(const_get(:Methods))", "base.class_eval { }")
+
+      entries = described_class.blocks_for(source: source, sources: NO_SOURCES,
+                                           mixin_index: hosts("Wrap::Source" => ["Wrap::Host"]))
+
+      expect(entries.first).not_to have_key("self")
+    end
+  end
+
 end


### PR DESCRIPTION
A block relocated onto a class needs nothing said about its self: the `def`s are members of that class and run with an instance of it, which the reopening already says. One relocated into a module the host is **handed** — a hook doing `base.extend(M)` — is different: those bodies run on the host's *class object*, where the host's own class methods live, and naming only `M` checks them against a self they never have.

Only `ClassMethodsImplements` said otherwise, and only for `ClassMethods` by name:

```yaml
self: singleton(::Post) & ::Post::Taggable::ClassMethods
```

The core now derives it — `singleton(<host>) & <module>`, for every class the mixin graph says mixes the scope in — which is the last thing that extension knows and the core does not.

## Neither half is a guess

* **That the module is handed out** is read off the provider's own source: the same `base.extend(const_get(:X))` #272 reads from the host's side, asked here from the concern's. `Replay#extended` carries it.
* **Who the hosts are** is the mixin graph's answer, and it has to be — the `include` naming them is written in *their* files, not in the one holding the block.

Both terms of the intersection earn their place. The singleton is where the host's class methods live, which is what these bodies reach for (a scope, a sibling class method, `joins`). The module keeps calls *between* the block's own methods resolving, whether or not the host's RBS ends up naming it.

## Two consumers, one derivation

`steep check` reads the `blocks:` sidecar. The analyzer reads an `@type instance:` line the expander writes into the reopening itself:

```ruby
module Example53::Baz::BananaMethods
  # @type instance: singleton(::Example53::Bar) & ::Example53::Baz::BananaMethods
  def age
    origin.length + 31
  end
end
```

The second is not injected through `ModuleSelfTypes.inject` because it cannot be: that anchor places lines inside a **nested** module's body, and this reopening is compact and top-level, so the annotation would land at end of file bound to nothing. Both call `running_selves`, so the two cannot disagree about the self one method has.

Shipping only the sidecar half was measured and is not enough — the Steep error goes while the inferred type stays `untyped`, because the analyzer type-checks the relocated block in-process.

## Measured

`example53` closes on both halves:

```rbs
-def self.call_age: () -> untyped        +def self.call_age: () -> Integer
-  def age: () -> untyped                +  def age: () -> Integer
```
```
-app/models/example53.rb:19:8: [error] Type `::Example53::Baz::BananaMethods` does not have method `origin`
```

`example52` gains the annotation and no type change — its block body asks nobody for anything, which is exactly why 53 had to exist.

`mixin_index` is required on both entry points, with no default: a caller that forgot it would emit an entry right about the module and silent about the self (docs/engineering/required-threaded-deps.md). 4 new unit examples. Full suite green (1478).

This is the last piece before `ClassMethodsExpander` and `ClassMethodsImplements` can be deleted — the next PR transcribes `def class_methods` into the Concern pseudo-code and removes both, with "the dummy's output does not move" as the criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012eSFCZnXyb2MXWHVYrTL1z