### PR TITLE
Don't count a `return` the checker has already refuted

### DIFF
--- a/lib/rbs_infer/inference/class_member_collector.rb
+++ b/lib/rbs_infer/inference/class_member_collector.rb
@@ -571,6 +571,11 @@ module RbsInfer::Inference
       type
     end
 
+    # Purely syntactic, unlike `ReturnTypeResolver`'s: this pass runs BEFORE any
+    # type-check, so there is no reachability verdict to consult yet. A `return`
+    # the checker will later prove dead is counted here and taken back by the
+    # resolver's narrowing pass, which does have the bridge
+    # (felixefelip/rbs_infer#286).
     def has_nil_return?(defn)
       RbsInfer::Analyzer.find_all_nodes(defn) do |node|
         next false unless node.is_a?(Prism::ReturnNode)

--- a/lib/rbs_infer/inference/return_type_resolver.rb
+++ b/lib/rbs_infer/inference/return_type_resolver.rb
@@ -99,7 +99,7 @@ module RbsInfer::Inference
               steep_type = "self" if self_return?(m, steep_type, self_types)
 
               # Check for early return nil in body
-              if defn && has_nil_return?(defn)
+              if defn && has_nil_return?(defn, dead_ranges: dead_ranges(parsed_target))
                 steep_type = RbsInfer::Signatures::RbsParserUtil.nilablize(steep_type)
               end
 
@@ -142,7 +142,7 @@ module RbsInfer::Inference
             next unless RbsInfer::Signatures::RbsParserUtil.nilablize(steep_type) == current_type
 
             defn = def_map[m.name]
