### PR TITLE
Type a setter from its body, like every other method

### DIFF
--- a/lib/rbs_infer/inference/return_type_resolver.rb
+++ b/lib/rbs_infer/inference/return_type_resolver.rb
@@ -50,12 +50,13 @@ module RbsInfer::Inference
       # Aplicar tipos já resolvidos pelo resolver (ex: chamadas a métodos herdados)
       untyped_methods.each do |m|
         next if m.name == "initialize"
-        # Setters' return is body/assignment-specific (`obj.x = v` evaluates
-        # to the RHS, not the method's return) and is set by the owner-aware
-        # TypeMerger passes from each def's body. `known_return_types` is
-        # name-keyed, so resolving a setter here would leak a colliding
-        # setter's return (e.g. a CurrentAttributes override onto the
-        # generated module accessor) — felixefelip/rbs_infer#22.
+        # Skipped for the map, not for being a setter: `known_return_types` is
+        # keyed by NAME alone — no owner, no kind — so resolving a setter here
+        # would leak a colliding setter's return (a CurrentAttributes override
+        # onto the generated module accessor) — felixefelip/rbs_infer#22. The
+        # Steep pass below has no such skip: its map is kind-split (#33) and it
+        # reads each def's own body, which is what a setter returns
+        # (felixefelip/rbs_infer#287).
         next if setter_name?(m.name)
         resolved = return_types_for(m, known_return_types, class_return_types)[m.name]
         if resolved && resolved != "untyped"
@@ -75,7 +76,6 @@ module RbsInfer::Inference
           self_types = Set.new([@target_class] + @instance_types)
 
           still_untyped.each do |m|
-            next if setter_name?(m.name)
             steep_type = steep_returns_for(m, steep_returns)[m.name]
             # `nil` is a genuine inference, not a fallback: the env is built with
             # `implicitly_returns_nil: false`, so Steep types a body as `nil` only
@@ -194,7 +194,6 @@ module RbsInfer::Inference
           members.each do |m|
             next unless method_member?(m)
             next if m.name == "initialize"
-            next if setter_name?(m.name)
 
             current_type = RbsInfer::Signatures::RbsParserUtil.return_type_of(m.signature)
             next unless current_type && current_type != "untyped"
@@ -249,9 +248,12 @@ module RbsInfer::Inference
 
       members.each do |m|
         next unless method_member?(m)
-        # `initialize` is `-> void` by convention, and a setter's return is the assigned
-        # value — neither is the body's own tail type, so neither is ours to widen.
-        next if m.name == "initialize" || setter_name?(m.name)
+        # `initialize` is `-> void` by convention, so it is not the body's tail type
+        # and not ours to widen. A setter's IS: `obj.x = v` evaluating to `v` is a
+        # property of the assignment operator, which discards the method's return —
+        # the declaration describes what `super` gets, which is the body
+        # (felixefelip/rbs_infer#287).
+        next if m.name == "initialize"
 
         current = RbsInfer::Signatures::RbsParserUtil.return_type_of(m.signature)
         next if current.nil? || current == "untyped" || current == "void" || current.end_with?("?")
@@ -624,6 +626,14 @@ module RbsInfer::Inference
     # declared as type `self`". Mirrors the `own_kind != :class_method` guard
     # in TypeMerger (felixefelip/rbs_infer#33/#34).
     def self_return?(member, steep_type, self_types)
+      # Never for a setter, whatever its body evaluates to. `self` is the
+      # RECEIVER, and a setter returns neither the receiver nor — on the one
+      # path that observes it, `super` — anything the receiver's identity
+      # implies: `def user=(v); @user = v; end` on a `Widget` hands `super`'s
+      # caller the assigned `Widget`, not the `Widget` it was called on
+      # (felixefelip/rbs_infer#287).
+      return false if setter_name?(member.name)
+
       member.kind != :class_method && self_types.include?(steep_type)
     end
 

--- a/spec/dummy/sig/rbs_infer/app/models/current.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/current.rbs
@@ -1,5 +1,5 @@
 class Current < ActiveSupport::CurrentAttributes
   def self.author_full_name: () -> String?
 
-  def user=: (((User & User::Validated) | User?) value) -> untyped
+  def user=: (((User & User::Validated) | User?) value) -> String?
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example13.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example13.rbs
@@ -16,9 +16,9 @@ class Example13
 
     def self.registry_instance: () -> Example13::Registry
     def self.user: () -> (Example13Viewer | nil)?
