### PR TITLE
Give the extracted classes back the private they lost

### DIFF
--- a/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
@@ -114,8 +114,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
 
     protected
 
-    # One reader where there were fourteen: what this file said, for the
-    # collector absorbing it (felixefelip/rbs_infer#306).
+    # What this file said, for the collector absorbing it.
     attr_reader :shapes, :providers
 
     # What an ABSORBING collector reads off this one, answered by the

--- a/lib/rbs_infer/project/stored_block_replay_expander/corpus.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/corpus.rb
@@ -66,6 +66,8 @@ module RbsInfer::Project::StoredBlockReplayExpander
       Reach.new(names: seen, shapes: found)
     end
 
+    private
+
     # The name a lookup lands on: the first candidate the project actually
     # declares, or — when it declares none of them — the name as written, which
     # is what this pass answered before it asked at all. Falling back rather

--- a/lib/rbs_infer/project/stored_block_replay_expander/declarations.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/declarations.rb
@@ -220,6 +220,8 @@ module RbsInfer::Project::StoredBlockReplayExpander
       owner.to_s.sub(/\Asingleton\((.*)\)\z/, "\\1")
     end
 
+    private
+
     # The name an `extend` writes, for a module this file does not declare.
     #
     # `resolve` answers nil for those, and rightly: it is picking a NAMESPACE,
@@ -230,8 +232,6 @@ module RbsInfer::Project::StoredBlockReplayExpander
     def self.written_constant(node)
       RbsInfer::Analyzer.extract_constant_path(node)&.sub(/\A::/, "")
     end
-
-    private
 
     def qualify(name)
       name = name.to_s.sub(/\A::/, "")

--- a/lib/rbs_infer/project/stored_block_replay_expander/dsl_graph.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/dsl_graph.rb
@@ -128,6 +128,8 @@ module RbsInfer::Project::StoredBlockReplayExpander
       names.first if names.size == 1
     end
 
+    private
+
     # What a subject extending `provider` writes to reach `storage_owner#method`.
     # The keeper's own name when the provider IS the keeper; the delegating
     # method's name when it is not. Reading the keeper's name in both cases only

--- a/lib/rbs_infer/project/stored_block_replay_expander/resolution.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/resolution.rb
@@ -74,10 +74,6 @@ module RbsInfer::Project::StoredBlockReplayExpander
 
     private
 
-    # Everything below is one step of `run`. They were public only because the
-    # split that moved them here carried the methods and not the `private` that
-    # stood over them in `Collector` (felixefelip/rbs_infer#307).
-
     # The block a DSL call runs where it stands, or nil when the file does not
     # decide it.
     #

--- a/lib/rbs_infer/project/stored_block_replay_expander/resolution.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/resolution.rb
@@ -72,6 +72,12 @@ module RbsInfer::Project::StoredBlockReplayExpander
       resolved.uniq { |replay| [replay.target, replay.singleton, replay.source, replay.block.location.start_offset] }
     end
 
+    private
+
+    # Everything below is one step of `run`. They were public only because the
+    # split that moved them here carried the methods and not the `private` that
+    # stood over them in `Collector` (felixefelip/rbs_infer#308).
+
     # The block a DSL call runs where it stands, or nil when the file does not
     # decide it.
     #

--- a/lib/rbs_infer/project/stored_block_replay_expander/resolution.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/resolution.rb
@@ -76,7 +76,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
 
     # Everything below is one step of `run`. They were public only because the
     # split that moved them here carried the methods and not the `private` that
-    # stood over them in `Collector` (felixefelip/rbs_infer#308).
+    # stood over them in `Collector` (felixefelip/rbs_infer#307).
 
     # The block a DSL call runs where it stands, or nil when the file does not
     # decide it.

--- a/lib/rbs_infer/project/stored_block_replay_expander/shapes.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/shapes.rb
@@ -11,9 +11,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
   # that decided which file a block's offsets index).
   #
   # Held apart from the collector for the plainest of reasons: they are
-  # declarations, not behaviour. Two hundred lines of them sat between the class
-  # comment and `initialize`, so the first thing a reader met was thirteen
-  # structs rather than the pass they belong to (felixefelip/rbs_infer#304).
+  # declarations, not behaviour.
   #
   # Included rather than referenced, so `Storage` keeps meaning `Storage` in
   # every method that builds one: a constant reached through an ancestor


### PR DESCRIPTION
`Resolution` had eighteen public methods and exactly one caller: `run`. The other sixteen are its own steps.

## Why it happened

Each extraction in #303–#306 moved methods by *span* — comment plus body. The `private` they sat under in `Collector` belongs to no span, so it stayed behind. `DeferralReader` escaped it only because that one was written by hand rather than moved by script.

## Where the line actually goes

Measured over `lib/` and `spec/` rather than assumed:

| class | called from outside | not called |
|---|---|---|
| `Resolution` | `run` | the other 16 |
| `DslGraph` | everything but `written_names` | 1 |
| `Corpus` | `reach`, `lookup_candidates` | `resolve_lookup` |
| `Declarations` | everything but `written_constant` | 1 |

The line lands somewhere different in each, and in `DslGraph` it moves exactly one method. A class whose surface is `run` should say so; one that is a lookup table for six questions should not pretend to be smaller than it is.

## What deliberately stays public

`ShapeReader` and `NodeReading` keep all fifteen methods public, and that is not the same oversight. They are modules of functions, called qualified from outside (`ShapeReader.replay_shape(node.body)`) and meant to be testable one at a time — public is their contract, where for a class with a `run` it was an accident.

## Verification

Suite: 1546 examples, 3 failures — the three worktree-environment ones that also fail on `main` from a worktree and pass in a normal checkout. Nothing broke, which is itself the point: if any of those sixteen had a caller, this would have failed loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179Um6Qoek3LMYrqHKUPuos