### PR TITLE
Read the include chain through RBS, not just through source

### DIFF
--- a/lib/rbs_infer/project/mixin_index.rb
+++ b/lib/rbs_infer/project/mixin_index.rb
@@ -31,6 +31,7 @@ module RbsInfer::Project
       @parse_cache = parse_cache || ParseCache.new
       @included_shorts = {}                            # file → Set[short name]
       @extended_shorts = {}                            # file → Set[short name]
+      @written_mixin_names = Set.new                   # every name written in an include/extend
       @files_defining = Hash.new { |h, k| h[k] = [] }  # short name → [file]
       @includes_by_class = Hash.new { |h, k| h[k] = Set.new } # class FQN → Set[written name]
       @extends_by_class = Hash.new { |h, k| h[k] = Set.new }  # class FQN → Set[written name]
@@ -39,18 +40,29 @@ module RbsInfer::Project
       @extenders_by_target = {}                               # target FQN → [extender FQN]
       @hosts_of_cache = {}                                    # target FQN → resolved hosts
       @extenders_of_cache = {}                                # target FQN → resolved extenders
+      @ancestor_builder = nil                                 # RBS env the memo below belongs to
+      @ancestor_shorts = {}                                   # written name → Set[ancestor short]
       build(source_files)
     end
 
     # Files whose bare calls can reach instance methods of `module_name`
     # (the host + the host's sibling concerns).
+    #
+    # A host is any file mixing in something that CARRIES the target, not only
+    # one naming it: `include` chains, and the chain may run through a module
+    # the corpus has no Ruby for. Every ERB template includes `ActionViewContext`,
+    # which is emitted as `.rbs` and includes every app helper — so a partial
+    # calling `idade_recomendada_para(recomendacao_vacina)` was not a host of
+    # `SugestoesHelper`, was swept by no other route either (it names no
+    # constant, and the call is bare), and the helper's parameter came out
+    # `untyped` with the call site never read.
     def files_reaching(module_name)
-      short = module_name.split("::").last
+      carriers = carrier_shorts(module_name)
       result = Set.new
-      host_files(short).each do |host|
+      host_files(carriers).each do |host|
         result << host
         @included_shorts.fetch(host, EMPTY).each do |sibling_short|
-          next if sibling_short == short
+          next if carriers.include?(sibling_short)
           @files_defining[sibling_short].each { |f| result << f }
         end
       end
@@ -132,13 +144,70 @@ module RbsInfer::Project
       (direct + inherited).uniq.sort
     end
 
-    # Files whose class/module mixes `short` in, by either route. A file that
-    # only EXTENDS the module still makes bare calls into it — `bazinga(Baz)` in
-    # a class body is a call on the class object — so reachability does not care
-    # which of the two ancestries carries it.
-    def host_files(short)
-      @included_shorts.filter_map { |file, shorts| file if shorts.include?(short) } |
-        @extended_shorts.filter_map { |file, shorts| file if shorts.include?(short) }
+    # The short names that carry `module_name` — itself, plus every mixin name
+    # the sources write whose ANCESTRY reaches it.
+    #
+    # The source alone cannot answer the second half. A module declared only in
+    # RBS has no `include` line in the corpus for `build` to read, so the chain
+    # through it is invisible and `host_files` — which matches a written name
+    # against the target's — stops one link short. The RBS environment already
+    # holds the answer, transitively and for `.rbs`-only modules alike; this
+    # asks it instead of re-deriving a closure over what the corpus happens to
+    # show.
+    #
+    # Asked once per WRITTEN mixin name (dozens), not once per file (hundreds):
+    # what a name carries is a property of the name.
+    def carrier_shorts(module_name)
+      short = module_name.split("::").last
+      carriers = Set[short]
+      @written_mixin_names.each do |name|
+        carriers << name.split("::").last if ancestor_shorts(name).include?(short)
+      end
+      carriers
+    end
+
+    # Short names of every instance ancestor of `name`, per RBS. Empty when the
+    # environment cannot answer — a module the generated RBS does not declare
+    # yet (a cold run, before `sig/` exists) among them, which is why an empty
+    # answer must read as "nothing to add here", never as "includes nothing":
+    # the source-derived half of `files_reaching` stands on its own.
+    #
+    # Memoized against the environment's IDENTITY rather than held for the life
+    # of the index. `Corpus` keeps one `MixinIndex` for the whole run because
+    # its answers are a pure function of the source files, and this one is not:
+    # the CLI regenerates `sig/` between dependency levels and passes and calls
+    # `SteepEnvironment.reset!`, which makes the next builder a different
+    # object and drops these answers with it — the same key `SteepBridge` hangs
+    # its type-check cache on, so there is no new invalidation hook to wire.
+    def ancestor_shorts(name)
+      builder = RbsInfer::Signatures::SteepEnvironment.definition_builder
+      return EMPTY unless builder
+
+      unless @ancestor_builder.equal?(builder)
+        @ancestor_builder = builder
+        @ancestor_shorts = {}
+      end
+
+      @ancestor_shorts[name] ||= compute_ancestor_shorts(builder, name)
+    end
+
+    def compute_ancestor_shorts(builder, name)
+      type_name = RBS::TypeName.parse("::#{name.sub(/\A::/, "")}")
+      builder.ancestor_builder.instance_ancestors(type_name)
+             .ancestors.map { |a| a.name.to_s.split("::").last }.to_set
+    rescue StandardError
+      # An unknown name raises rather than answering empty, and so does a
+      # declaration RBS cannot build. Neither is a reason to fail the sweep.
+      EMPTY
+    end
+
+    # Files whose class/module mixes any of `carriers` in, by either route. A
+    # file that only EXTENDS the module still makes bare calls into it —
+    # `bazinga(Baz)` in a class body is a call on the class object — so
+    # reachability does not care which of the two ancestries carries it.
+    def host_files(carriers)
+      @included_shorts.filter_map { |file, shorts| file if shorts.intersect?(carriers) } |
+        @extended_shorts.filter_map { |file, shorts| file if shorts.intersect?(carriers) }
     end
 
     def build(source_files)