-    def self.user=: ((Example13Viewer | nil) value) -> (Example13Viewer | nil)
+    def self.user=: ((Example13Viewer | nil) value) -> Example13Viewer?
     def self.tenant: () -> (Example13Tenant | nil)?
-    def self.tenant=: ((Example13Tenant | nil) value) -> (Example13Tenant | nil)
+    def self.tenant=: ((Example13Tenant | nil) value) -> Example13Tenant?
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example15.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example15.rbs
@@ -23,6 +23,6 @@ class Example15
     self.@user: Example15::User?
 
     def self.user: () -> Example15::User?
-    def self.user=: (User value) -> User
+    def self.user=: (User value) -> Example15::User
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example16.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example16.rbs
@@ -28,6 +28,6 @@ class Example16
     self.@user: Example16::User?
 
     def self.user: () -> Example16::User?
-    def self.user=: (User value) -> User
+    def self.user=: (User value) -> Example16::User
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example3.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example3.rbs
@@ -28,11 +28,11 @@ class Example3
 
     def self.foo_instance: () -> Example3::Foo
     def self.user: () -> (Example3::User | nil)?
-    def self.user=: ((Example3::User | nil) value) -> (Example3::User | nil)
+    def self.user=: ((Example3::User | nil) value) -> Example3::User?
     def self.name: () -> String?
     def self.name=: (String? value) -> String?
     def self.clear_user: () -> nil
 
-    def user=: ((Example3::User | nil) value) -> untyped
+    def user=: ((Example3::User | nil) value) -> String?
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example4.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example4.rbs
@@ -8,7 +8,7 @@ class Example4
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: ((String | nil) value) -> (String | nil)
+    def self.name=: ((String | nil) value) -> String?
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_current_runtime/current.rbs
@@ -12,7 +12,7 @@ class Current
     @viewer_name: String?
 
     def user: () -> ((User & User::Validated) | User | nil)
-    def user=: (((User & User::Validated) | User?) value) -> ((User & User::Validated) | User)?
+    def user=: (((User & User::Validated) | User?) value) -> ((User & User::Validated) | User | nil)
     def author_name: () -> String?
     def author_name=: (String? value) -> String?
     def account: () -> (Account & Account::Validated)?
@@ -24,7 +24,7 @@ class Current
   include GeneratedAttributeMethods
 
   def self.user: () -> ((User & User::Validated) | User)?
-  def self.user=: (((User & User::Validated) | User?) value) -> ((User & User::Validated) | User?)
+  def self.user=: (((User & User::Validated) | User?) value) -> ((User & User::Validated) | User | nil)
   def self.author_name: () -> String?
   def self.author_name=: (String? value) -> String?
   def self.account: () -> (Account & Account::Validated)?

--- a/spec/expectations/models/current.rbs
+++ b/spec/expectations/models/current.rbs
@@ -1,5 +1,5 @@
 class Current < ActiveSupport::CurrentAttributes
   def self.author_full_name: () -> String?
 
-  def user=: (((User & User::Validated) | User?) value) -> untyped
+  def user=: (((User & User::Validated) | User?) value) -> String?
 end

--- a/spec/expectations/models/example13.rbs
+++ b/spec/expectations/models/example13.rbs
@@ -16,9 +16,9 @@ class Example13
 
     def self.registry_instance: () -> Example13::Registry
     def self.user: () -> (Example13Viewer | nil)?
-    def self.user=: ((Example13Viewer | nil) value) -> (Example13Viewer | nil)
+    def self.user=: ((Example13Viewer | nil) value) -> Example13Viewer?
     def self.tenant: () -> (Example13Tenant | nil)?
-    def self.tenant=: ((Example13Tenant | nil) value) -> (Example13Tenant | nil)
+    def self.tenant=: ((Example13Tenant | nil) value) -> Example13Tenant?
   end
 end
 

--- a/spec/expectations/models/example15.rbs
+++ b/spec/expectations/models/example15.rbs
@@ -23,6 +23,6 @@ class Example15
     self.@user: Example15::User?
 
     def self.user: () -> Example15::User?
-    def self.user=: (User value) -> User
+    def self.user=: (User value) -> Example15::User
   end
 end

--- a/spec/expectations/models/example16.rbs
+++ b/spec/expectations/models/example16.rbs
@@ -28,6 +28,6 @@ class Example16
     self.@user: Example16::User?
 
     def self.user: () -> Example16::User?
-    def self.user=: (User value) -> User
+    def self.user=: (User value) -> Example16::User
   end
 end

