### PR TITLE
fix(params): ask the checker for a self-send argument, not the attr table

### DIFF
--- a/lib/rbs_infer/inference/intra_class_call_analyzer.rb
+++ b/lib/rbs_infer/inference/intra_class_call_analyzer.rb
@@ -20,6 +20,12 @@ module RbsInfer::Inference
       # Per-READ types, which carry Steep's narrowing; `@steep_local_var_types`
       # is per-method and cannot (felixefelip/rbs_infer#142).
       @steep_lvar_read_types = steep_bridge && source_code ? steep_bridge.local_var_read_types(source_code) : {}
+      # Every typed expression in this file, keyed by range. `@attr_types` can
+      # only answer for the class's own `attr_*`; an association reader, a
+      # delegated method, a plain `def` — anything else the body calls on itself
+      # — was not in it and resolved to `untyped`, which drops the call site
+      # from the candidates entirely (felixefelip/rbs_infer#298).
+      @steep_expression_types = steep_bridge && source_code ? steep_bridge.all_expression_types(source_code) : {}
       # Constant args resolve to their value type (#46); intra-class
       # constants are in this same source, covered by the same-file tier.
       @constant_arg_resolver = ConstantArgTypeResolver.new(
@@ -215,6 +221,18 @@ module RbsInfer::Inference
       @steep_lvar_read_types[[node.location.start_line, node.location.start_character_column]]
     end
 
+    # Steep's type for an arbitrary expression, or nil. Keyed by the node's whole
+    # RANGE, so a receiver cannot answer for the call that wraps it — the same
+    # key `NewCallCollector#expression_type` builds.
+    def expression_type(node)
+      type = @steep_expression_types[RbsInfer::Signatures::SteepBridge.prism_expression_key(node.location)]
+
+      # `self` is a real RBS type meaning "the receiver of THIS method", so
+      # carrying it into another method's parameter says the argument is
+      # whatever that method was called on. Unusable here.
+      type unless type == "self"
+    end
+
     def resolve_value_type(node)
       literal = RbsInfer::AST::NodeTypeInferrer.infer_literal_node_type(node, constant_resolver: @constant_arg_resolver)
       return literal if literal
@@ -231,7 +249,11 @@ module RbsInfer::Inference
         if node.name == :new && node.receiver
           RbsInfer::Analyzer.extract_constant_path(node.receiver) || "untyped"
         elsif node.receiver.nil?
-          @attr_types[node.name.to_s] || "untyped"
+          # The checker first, `@attr_types` as the fallback where it has no
+          # answer — the same order `lvar_read_type` uses above, and for the same
+          # reason: this is the type the argument HAS at the point it is passed,
+          # narrowing included.
+          expression_type(node) || @attr_types[node.name.to_s] || "untyped"
         elsif (node.receiver.is_a?(Prism::ConstantReadNode) || node.receiver.is_a?(Prism::ConstantPathNode)) && @method_type_resolver
           class_name = RbsInfer::Analyzer.extract_constant_path(node.receiver)
           if class_name

--- a/spec/dummy/sig/generated/.steep_contracts.yml
+++ b/spec/dummy/sig/generated/.steep_contracts.yml
@@ -149,6 +149,8 @@ methods:
         receiver:
           kind: self
         method: created_at
+    - kind: self_type
+      type: "(::Post & ::Post::Validated)"
   Post::Notifiable#notification_payload:
     requires:
     - kind: not_nil

--- a/spec/dummy/sig/rbs_rails/app/models/account.rbs
+++ b/spec/dummy/sig/rbs_rails/app/models/account.rbs
@@ -414,13 +414,13 @@ class ::Account < ::ApplicationRecord
   end
 
   class ::Account::ActiveRecord_Relation < ::ActiveRecord::Relation
-    include ::Enumerable[::Account]
+    include ::Enumerable[::Account & ::Account::Validated]
     include ::Account::GeneratedRelationMethods
     include ::ActiveRecord::Relation::Methods[::Account, ::Integer, ::Account::Validated]
   end
 
   class ::Account::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
-    include ::Enumerable[::Account]
+    include ::Enumerable[::Account & ::Account::Validated]
     include ::Account::GeneratedRelationMethods
     include ::ActiveRecord::Relation::Methods[::Account, ::Integer, ::Account::Validated]
 

--- a/spec/dummy/sig/rbs_rails/app/models/assignment.rbs
+++ b/spec/dummy/sig/rbs_rails/app/models/assignment.rbs
@@ -267,13 +267,13 @@ class ::Assignment < ::ApplicationRecord
   end
 
   class ::Assignment::ActiveRecord_Relation < ::ActiveRecord::Relation
-    include ::Enumerable[::Assignment]
+    include ::Enumerable[::Assignment & ::Assignment::Validated]
     include ::Assignment::GeneratedRelationMethods
     include ::ActiveRecord::Relation::Methods[::Assignment, ::Integer, ::Assignment::Validated]
   end
 
   class ::Assignment::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
-    include ::Enumerable[::Assignment]
+    include ::Enumerable[::Assignment & ::Assignment::Validated]
     include ::Assignment::GeneratedRelationMethods
     include ::ActiveRecord::Relation::Methods[::Assignment, ::Integer, ::Assignment::Validated]
 

--- a/spec/dummy/sig/rbs_rails/app/models/comment.rbs
+++ b/spec/dummy/sig/rbs_rails/app/models/comment.rbs
@@ -310,13 +310,13 @@ class ::Comment < ::ApplicationRecord
   end
 
   class ::Comment::ActiveRecord_Relation < ::ActiveRecord::Relation
-    include ::Enumerable[::Comment]
+    include ::Enumerable[::Comment & ::Comment::Validated]
     include ::Comment::GeneratedRelationMethods
     include ::ActiveRecord::Relation::Methods[::Comment, ::Integer, ::Comment::Validated]
   end
 
   class ::Comment::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
-    include ::Enumerable[::Comment]
+    include ::Enumerable[::Comment & ::Comment::Validated]
     include ::Comment::GeneratedRelationMethods
     include ::ActiveRecord::Relation::Methods[::Comment, ::Integer, ::Comment::Validated]
 

--- a/spec/dummy/sig/rbs_rails/app/models/notification.rbs
+++ b/spec/dummy/sig/rbs_rails/app/models/notification.rbs
@@ -304,13 +304,13 @@ class ::Notification < ::ApplicationRecord
   end
 
   class ::Notification::ActiveRecord_Relation < ::ActiveRecord::Relation
-    include ::Enumerable[::Notification]
+    include ::Enumerable[::Notification & ::Notification::Validated]
     include ::Notification::GeneratedRelationMethods
     include ::ActiveRecord::Relation::Methods[::Notification, ::Integer, ::Notification::Validated]
   end
 
   class ::Notification::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
-    include ::Enumerable[::Notification]
+    include ::Enumerable[::Notification & ::Notification::Validated]
     include ::Notification::GeneratedRelationMethods
     include ::ActiveRecord::Relation::Methods[::Notification, ::Integer, ::Notification::Validated]
 

--- a/spec/dummy/sig/rbs_rails/app/models/post.rbs
+++ b/spec/dummy/sig/rbs_rails/app/models/post.rbs
@@ -531,13 +531,13 @@ class ::Post < ::ApplicationRecord
   end
 
   class ::Post::ActiveRecord_Relation < ::ActiveRecord::Relation
-    include ::Enumerable[::Post]
+    include ::Enumerable[::Post & ::Post::Validated]
     include ::Post::GeneratedRelationMethods
     include ::ActiveRecord::Relation::Methods[::Post, ::Integer, ::Post::Validated]
   end
 
   class ::Post::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
-    include ::Enumerable[::Post]
+    include ::Enumerable[::Post & ::Post::Validated]
     include ::Post::GeneratedRelationMethods
     include ::ActiveRecord::Relation::Methods[::Post, ::Integer, ::Post::Validated]
 

--- a/spec/dummy/sig/rbs_rails/app/models/post_tag.rbs
+++ b/spec/dummy/sig/rbs_rails/app/models/post_tag.rbs
@@ -267,13 +267,13 @@ class ::PostTag < ::ApplicationRecord
   end
 
   class ::PostTag::ActiveRecord_Relation < ::ActiveRecord::Relation
-    include ::Enumerable[::PostTag]
+    include ::Enumerable[::PostTag & ::PostTag::Validated]
     include ::PostTag::GeneratedRelationMethods
     include ::ActiveRecord::Relation::Methods[::PostTag, ::Integer, ::PostTag::Validated]
   end
 
   class ::PostTag::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
-    include ::Enumerable[::PostTag]
+    include ::Enumerable[::PostTag & ::PostTag::Validated]
     include ::PostTag::GeneratedRelationMethods
     include ::ActiveRecord::Relation::Methods[::PostTag, ::Integer, ::PostTag::Validated]
 

--- a/spec/dummy/sig/rbs_rails/app/models/tag.rbs
+++ b/spec/dummy/sig/rbs_rails/app/models/tag.rbs
@@ -220,13 +220,13 @@ class ::Tag < ::ApplicationRecord
   end
 
   class ::Tag::ActiveRecord_Relation < ::ActiveRecord::Relation
-    include ::Enumerable[::Tag]
+    include ::Enumerable[::Tag & ::Tag::Validated]
     include ::Tag::GeneratedRelationMethods
     include ::ActiveRecord::Relation::Methods[::Tag, ::Integer, ::Tag::Validated]
   end
 
   class ::Tag::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
-    include ::Enumerable[::Tag]
+    include ::Enumerable[::Tag & ::Tag::Validated]
     include ::Tag::GeneratedRelationMethods
     include ::ActiveRecord::Relation::Methods[::Tag, ::Integer, ::Tag::Validated]
 

--- a/spec/dummy/sig/rbs_rails/app/models/user.rbs
+++ b/spec/dummy/sig/rbs_rails/app/models/user.rbs
@@ -432,13 +432,13 @@ class ::User < ::ApplicationRecord
   end
 
   class ::User::ActiveRecord_Relation < ::ActiveRecord::Relation
-    include ::Enumerable[::User]
+    include ::Enumerable[::User & ::User::Validated]
     include ::User::GeneratedRelationMethods
     include ::ActiveRecord::Relation::Methods[::User, ::Integer, ::User::Validated]
   end
 
   class ::User::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
-    include ::Enumerable[::User]
+    include ::Enumerable[::User & ::User::Validated]
     include ::User::GeneratedRelationMethods
     include ::ActiveRecord::Relation::Methods[::User, ::Integer, ::User::Validated]
 

--- a/spec/expectations/services/tag_destroy.rbs
+++ b/spec/expectations/services/tag_destroy.rbs
@@ -16,7 +16,7 @@ class TagDestroy
   def iterate_tag_posts: () -> Tag_Post::ActiveRecord_Associations_CollectionProxy
   def iterate_tag_posts_with_transaction: () -> Tag_Post::ActiveRecord_Associations_CollectionProxy
   def call_process_tag: () -> void
-  def process_tag: (Tag & Tag::Validated tag) -> void
+  def process_tag: ((Tag & Tag::Validated) tag) -> void
   def test_nokogiri: () -> Nokogiri::XML::Document
   def parse_xml: () -> Array[Nokogiri::XML::Node]
   def parse_xml_as_hash: () -> Array[{ date: Nokogiri::XML::Node?, order: Nokogiri::XML::Node }]

--- a/spec/expectations/steep_contracts.yml
+++ b/spec/expectations/steep_contracts.yml
@@ -149,6 +149,8 @@ methods:
         receiver:
           kind: self
         method: created_at
+    - kind: self_type
+      type: "(::Post & ::Post::Validated)"
   Post::Notifiable#notification_payload:
     requires:
     - kind: not_nil

--- a/spec/lib/rbs_infer/inference/intra_class_call_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/inference/intra_class_call_analyzer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RbsInfer::Inference::IntraClassCallAnalyzer do
   # felixefelip/rbs_infer#142. The argument is narrowed at the point it is
   # passed, and the callee's parameter must not be typed as if it were not:
   # a nilable parameter makes every downstream fact about it unprovable.
-  it "usa o tipo NARROWED do local no call-site, não o da atribuição", :dummy_app do
+  it "uses the local's NARROWED type at the call site, not the assignment's", :dummy_app do
     source = <<~RUBY
       class Foo
         def call
@@ -44,7 +44,7 @@ RSpec.describe RbsInfer::Inference::IntraClassCallAnalyzer do
   # was dropped from the candidates. With one other call site typed, the
   # parameter then took THAT site's type as if it were the only one: the union
   # was not widened, it was never formed.
-  it "usa o tipo do checker para um argumento que é um self-send", :dummy_app do
+  it "uses the checker's type for an argument that is a self-send", :dummy_app do
     source = <<~RUBY
       class Post
         def call
@@ -68,21 +68,21 @@ RSpec.describe RbsInfer::Inference::IntraClassCallAnalyzer do
     expect(visitor.inferred_param_types["publish"]["user"]).to eq("User?")
   end
 
-  it "infere tipo de kwarg via local variable = Klass.new(...)" do
+  it "infers a kwarg's type through a local assigned from Klass.new(...)" do
     source = <<~RUBY
       class Foo
         def call
-          aluno = Entity.new(nome: "test")
-          publicar(aluno:)
+          student = Entity.new(name: "test")
+          enroll(student:)
         end
 
-        def publicar(aluno:)
+        def enroll(student:)
         end
       end
     RUBY
 
     visitor = analyze(source)
-    expect(visitor.inferred_param_types["publicar"]["aluno"]).to eq("Entity")
+    expect(visitor.inferred_param_types["enroll"]["student"]).to eq("Entity")
   end
 
   it "unions kwarg types from distinct call-sites (felixefelip/rbs_infer#64)" do
@@ -105,118 +105,118 @@ RSpec.describe RbsInfer::Inference::IntraClassCallAnalyzer do
     expect(visitor.inferred_param_types["track_event"]["action"]).to eq("(String | Symbol)")
   end
 
-  it "infere tipo via ImplicitNode (shorthand keyword: publicar(aluno:))" do
+  it "infers a type through an ImplicitNode (shorthand keyword: enroll(student:))" do
     source = <<~RUBY
       class Foo
         def call
-          aluno = ::MyApp::Entity.new(nome: "test")
-          publicar(aluno:)
+          student = ::MyApp::Entity.new(name: "test")
+          enroll(student:)
         end
       end
     RUBY
 
     visitor = analyze(source)
-    expect(visitor.inferred_param_types["publicar"]["aluno"]).to eq("::MyApp::Entity")
+    expect(visitor.inferred_param_types["enroll"]["student"]).to eq("::MyApp::Entity")
   end
 
-  it "ignora argumentos com tipo desconhecido" do
+  it "ignores arguments whose type is unknown" do
     source = <<~RUBY
       class Foo
         def call
-          publicar(aluno: alguma_coisa)
+          enroll(student: something_or_other)
         end
       end
     RUBY
 
     visitor = analyze(source)
-    expect(visitor.inferred_param_types["publicar"]).to be_empty
+    expect(visitor.inferred_param_types["enroll"]).to be_empty
   end
 
-  it "infere múltiplos kwargs na mesma chamada" do
+  it "infers several kwargs from the same call" do
     source = <<~RUBY
       class Foo
         def call
-          aluno = Entity.new
-          curso = Curso.new
-          matricular(aluno:, curso:)
+          student = Entity.new
+          course = Course.new
+          enroll(student:, course:)
         end
       end
     RUBY
 
     visitor = analyze(source)
-    expect(visitor.inferred_param_types["matricular"]["aluno"]).to eq("Entity")
-    expect(visitor.inferred_param_types["matricular"]["curso"]).to eq("Curso")
+    expect(visitor.inferred_param_types["enroll"]["student"]).to eq("Entity")
+    expect(visitor.inferred_param_types["enroll"]["course"]).to eq("Course")
   end
 
-  context "usage-side: infere tipos de params via Klass.new(param:) no corpo" do
+  context "usage-side: infers param types from a Klass.new(param:) in the body" do
     let(:resolver) do
       instance_double(RbsInfer::Signatures::MethodTypeResolver).tap do |r|
-        allow(r).to receive(:resolve_all).with("Telefone").and_return({
-          "ddd" => "String",
-          "numero" => "String"
+        allow(r).to receive(:resolve_all).with("Phone").and_return({
+          "area_code" => "String",
+          "number" => "String"
         })
       end
     end
 
-    it "infere tipo de param quando forwarded via shorthand para Klass.new(param:)" do
+    it "infers a param's type when it is forwarded by shorthand to Klass.new(param:)" do
       source = <<~RUBY
         class Foo
-          def adicionar_telefone(ddd:, numero:)
-            Telefone.new(ddd:, numero:)
+          def add_phone(area_code:, number:)
+            Phone.new(area_code:, number:)
           end
         end
       RUBY
 
       visitor = analyze(source, method_type_resolver: resolver)
-      expect(visitor.inferred_param_types["adicionar_telefone"]["ddd"]).to eq("String")
-      expect(visitor.inferred_param_types["adicionar_telefone"]["numero"]).to eq("String")
+      expect(visitor.inferred_param_types["add_phone"]["area_code"]).to eq("String")
+      expect(visitor.inferred_param_types["add_phone"]["number"]).to eq("String")
     end
 
-    it "infere tipo via param: param explícito em Klass.new" do
+    it "infers a type through an explicit `param: param` in Klass.new" do
       source = <<~RUBY
         class Foo
-          def adicionar(codigo:)
-            Telefone.new(ddd: codigo)
+          def add(code:)
+            Phone.new(area_code: code)
           end
         end
       RUBY
 
       resolver_local = instance_double(RbsInfer::Signatures::MethodTypeResolver)
-      allow(resolver_local).to receive(:resolve_all).with("Telefone").and_return({
-        "ddd" => "String",
-        "numero" => "String"
+      allow(resolver_local).to receive(:resolve_all).with("Phone").and_return({
+        "area_code" => "String",
+        "number" => "String"
       })
 
       visitor = analyze(source, method_type_resolver: resolver_local)
-      expect(visitor.inferred_param_types["adicionar"]["codigo"]).to eq("String")
+      expect(visitor.inferred_param_types["add"]["code"]).to eq("String")
     end
 
-    it "não infere quando o valor não é um parâmetro do método" do
+    it "does not infer when the value is not a parameter of the method" do
       source = <<~RUBY
         class Foo
-          def adicionar(ddd:)
+          def add(area_code:)
             local = "11"
-            Telefone.new(ddd:, numero: local)
+            Phone.new(area_code:, number: local)
           end
         end
       RUBY
 
       visitor = analyze(source, method_type_resolver: resolver)
-      expect(visitor.inferred_param_types["adicionar"]["ddd"]).to eq("String")
-      expect(visitor.inferred_param_types["adicionar"]).not_to have_key("numero")
+      expect(visitor.inferred_param_types["add"]["area_code"]).to eq("String")
+      expect(visitor.inferred_param_types["add"]).not_to have_key("number")
     end
 
-    it "não infere sem method_type_resolver" do
+    it "does not infer without a method_type_resolver" do
       source = <<~RUBY
         class Foo
-          def adicionar(ddd:)
-            Telefone.new(ddd:)
+          def add(area_code:)
+            Phone.new(area_code:)
           end
         end
       RUBY
 
       visitor = analyze(source)
-      expect(visitor.inferred_param_types["adicionar"]).to be_empty
+      expect(visitor.inferred_param_types["add"]).to be_empty
     end
   end
 end

--- a/spec/lib/rbs_infer/inference/intra_class_call_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/inference/intra_class_call_analyzer_spec.rb
@@ -38,6 +38,36 @@ RSpec.describe RbsInfer::Inference::IntraClassCallAnalyzer do
     expect(visitor.inferred_param_types["publish"]["user"]).to eq("(User & User::Validated)")
   end
 
+  # felixefelip/rbs_infer#298. A receiverless call resolved through `@attr_types`
+  # alone, which only ever holds the class's own `attr_*`. An association reader
+  # — or any other `def` — was not in it, came back `untyped`, and the call site
+  # was dropped from the candidates. With one other call site typed, the
+  # parameter then took THAT site's type as if it were the only one: the union
+  # was not widened, it was never formed.
+  it "usa o tipo do checker para um argumento que é um self-send", :dummy_app do
+    source = <<~RUBY
+      class Post
+        def call
+          publish(user)
+        end
+
+        def publish(user)
+        end
+      end
+    RUBY
+
+    bridge = RbsInfer::Signatures::SteepBridge.new
+    result = Prism.parse(source)
+    visitor = described_class.new(
+      steep_bridge: bridge,
+      source_code: source,
+      method_positional_params: { "publish" => ["user"] }
+    )
+    result.value.accept(visitor)
+
+    expect(visitor.inferred_param_types["publish"]["user"]).to eq("User?")
+  end
+
   it "infere tipo de kwarg via local variable = Klass.new(...)" do
     source = <<~RUBY
       class Foo


### PR DESCRIPTION
## The bug

`IntraClassCallAnalyzer` resolved a receiverless call argument through a lookup table that only ever holds the class's own `attr_*` (`intra_class_call_analyzer.rb:251`):

```ruby
elsif node.receiver.nil?
  @attr_types[node.name.to_s] || "untyped"
```

An association reader, a delegated method, a plain `def` — anything else the body calls on itself — was not in that table, came back `"untyped"`, and `"untyped"` candidates are dropped (lines 66 and 92). So the call site was not *widened into* the union; **it was never counted at all.**

Invisible while it is the only call site (the parameter stays `untyped` either way), and wrong the moment there is a second one — the parameter takes the *other* site's type as if it were alone:

```ruby
creator: export_user(creator),                 # dropped: `creator` is a self-send
...
  creator: export_user(comment.creator),       # counted: `comment` is a local
```
```rbs
def export_user: (User & User::Validated user) -> ...
```

One of two call sites decided it.

## Proof

Eight lines against the dummy app reproduce the mechanism, and show the answer was available the whole time:

```
INFERRED:   {}                                  <- no candidate at all
STEEP SAYS: {"3:12-3:16" => "User?", ...}       <- the exact node
```

## The fix

`SteepBridge#all_expression_types` is the same map `NewCallCollector`, `BlockSignatureResolver` and `CallerFileAnalyzer` already read — keyed by the node's whole range, so a receiver cannot answer for the call that wraps it. Ask it first, fall back to `@attr_types` where it has no answer.

That order is the one `lvar_read_type` already uses one branch above, for the same stated reason: this is the type the argument **has where it is passed**, narrowing included. `self` is filtered out exactly as `NewCallCollector#expression_type` does — it means "the receiver of THIS method" and says nothing about another method's parameter.

Scoped to the receiverless branch. The `.new` and constant-receiver branches resolve deliberately (a constant path beats the checker for a generic's arguments) and are left alone.

## Verification

Full suite green: **1535 examples, 0 failures**.

Snapshot movement is one line, and it is the checker's rendering winning over the table's for an attr the two already agreed on:

```diff
-  def process_tag: (Tag & Tag::Validated tag) -> void
+  def process_tag: ((Tag & Tag::Validated) tag) -> void
```

## Also carried

The dummy's regeneration for two upstream changes already merged:

- **rbs_rails#18** — `include ::Enumerable[Model & Model::Validated]` on every relation/collection proxy.
- **steep#158** — `Post::Exportable#export_stamp` gains the `self_type: "(::Post & ::Post::Validated)"` predicate its single validated call site proves. That is the fixture whose own comment documents the case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jet9LtU182AyZRYL9uM21y