@@ -174,6 +243,9 @@ module RbsInfer::Project
         # anything anything in it mixes in.
         @included_shorts[file] = written.map { |name| name.split("::").last }.to_set
         @extended_shorts[file] = extended.map { |name| name.split("::").last }.to_set
+        # Kept unshortened as well: resolving one against RBS needs the name the
+        # source wrote (`ActionView::Helpers`), which the short form has lost.
+        @written_mixin_names.merge(written).merge(extended)
         # Self-types cannot use that union — they key on the DECLARATION that
         # wrote the mixin. Attributing a file's every `include` to its headline
         # class made `class Example23; module Baz; extend Foo; end; end` answer
@@ -350,3 +422,5 @@ module RbsInfer::Project
     private_constant :MixinWriter
   end
 end
+
+require_relative "../signatures/steep_environment"

--- a/spec/dummy/app/helpers/posts_helper.rb
+++ b/spec/dummy/app/helpers/posts_helper.rb
@@ -33,4 +33,20 @@ module PostsHelper
   def post_index_marker(post)
     content_tag(:span, post.title, class: "post-marker")
   end
+
+  # Helper called ONLY from a PARTIAL (`posts/_comment.html.erb`). Regression
+  # fixture for the mixin chain that runs through RBS: a partial's generated
+  # class includes `ActionViewContext` and nothing else, and it is
+  # `ActionViewContext` — emitted as `.rbs`, so absent from the source corpus —
+  # that carries `PostsHelper`. Reading the include chain from source alone
+  # stopped one link short, the partial was swept as a caller of nothing, and
+  # this parameter came out `untyped` while Steep typed the very same argument
+  # `Comment & Comment::Validated`.
+  #
+  # The pair with `post_index_marker` above is the point: that one is reached
+  # from a non-partial view, whose class DOES write `include PostsHelper`. If
+  # only this one regresses, the RBS half of the chain broke.
+  def comment_author_badge(comment)
+    content_tag(:span, comment.author_name, class: "comment-badge")
+  end
 end

--- a/spec/dummy/app/views/posts/_comment.html.erb
+++ b/spec/dummy/app/views/posts/_comment.html.erb
@@ -1,4 +1,5 @@
 <div class="comment" id="comment-<%= comment.id %>">
   <p class="comment-author"><%= comment.author_name %></p>
+  <p><%= comment_author_badge(comment) %></p>
   <p class="comment-body"><%= comment.body %></p>
 </div>

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -2242,6 +2242,12 @@ method_entry_facts:
   ivars:
     "@post": "(::Post & ::Post::Validated)"
 - class: PostsHelper
+  method: comment_author_badge
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
+- class: PostsHelper
   method: post_index_marker
   consts:
     Current.author_name: "::String"

--- a/spec/dummy/sig/rbs_infer/app/helpers/posts_helper.rbs
+++ b/spec/dummy/sig/rbs_infer/app/helpers/posts_helper.rbs
@@ -3,4 +3,5 @@ module PostsHelper
   def post_summary: ((Post & Post::Validated) post, ?Integer length) -> String
   def post_weights: (?Array[Integer] weights, ?Integer length, ?singleton(::Palette) klass) -> String
   def post_index_marker: ((Post & Post::Validated) post) -> String
+  def comment_author_badge: (Comment & Comment::Validated comment) -> String
 end