--- a/spec/expectations/models/example3.rbs
+++ b/spec/expectations/models/example3.rbs
@@ -28,11 +28,11 @@ class Example3
 
     def self.foo_instance: () -> Example3::Foo
     def self.user: () -> (Example3::User | nil)?
-    def self.user=: ((Example3::User | nil) value) -> (Example3::User | nil)
+    def self.user=: ((Example3::User | nil) value) -> Example3::User?
     def self.name: () -> String?
     def self.name=: (String? value) -> String?
     def self.clear_user: () -> nil
 
-    def user=: ((Example3::User | nil) value) -> untyped
+    def user=: ((Example3::User | nil) value) -> String?
   end
 end

--- a/spec/expectations/models/example4.rbs
+++ b/spec/expectations/models/example4.rbs
@@ -8,7 +8,7 @@ class Example4
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: ((String | nil) value) -> (String | nil)
+    def self.name=: ((String | nil) value) -> String?
   end
 end
 

--- a/spec/expectations/steep_current_runtime/current.rbs
+++ b/spec/expectations/steep_current_runtime/current.rbs
@@ -12,7 +12,7 @@ class Current
     @viewer_name: String?
 
     def user: () -> ((User & User::Validated) | User | nil)
-    def user=: (((User & User::Validated) | User?) value) -> ((User & User::Validated) | User)?
+    def user=: (((User & User::Validated) | User?) value) -> ((User & User::Validated) | User | nil)
     def author_name: () -> String?
     def author_name=: (String? value) -> String?
     def account: () -> (Account & Account::Validated)?
@@ -24,7 +24,7 @@ class Current
   include GeneratedAttributeMethods
 
   def self.user: () -> ((User & User::Validated) | User)?
-  def self.user=: (((User & User::Validated) | User?) value) -> ((User & User::Validated) | User?)
+  def self.user=: (((User & User::Validated) | User?) value) -> ((User & User::Validated) | User | nil)
   def self.author_name: () -> String?
   def self.author_name=: (String? value) -> String?
   def self.account: () -> (Account & Account::Validated)?

--- a/spec/integration/steep_scenarios_spec.rb
+++ b/spec/integration/steep_scenarios_spec.rb
@@ -416,4 +416,49 @@ RSpec.describe "rbs_infer -> Steep precondition scenarios" do
     expect(result.diagnostics).to be_empty
   end
 
+
+  # felixefelip/rbs_infer#287. A setter's DECLARED return is its body's tail,
+  # like any other method's. `obj.x = v` evaluating to `v` is a property of the
+  # assignment operator — Ruby discards the method's return there — so the
+  # declaration is not what an assignment reads; it is what `super` reads, and
+  # `super` into a setter is the shape `ActiveSupport::CurrentAttributes`
+  # overrides are written in.
+  #
+  # The Widget scenario above is the same rule where body and parameter agree
+  # (`@user = value` evaluates to `value`). Here they diverge, which is where
+  # skipping setters wholesale left `-> untyped`.
+  it "types a setter from its body, not from its parameter" do
+    result = steep_scenario(<<~RUBY)
+      class Holder
+        attr_accessor :label
+
+        def user=(value)
+          @user = value
+
+          unless value.nil?
+            self.label = value.name
+          end
+        end
+
+        def install
+          self.user = candidate
+        end
+
+        def candidate
+          [nil, Person.new].sample
+        end
+      end
+
+      class Person
+        def name
+          "jo"
+        end
+      end
+    RUBY
+
+    # `String?` — the `unless` yields the assigned label or nil — and NOT
+    # `Person`, which is what the parameter says.
+    expect(result.generated_rbs).to include("def user=: (Person? value) -> String?")
+    expect(result.diagnostics).to be_empty
+  end
 end

--- a/spec/lib/rbs_infer/inference/return_type_resolver_spec.rb
+++ b/spec/lib/rbs_infer/inference/return_type_resolver_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe RbsInfer::Inference::ReturnTypeResolver do
     it "is false for any method returning some other class" do
       expect(resolver.send(:self_return?, member(:method), "Other", self_types)).to be(false)
     end