-            next if defn && has_nil_return?(defn)
+            next if defn && has_nil_return?(defn, dead_ranges: dead_ranges(parsed_target))
 
             steep_type = "self" if self_return?(m, steep_type, self_types)
             m.signature = m.signature.sub(/-> #{Regexp.escape(current_type)}$/, "-> #{steep_type}")
@@ -163,7 +163,7 @@ module RbsInfer::Inference
             steep_type = "self" if self_return?(m, steep_type, self_types)
 
             defn = def_map[m.name]
-            if defn && has_nil_return?(defn)
+            if defn && has_nil_return?(defn, dead_ranges: dead_ranges(parsed_target))
               steep_type = RbsInfer::Signatures::RbsParserUtil.nilablize(steep_type)
             end
 
@@ -208,7 +208,9 @@ module RbsInfer::Inference
 
             steep_type = "self" if self_return?(m, steep_type, self_types)
             defn = def_map[m.name]
-            steep_type = RbsInfer::Signatures::RbsParserUtil.nilablize(steep_type) if defn && has_nil_return?(defn)
+            if defn && has_nil_return?(defn, dead_ranges: dead_ranges(parsed_target))
+              steep_type = RbsInfer::Signatures::RbsParserUtil.nilablize(steep_type)
+            end
             next if steep_type == current_type
             # Compared against the declared type WIDENED BY NIL, so a body that
             # differs from it only by nilability is left alone. That axis is the
@@ -255,7 +257,7 @@ module RbsInfer::Inference
         next if current.nil? || current == "untyped" || current == "void" || current.end_with?("?")
 
         defn = def_map(parsed_target)[m.name]
-        next unless defn && has_nil_return?(defn)
+        next unless defn && has_nil_return?(defn, dead_ranges: dead_ranges(parsed_target))
 
         m.signature = m.signature.sub(/-> #{Regexp.escape(current)}\z/, "-> #{RbsInfer::Signatures::RbsParserUtil.nilablize(current)}")
       end
@@ -639,12 +641,33 @@ module RbsInfer::Inference
     end
 
     # Verifica se o corpo do método contém `return nil` ou `return` (implícito nil)
-    def has_nil_return?(defn)
+    def has_nil_return?(defn, dead_ranges:)
       RbsInfer::Analyzer.find_all_nodes(defn) do |node|
         next false unless node.is_a?(Prism::ReturnNode)
+        # A `return` that cannot run says nothing about what the method returns.
+        # `return if current_user.nil?`, written under a guard that already
+        # established `current_user`, reads as dead code to a human — and Steep,
+        # which computed exactly that, reports the branch as unreachable. Counting
+        # it made a method that never returns nil come out `T?`, and every fact
+        # downstream of that type went with it (felixefelip/rbs_infer#286).
+        next false if dead_ranges.any? { |range| range.cover?(node.location.start_offset) }
+
         node.arguments.nil? ||
           node.arguments.arguments.any? { |arg| arg.is_a?(Prism::NilNode) }
       end.any?
+    end
+
+    # The dead branches of the target's source, memoized per target the way
+    # `def_map` is: all five passes above ask, and the answer is one type-check
+    # away. Empty without a bridge or a source — the honest "nothing proved
+    # dead", which leaves every `return` counted exactly as before.
+    def dead_ranges(parsed_target)
+      @dead_ranges ||=
+        if @steep_bridge && parsed_target&.source
+          @steep_bridge.unreachable_branch_ranges(parsed_target.source)
+        else
+          []
+        end
     end
 
     # Conditional tail expressions (`if`/`unless`/`case` — including the

--- a/lib/rbs_infer/signatures/steep_bridge.rb
+++ b/lib/rbs_infer/signatures/steep_bridge.rb
@@ -266,6 +266,32 @@ module RbsInfer::Signatures
       steep_bridge_ivar_write_analyzer.ivar_write_types_per_method(source_code, target_class: target_class)
     end
 
+    # Byte ranges of the branches Steep proved cannot run in `source_code`.
+    #
+    # Steep decides this while typing an `if`/`unless`: when the condition makes
+    # the truthy (or falsy) environment `unreachable`, the clause is dead, and it
+    # says so as a `Ruby::UnreachableBranch`. That verdict is the entire answer to
+    # "does this `return` happen" — a question a syntactic walk over the body
+    # cannot ask, and the reason a guard the checker has already refuted still
+    # widened the method's return type (felixefelip/rbs_infer#286).
+    #
+    # Answered in BYTE offsets, because the caller reads Prism nodes: Steep's
+    # parser indexes its buffer by CHARACTER, so one non-ASCII byte earlier in the
+    # file is enough to slide every range onto the wrong node.
+    def unreachable_branch_ranges(source_code)
+      typing = type_check(source_code)
+      return [] unless typing
+
+      typing.errors.filter_map do |error|
+        next unless error.is_a?(Steep::Diagnostic::Ruby::UnreachableBranch)
+
+        range = error.node&.loc&.expression
+        next unless range
+
+        byte_offset(source_code, range.begin_pos)...byte_offset(source_code, range.end_pos)
+      end
+    end
+
     # Runs Steep's `Postconditions::Inferrer` against the source and
     # returns the resulting `InferredEntry` array. These describe what
     # ivars each method narrows (unconditional for setters, when_true
@@ -523,6 +549,14 @@ module RbsInfer::Signatures
                      type.is_a?(RBS::Types::Bases::Class)
 
       type.each_type.any? { |t| context_dependent?(t) }
+    end
+
+    # A character offset into `source` as a byte offset. Identical for an
+    # ASCII-only file, which is the common case and worth not scanning for.
+    def byte_offset(source, char_offset)
+      return char_offset if source.ascii_only?
+
+      source[0, char_offset].to_s.bytesize
     end
 
     def steep_bridge_ivar_write_analyzer

--- a/spec/dummy/app/models/example56.rb
+++ b/spec/dummy/app/models/example56.rb
@@ -1,0 +1,53 @@
+# A guard the checker has already refuted.
+#
+# `has_nil_return?` used to be a syntactic walk: any bare `return` in the body
+# widened the method's return type, however the branch it sits in was typed. So
+# a guard written against a value that is already non-nil — the shape every
+# `before_action`-established reader has — made a method that never returns nil
+# come out `T?`, and every fact downstream of that type went with it.
+#
+# Steep decides reachability while typing the `if` and reports the dead clause
+# as `UnreachableBranch`. These are the spellings it covers.
+#
+# Three diagnostics stay in the steep baseline and belong there: having declared
+# the branch unreachable, Steep still checks its `return` against the declared
+# return type and reports `nil` as a mismatch. Same asymmetry, other side of the
+# fence — the checker knows the code cannot run and reports it anyway. Filed on
+# the fork; the fix erases the three entries, here and in posts_controller.rb.
+class Example56
+  class Reader
+    def name
+      "farm"
+    end
+
+    def maybe_name
+      [nil, "farm"].sample
+    end
+
+    # Dead: `name` is non-nil, so `name.nil?` is statically false.
+    def label
+      return if name.nil?
+
+      name.upcase
+    end
+
+    # Dead, positive spelling.
+    def shout
+      return unless name
+
+      name.upcase
+    end
+
+    # LIVE, and the control for the fix: `maybe_name` really can be nil, so the
+    # guard really can return and `String?` is the honest answer.
+    def maybe_label
+      return if maybe_name.nil?
+
+      "loud"
+    end
+  end
+
+  def self.call
+    Reader.new.label.length
+  end
+end

--- a/spec/dummy/sig/rbs_infer/app/controllers/posts_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/app/controllers/posts_controller.rbs
@@ -19,5 +19,5 @@ class PostsController < ApplicationController
   def set_post: () -> (Post & Post::Validated)
   def set_test: () -> (Post & Post::Validated)?
   def post_params: () -> untyped
-  def build_filtering_for_current_user: () -> PostFiltering?
+  def build_filtering_for_current_user: () -> PostFiltering
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example56.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example56.rbs
@@ -1,0 +1,13 @@
+class Example56
+  def self.call: () -> Integer
+end
+
+class Example56
+  class Reader
+    def name: () -> String
+    def maybe_name: () -> String?
+    def label: () -> String
+    def shout: () -> String
+    def maybe_label: () -> String?
+  end
+end

--- a/spec/expectations/controllers/posts_controller.rbs
+++ b/spec/expectations/controllers/posts_controller.rbs
@@ -19,5 +19,5 @@ class PostsController < ApplicationController
   def set_post: () -> (Post & Post::Validated)
   def set_test: () -> (Post & Post::Validated)?
   def post_params: () -> untyped
-  def build_filtering_for_current_user: () -> PostFiltering?
+  def build_filtering_for_current_user: () -> PostFiltering
 end

--- a/spec/expectations/models/example56.rbs
+++ b/spec/expectations/models/example56.rbs
@@ -1,0 +1,13 @@
+class Example56
+  def self.call: () -> Integer
+end
+
+class Example56
+  class Reader
+    def name: () -> String
+    def maybe_name: () -> String?
+    def label: () -> String
+    def shout: () -> String
+    def maybe_label: () -> String?
+  end
+end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -1,3 +1,4 @@
+app/controllers/posts_controller.rb:76:4: [error] The method cannot return a value of type `nil` because declared as type `::PostFiltering`
 app/models/concerns/test/filtrable.rb:16:13: [error] Type `(::Post & ::Test::Filtrable)` does not have method `adddd`
 app/models/concerns/test/filtrable.rb:16:4: [error] Type `(::Post & ::Test::Filtrable)` does not have method `asdasd`
 app/models/eval_reopen.rb:61:6: [warning] Method `::Object#by_instance_eval` is not declared in RBS
@@ -16,6 +17,8 @@ app/models/example4.rb:14:25: [error] Type `(::String | nil)` does not have meth
 app/models/example4.rb:22:25: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:27:23: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/example4.rb:40:23: [error] Type `(::String | nil)` does not have method `upcase`
+app/models/example56.rb:29:6: [error] The method cannot return a value of type `nil` because declared as type `::String`
+app/models/example56.rb:36:6: [error] The method cannot return a value of type `nil` because declared as type `::String`
 app/models/example7.rb:31:28: [error] Type `(::Integer | nil)` does not have method `abs`
 app/models/example7.rb:34:27: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/included_hook.rb:110:12: [warning] Method `::IncludedHook::Arbitrary#from_arbitrary` is not declared in RBS

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -278,6 +278,10 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     assert_snapshot("models/example55/baz", target_file: "app/models/example55/baz.rb")
   end
 
+  it "example56 (a guard the checker has already refuted) matches expected RBS" do
+    assert_snapshot("models/example56", target_file: "app/models/example56.rb")
+  end
+
   it "example55/foo (the DSL in a file of its own) matches expected RBS" do
     assert_snapshot("models/example55/foo", target_file: "app/models/example55/foo.rb")
   end

--- a/spec/lib/rbs_infer/inference/return_type_resolver_spec.rb
+++ b/spec/lib/rbs_infer/inference/return_type_resolver_spec.rb
@@ -151,4 +151,57 @@ RSpec.describe RbsInfer::Inference::ReturnTypeResolver do
       expect(init).not_to include("xml")
     end
   end
+
+  # felixefelip/rbs_infer#286. The predicate decides whether a body's `return`
+  # widens the method's type to `T?`. It used to answer from the parse alone, so
+  # a guard the checker had already refuted still nilablized the signature. It
+  # now takes the ranges Steep proved dead and skips the `return`s inside them.
+  describe "#has_nil_return?" do
+    # One dead `return` and one live one, so the filter has to answer per node
+    # rather than for the method as a whole.
+    let(:source) do
+      <<~RUBY
+        def label
+          return if refuted?
+
+          return nil if genuinely_unknown?
+
+          "x"
+        end
+      RUBY
+    end
+
+    let(:defn) { def_node(source) }
+    let(:dead_guard) { range_of("return if") }
+    let(:live_guard) { range_of("return nil") }
+
+    # The byte range of the `return` keyword opening the given line.
+    def range_of(snippet)
+      start = source.index(snippet)
+      start...(start + "return".bytesize)
+    end
+
+    it "counts a bare `return` when nothing is proved dead" do
+      expect(resolver.send(:has_nil_return?, defn, dead_ranges: [])).to be(true)
+    end
+
+    it "counts a `return` a range does not cover" do
+      # A dead branch elsewhere in the file says nothing about these two.
+      elsewhere = (source.bytesize + 10)...(source.bytesize + 20)
+      expect(resolver.send(:has_nil_return?, defn, dead_ranges: [elsewhere])).to be(true)
+    end
+
+    it "still counts the live `return` when only the other one is dead" do
+      expect(resolver.send(:has_nil_return?, defn, dead_ranges: [dead_guard])).to be(true)
+    end
+
+    it "counts nothing once every `return` is proved dead" do
+      expect(resolver.send(:has_nil_return?, defn, dead_ranges: [dead_guard, live_guard])).to be(false)
+    end
+
+    it "ignores a `return` with a value, dead or not" do
+      valued = def_node("def label\n  return \"x\" if cond?\n\n  \"y\"\nend\n")
+      expect(resolver.send(:has_nil_return?, valued, dead_ranges: [])).to be(false)
+    end
+  end
 end

--- a/spec/lib/rbs_infer/signatures/steep_bridge_spec.rb
+++ b/spec/lib/rbs_infer/signatures/steep_bridge_spec.rb
@@ -588,4 +588,68 @@ RSpec.describe RbsInfer::Signatures::SteepBridge, :dummy_app do
       expect(bridge.accepts?("String", "not a type[")).to be_nil
     end
   end
+
+  # felixefelip/rbs_infer#286. Steep decides reachability while typing the `if`;
+  # this reads that verdict back so the return-type widening can follow the
+  # checker instead of the parser.
+  describe "#unreachable_branch_ranges" do
+    it "covers the `return` of a guard the checker has already refuted" do
+      code = <<~RUBY
+        class Foo
+          def bar
+            name = "farm"
+            return if name.nil?
+
+            name
+          end
+        end
+      RUBY
+
+      ranges = bridge.unreachable_branch_ranges(code)
+
+      expect(ranges.size).to eq(1)
+      expect(code.byteslice(ranges[0].begin, ranges[0].size)).to eq("return")
+    end
+
+    it "is empty for a guard that can genuinely run" do
+      code = <<~RUBY
+        class Foo
+          def bar
+            name = User.where(active: true).first
+            return if name.nil?
+
+            name
+          end
+        end
+      RUBY
+
+      expect(bridge.unreachable_branch_ranges(code)).to be_empty
+    end
+
+    # The consumer reads Prism nodes, which carry BYTE offsets; Steep's parser
+    # indexes its buffer by CHARACTER. On an ASCII file the two agree, which is
+    # why every snapshot fixture would miss this — one multibyte character before
+    # the guard is enough to slide the range onto the wrong node.
+    it "answers in byte offsets, not character offsets" do
+      code = <<~RUBY
+        class Foo
+          # ação, coração, não — multibyte antes da guarda
+          def bar
+            name = "fazenda"
+            return if name.nil?
+
+            name
+          end
+        end
+      RUBY
+
+      range = bridge.unreachable_branch_ranges(code).fetch(0)
+
+      expect(code.byteslice(range.begin, range.size)).to eq("return")
+      # What a character-indexed range would have pointed at, spelled out so a
+      # regression reads as "it went back to characters" rather than an offset
+      # nobody can place.
+      expect(code[range.begin, range.size]).not_to eq("return")
+    end
+  end
 end


### PR DESCRIPTION
## The bug

`ReturnTypeResolver#has_nil_return?` was a syntactic walk over the body — any bare `return` (or `return nil`) anywhere in it widened the method's return type to `T?`, whatever the branch it sits in was typed:

```ruby
def has_nil_return?(defn)
  RbsInfer::Analyzer.find_all_nodes(defn) do |node|
    next false unless node.is_a?(Prism::ReturnNode)
    node.arguments.nil? || node.arguments.arguments.any? { |arg| arg.is_a?(Prism::NilNode) }
  end.any?
end
```

Nothing asks whether that `return` can run. So a guard written against a value that is already non-nil — the shape every `before_action`-established reader has — turned a method that never returns nil into a nilable one:

```ruby
def pessoa_ativa
  return if current_user.nil?   # dead: current_user is non-nil past authenticate_user!

  current_user.pessoas.find_by(id: session[:pessoa_id]) || current_user.pessoa_titular
end
```

(`find_by` gives `(Pessoa & Validated)?` and `pessoa_titular` is non-nil under `User::Validated` — `validates :pessoa_titular, presence: true`. The **only** `nil` in that method was the dead `return`.)

And the type is not where it stops. The caller does `Current.pessoa = pessoa_ativa`; with a nilable argument the `unless value.nil?` inside `Current#pessoa=` stays live, so `Current.caderneta` was never established, the action's `Current.caderneta.vacinas` was a `NoMethod`, the ivar write typed as `"nil"`, and `infer_ivar_types` dropped the declaration outright. The ivar stopped being generated three steps from the guard, with nothing in between pointing back at it.

## The fix

Steep already had the answer and was never asked. It decides reachability while typing the `if` and reports the dead clause as `UnreachableBranch` — verified on the real file:

```
UnreachableBranch L13: if
send L13 current_user       => (::User & ::User::Validated)
send L13 current_user.nil?  => <% Logic::ReceiverIsNil %>
```

It covers every spelling I tested: `return if x.nil?`, a local holding the same value, `return unless x`, and a literal-false condition.

`SteepBridge#unreachable_branch_ranges` reads that verdict back, and `has_nil_return?` skips any `return` inside one — the widening now follows the checker instead of the parser. The ranges are in **byte** offsets: Steep's parser indexes its buffer by character, so one non-ASCII byte earlier in the file would slide every range onto the wrong node.

`ClassMemberCollector` has a second copy of `has_nil_return?`. It stays syntactic and is commented as such: that pass runs before any type-check, so there is no verdict to consult; its guess is taken back by the resolver's narrowing pass, which does have the bridge.

## What moves

`posts_controller`'s `build_filtering_for_current_user` narrows to `-> PostFiltering` for the same reason — its one caller assigns `Current.user` immediately before, so `return unless Current.user` is dead by the closed-world reading the rest of the pipeline already uses. Steep flags it itself; I checked before accepting it.

`example56` is the regression fixture, with a live guard as the control so the fix cannot over-fire:

| | before | after |
|---|---|---|
| `label` (dead `.nil?` guard) | `String?` | **`String`** |
| `shout` (dead `unless` guard) | `String?` | **`String`** |
| `maybe_label` (**live** guard) | `String?` | `String?` |
| `self.call` (cascade) | `untyped` | **`Integer`** |

## Baseline

Three diagnostics enter `steep_baseline.txt` and belong there:

```
app/controllers/posts_controller.rb:76:4: [error] The method cannot return a value of type `nil` because declared as type `::PostFiltering`
app/models/example56.rb:29:6: [error] The method cannot return a value of type `nil` because declared as type `::String`
app/models/example56.rb:36:6: [error] The method cannot return a value of type `nil` because declared as type `::String`
```

Same asymmetry, the other side of the fence: having declared the branch unreachable, Steep still checks its `return` against the declared return type. `TypeConstruction`'s `when :return` reports `ReturnTypeMismatch` with no reachability guard, even though `truthy.unreachable` was computed a few lines earlier in the `:if` handler. That is a defect in the fork, not in this change, and its fix erases all three entries.

## Tests

`make test` green (1353 + 123, 0 failures). Reverting only `lib/` makes the `example56` snapshot fail exactly on the two dead guards, with the live one unchanged.

Verified end-to-end on the app the report came from: `pessoa_ativa` becomes non-nil, `set_authenticated_user` establishes `Current.caderneta`, the entry facts carry it into `CadernetaController#index`, and `@vacinas` is generated again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BrWNAbYgzR7CKVuoKk6DS