--- a/spec/expectations/helpers/posts_helper.rbs
+++ b/spec/expectations/helpers/posts_helper.rbs
@@ -3,4 +3,5 @@ module PostsHelper
   def post_summary: ((Post & Post::Validated) post, ?Integer length) -> String
   def post_weights: (?Array[Integer] weights, ?Integer length, ?singleton(::Palette) klass) -> String
   def post_index_marker: ((Post & Post::Validated) post) -> String
+  def comment_author_badge: (Comment & Comment::Validated comment) -> String
 end

--- a/spec/lib/rbs_infer/project/mixin_index_spec.rb
+++ b/spec/lib/rbs_infer/project/mixin_index_spec.rb
@@ -389,4 +389,50 @@ RSpec.describe RbsInfer::Project::MixinIndex do
       expect(index.files_reaching("Foo")).to include(bar)
     end
   end
+
+  # The include chain is not always written in Ruby. A generated `.rbs` can
+  # declare a module and what it mixes in — `ActionViewContext` includes every
+  # Rails helper — and a file including THAT reaches the far end of the chain
+  # without ever naming it.
+  describe "a chain running through a module declared only in RBS" do
+    around do |example|
+      Dir.chdir(@dir) do
+        RbsInfer::Signatures::SteepEnvironment.reset!
+        example.run
+      end
+      RbsInfer::Signatures::SteepEnvironment.reset!
+    end
+
+    it "reaches a module carried by an RBS-only mixin" do
+      write_file("sig/generated/context.rbs", <<~RBS)
+        module ViewContext
+          include Sharable
+        end
+
+        module Sharable
+          def badge: (untyped) -> void
+        end
+      RBS
+      sharable = write_file("sharable.rb", "module Sharable\n  def badge(x) = nil\nend\n")
+      template = write_file("template.rb", "class Template\n  include ViewContext\n  badge(thing)\nend\n")
+
+      index = described_class.new([sharable, template])
+
+      expect(index.files_reaching("Sharable")).to include(template)
+    end
+
+    # The RBS half is additive. A cold run has no generated `sig/` yet, and an
+    # environment that cannot answer must leave the source-derived answer
+    # standing rather than reading as "this mixin carries nothing".
+    it "still reaches what the source alone shows when RBS knows nothing" do
+      sharable = write_file("sharable.rb", "module Sharable\n  def badge(x) = nil\nend\n")
+      direct = write_file("direct.rb", "class Direct\n  include Sharable\n  badge(thing)\nend\n")
+      template = write_file("template.rb", "class Template\n  include ViewContext\n  badge(thing)\nend\n")
+
+      index = described_class.new([sharable, direct, template])
+
+      expect(index.files_reaching("Sharable")).to include(direct)
+      expect(index.files_reaching("Sharable")).not_to include(template)
+    end
+  end
 end


### PR DESCRIPTION
`MixinIndex#files_reaching` answers who can reach a module's instance methods with a bare call, and it read the include chain from the corpus alone: a file is a host only if some source in it writes `include <target>`. A chain running through a module declared **only in RBS** stopped one link short.

Every ERB template's generated class includes `ActionViewContext` and nothing else, and `ActionViewContext` — emitted as `.rbs` by the rails_custom generator, because two of its includes are RBS *interfaces* that cannot be written in Ruby — is what carries every app helper. So a partial calling a helper was a host of nothing, and no other route covered it either: the template names no constant (`files_referencing` misses), the call has no receiver (`files_calling` keys on the `.`), and `files_with_bare_call` is gated on `universal_ancestor?`.

The call site was never read and the helper's parameter came out `untyped`, while Steep typed the very same argument precisely.

## The miss, in an app

```ruby
# app/helpers/sugestoes_helper.rb
def idade_recomendada_para(recomendacao_vacina)  # -> untyped
```

Called from exactly one place, `app/views/sugestoes/_recomendacao_vacina.html.erb`, where Steep types the argument `(::Caderneta::RecomendacaoVacina & ::Caderneta::RecomendacaoVacina::Validated)`. The four candidate-caller routes returned:

```
files_reaching(SugestoesHelper)        -> index.html.erb, .../sugestoes/index.rb   (partial absent)
files_referencing(SugestoesHelper)     -> sugestoes_helper.rb, .../sugestoes/index.rb
files_calling(idade_recomendada_para)  -> (empty)
files_with_bare_call(...)              -> (empty)
```

The non-partial `index.html.erb` was reached only because `Views::PseudoCodeBuilder#includes` writes an explicit `include SugestoesHelper` for a view — `PathNaming#parse_view_path` returns nil for a partial by design. That explicit include is what masked the gap.

## The fix

Ask the RBS environment. It already holds the answer, transitively and for `.rbs`-only modules alike:

```
ERBPartialSugestoesRecomendacaoVacina instance ancestors:
  ::ActionViewContext, ::SugestoesHelper, ::PessoasHelper, ::DosesHelper, ::ApplicationHelper
```

`carrier_shorts` expands the target into itself plus every written mixin name whose RBS ancestry reaches it, and `host_files` matches against that set. Asked once per **written mixin name** (dozens), not once per file (hundreds) — what a name carries is a property of the name.

Memoized against the environment's identity, the same key `SteepBridge` hangs its type-check cache on, so `SteepEnvironment.reset!` between dependency levels and stabilization passes drops it: no new invalidation hook. This is what keeps `Corpus` honest, which caches one `MixinIndex` for the whole run on the grounds that its answers are a pure function of the source files — this one is not.

An environment that cannot answer leaves the source-derived half standing. That is not a corner case: on a cold run, before `sig/` exists, the chain does not resolve and the run converges on the next pass, which is what the `rbs_converge` loop already does.

### Rejected: emitting `ActionViewContext` as `.rb`

Measured — it does not fix this. With an `ActionViewContext.rb` in the corpus, `files_reaching` still omits the partial, because `host_files` matches only *direct* includes; the transitive step is needed either way. And two of the module's includes are RBS interfaces that are not expressible in Ruby, so the generator would still have to emit a `.rbs` alongside.

## Cost

Full `rbs_infer app/ lib/ sig/ --output` on a real app (132-file corpus), interleaved, three pairs:

| | run 1 | run 2 | run 3 | median |
|---|---|---|---|---|
| before | 24.8s | 27.1s | 23.5s | 24.8s |
| after | 31.9s | 31.2s | 27.5s | 31.2s |

About +25%. The cause is the candidate sweep for a helper module going from 2 files to ~72 of 132 — which is the correct answer (`include_all_helpers` makes every helper visible in every view), but every candidate is type-checked by `CallerFileAnalyzer`.

A follow-up recovers most of it: intersecting `reaching` with `SourceIndex#files_mentioning`, whose own doc calls it the only one of the four indexes safe to read as "these are ALL the files that could call it" — a file that never writes the method name cannot call it. Prototyped and measured at 27.1/28.2/25.6s (median 27.1s, so +2.3s instead of +6.4s) with byte-identical inference output. Left out of this PR because it changes candidate selection for every target, not just this bug.

## Effect on the app

Two signatures move, both toward the truth:

```diff
-def idade_recomendada_para: (untyped recomendacao_vacina) -> String?
+def idade_recomendada_para: (Caderneta::RecomendacaoVacina & Caderneta::RecomendacaoVacina::Validated recomendacao_vacina) -> String?

-def avatar_da_pessoa: ((Pessoa & Pessoa::Validated) pessoa, ?classes: untyped) -> untyped
+def avatar_da_pessoa: (((Pessoa & Pessoa::Validated) | Pessoa | (Pessoa & Pessoa::Validated)?) pessoa, ?classes: String?) -> untyped
```

The second is worth reading closely. `avatar_da_pessoa` has six call sites; only the one in a non-partial view was visible before, so the signature was narrower than the callers. Now the partial in `shared/` and the view in another controller's directory are read too, and both pass `Current.pessoa` — genuinely nilable.

The app's steep run goes 141 -> 143 diagnostics, and the move is the point:

- **2 resolved**, both `Cannot pass a value of type ... as an argument of type (Pessoa & Pessoa::Validated)` at call sites the old narrow signature was wrongly blaming.
- **4 new**, all inside the helper body: `Type ((Pessoa & Pessoa::Validated) | Pessoa | nil) does not have method avatar` / `nome` / `iniciais`. The body dereferences `pessoa` with no nil check, and two call sites really do pass a nilable.

The errors moved from the callers to the body — the truthful location for a latent nil bug the tool previously could not see.

(The union is not minimal — `(Pessoa & Pessoa::Validated) | Pessoa | (Pessoa & Pessoa::Validated)?` is `Pessoa?`. That is existing `TypeMerger` behaviour, untouched here.)

## Tests

- `spec/lib/rbs_infer/project/mixin_index_spec.rb` — two units: a chain through an RBS-only mixin resolves; an environment that knows nothing leaves the source-derived answer standing.
- Dummy fixture: `comment_author_badge` is called only from `posts/_comment.html.erb`, paired with the existing `post_index_marker`, which is called from a non-partial view whose class *does* write `include PostsHelper`. If only the first regresses, the RBS half of the chain broke.
- `1336 examples, 0 failures` (unit) and `134 examples, 0 failures` (integration); the dummy's steep baseline is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BrWNAbYgzR7CKVuoKk6DS