+
+    # felixefelip/rbs_infer#287. `self` is the RECEIVER, and a setter returns
+    # neither the receiver nor anything its identity implies: `def user=(v);
+    # @user = v; end` on a `Widget` hands `super`'s caller the ASSIGNED widget.
+    # Emitting `-> self` there says the assignment came back, which it did not.
+    it "is false for a setter, even when its body evaluates to the target class" do
+      setter = RbsInfer::Inference::Member.new(
+        kind: :method, name: "user=", signature: "user=: (X value) -> untyped", visibility: :public
+      )
+
+      expect(resolver.send(:self_return?, setter, "X", self_types)).to be(false)
+      # ...while the same body in a non-setter still resolves to `self`.
+      expect(resolver.send(:self_return?, member(:method), "X", self_types)).to be(true)
+    end
   end
 
   describe "#unconditional_nil_tail?" do


### PR DESCRIPTION
## The bug

`sig/generated/app/models/current.rbs` in a real app:

```rbs
def pessoa=: (Pessoa & Pessoa::Validated value) -> untyped
```

Not an inference failure — a deliberate skip. Every return-type pass in `ReturnTypeResolver` bailed on setters (`:59`, `:78`, `:197`, `:254`), on the rationale that *"a setter's return is the assigned value — not the body's own tail type"*.

Half of that is true, and it is the half about the **assignment operator**, not about the method:

```ruby
class Foo
  def bar=(value) = "OTHER"     # the body does not return value
end

f.bar = 42                  # => 42        the operator discards the method's return
f.send(:bar=, 42)           # => "OTHER"   the method
f.method(:bar=).call(42)    # => "OTHER"
super(value)                # => "OTHER"
```

RBS declares the **method**. Steep already models the operator on its own — I checked with a setter whose declared return deliberately differs from its parameter (`def name=: (String value) -> Integer`, body returning `42`):

| | Ruby | Steep |
|---|---|---|
| `p.name = "x"` | `"x"` (RHS) | `String` — **never consults the declaration** |
| `p.send(:name=, "x")` | `42` (body) | `String` — a checker quirk, diverges from runtime |
| `p.method(:name=).call("x")` | `42` (body) | `untyped` |
| `super(value)` in an override | `42` (body) | **`Integer` — reads the declaration** |

rbs_infer does the same on its side (`assignment_rhs_type`, `type_merger.rb:466`). So the parameter type buys nothing at assignment sites and is **false** on the one path that reads the declaration: `super` — which is exactly how a `CurrentAttributes` accessor override is written, in the dummy and in the app this came from.

Where body and parameter agree — `def x=(v); @x = v; end`, whose tail *is* `v` — nothing moves. That is why the `(T) -> T` convention looks like a rule of its own; it is just those bodies. Where they diverge, the skip left `untyped`:

```ruby
def pessoa=(value)
  super(value)

  unless value.nil?
    self.caderneta = value.caderneta
  end
end
```

Steep types that body `(Caderneta & Caderneta::Validated)?` and had all along — `method_return_types` returns it. The passes threw it away. `TypeMerger`'s rule 0 was the only thing ever typing a setter, and only for the one syntactic shape whose last statement is a bare ivar write.

## The fix

The three body-derived skips go. The fourth stays, and now says why it is a different question: `known_return_types` is keyed by **name alone** — no owner, no kind — so a setter resolved there leaks across owners (#22). The Steep map is kind-split (#33) and reads each def's own body.

`self_return?` gains a setter guard. `self` is the **receiver**, and a setter returns neither the receiver nor anything its identity implies. Without it `Widget#user=` came out `-> self` for a body handing back the assigned widget — the one real regression when I tried removing the skips alone.

## What moves

Every changed snapshot is one of four kinds:

| kind | example |
|---|---|
| **fixed** — `untyped` → the body's type | `Current#user=`, `Example3#user=` → `-> String?` |
| respelled | `-> (String \| nil)` → `-> String?` |
| union reordered | `-> ((User & Validated) \| User)?` → `-> ((User & Validated) \| User \| nil)` |
| constant qualified | `-> User` → `-> Example15::User` (same type, lexical resolution) |

**The steep baseline does not move.** The wider returns introduce no diagnostic against the real dummy source — which is what says the new signatures are true, not merely accepted.

## Tests

- An end-to-end `steep_scenario`: a setter whose body ends in an `unless` gets `(Person? value) -> String?`, with `diagnostics` empty. It is the complement of the existing Widget scenario, where body and parameter agree.
- A unit example pinning `self_return?` false for a setter and still true for a non-setter with the same body type.

Both checked against the mutation they describe: restoring the setter skip fails the scenario, dropping the `self_return?` guard fails the unit example, each alone.

`make test` green: 1363 + 123, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BrWNAbYgzR7CKVuoKk6DS