### PR TITLE
Narrow the collector's public surface to what a caller actually calls

### DIFF
--- a/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
@@ -68,43 +68,6 @@ module RbsInfer::Project::StoredBlockReplayExpander
       replays
     end
 
-    # The shapes this file wrote, resolved against the declarations now that all
-    # of them are known — a constant written in a hook's body may name a module
-    # declared further down, and a relative `extend Builder` needs the file's own
-    # namespaces before it can be read at all.
-    #
-    # The last step of COLLECTING rather than the first of resolving, which is
-    # why it sits here and not in `Resolution`: `collect_shapes` does the same
-    # four for a file read on another's behalf, where no resolution ever runs
-    # (felixefelip/rbs_infer#306).
-    def resolve_shapes
-      collect_readers_from_source
-
-      @shapes.deferrals.concat(resolve_deferrals)
-      @shapes.resolved_delegations.concat(resolve_delegations)
-      @shapes.resolved_inward_extends.concat(resolve_inward_extends)
-      @shapes.resolved_own_replays.concat(resolve_own_replays)
-    end
-
-    # Everything this file says about method shapes, for a collector reading it
-    # on another file's behalf. Its delegations are resolved here, against the
-    # declarations of the file they were written in — which is the only place
-    # the constant they name can be looked up.
-    def collect_shapes(root)
-      root.accept(self)
-      collect_readers_from_source
-      @shapes.deferrals.concat(resolve_deferrals)
-      @shapes.replace(:resolved_delegations, resolve_delegations)
-      @shapes.replace(:resolved_inward_extends, resolve_inward_extends)
-      @shapes.replace(:resolved_own_replays, resolve_own_replays)
-      # Who can call whose DSL, as THIS file writes it. A shape is only half of
-      # what another file needs: `extend ActiveSupport::Concern` is written in
-      # the concern, and without it a host holding the concern's shapes still
-      # cannot say which owner supplies them.
-      @providers = @names.providers
-      self
-    end
-
     def visit_class_node(node)
       @names.enter(node) { super }
     end
@@ -127,6 +90,25 @@ module RbsInfer::Project::StoredBlockReplayExpander
     end
 
     protected
+
+    # Everything this file says about method shapes, for a collector reading it
+    # on another file's behalf. Its delegations are resolved here, against the
+    # declarations of the file they were written in — which is the only place
+    # the constant they name can be looked up.
+    def collect_shapes(root)
+      root.accept(self)
+      collect_readers_from_source
+      @shapes.deferrals.concat(resolve_deferrals)
+      @shapes.replace(:resolved_delegations, resolve_delegations)
+      @shapes.replace(:resolved_inward_extends, resolve_inward_extends)
+      @shapes.replace(:resolved_own_replays, resolve_own_replays)
+      # Who can call whose DSL, as THIS file writes it. A shape is only half of
+      # what another file needs: `extend ActiveSupport::Concern` is written in
+      # the concern, and without it a host holding the concern's shapes still
+      # cannot say which owner supplies them.
+      @providers = @names.providers
+      self
+    end
 
     # What this file said, for the collector absorbing it.
     attr_reader :shapes, :providers
@@ -168,6 +150,24 @@ module RbsInfer::Project::StoredBlockReplayExpander
     end
 
     private
+
+    # The shapes this file wrote, resolved against the declarations now that all
+    # of them are known — a constant written in a hook's body may name a module
+    # declared further down, and a relative `extend Builder` needs the file's own
+    # namespaces before it can be read at all.
+    #
+    # The last step of COLLECTING rather than the first of resolving, which is
+    # why it sits here and not in `Resolution`: `collect_shapes` does the same
+    # four for a file read on another's behalf, where no resolution ever runs
+    # (felixefelip/rbs_infer#306).
+    def resolve_shapes
+      collect_readers_from_source
+
+      @shapes.deferrals.concat(resolve_deferrals)
+      @shapes.resolved_delegations.concat(resolve_delegations)
+      @shapes.resolved_inward_extends.concat(resolve_inward_extends)
+      @shapes.resolved_own_replays.concat(resolve_own_replays)
+    end
 
     def collect_method_shape(node)
       owner = @names.owner_for(node)


### PR DESCRIPTION
Follow-up to #307 and to the two commits on `main` that reorganized the sections
(`2c19ac2`, `5a854a1`). Those put the file in one `public → protected → private`
order; this asks the next question — of the methods left public, which ones does
anything actually call?

Two do not.

Measured across `lib/` and `spec/`: neither `resolve_shapes` nor `collect_shapes`
appears as a call anywhere outside `collector.rb`. The only hits are prose —
`shape_set.rb` and `dsl_graph.rb` mention them in comments. They were public
because `collect` grew out of them, not because they are a surface.

They are not the same kind of internal, though, and the difference is the point.

### `resolve_shapes` → private

Runs on `self`, once, as the last statement of `collect`:

```ruby
def collect(root)
  root.accept(self)
  absorb_external_shapes
  resolve_shapes
  ...
```

No second object ever asks for it. Private.

### `collect_shapes` → protected

Called on **another** collector. `absorb_external_shapes` builds one per file the
corpus reaches and asks it what that file said:

```ruby
shapes = self.class.new(entry.source, sources: ConstantSources::NONE)
             .collect_shapes(entry.result.value)
[shapes, shapes.external_lookups]
```

That is an explicit receiver, so private would break it. `protected` is the
visibility that states the rule the call already obeys: *a collector may ask a
collector.* It joins `shapes`, `providers`, `declaration_kinds` and
`external_lookups` — exactly the rest of that same contract — and opens the
section, because it is what produces the object the other four are read off.

### What stays public

`new`, `collect`, `extensions` — what `StoredBlockReplayExpander` calls — plus the
four `visit_*` methods, which cannot be narrowed: Prism dispatches them from
`Node#accept` with an explicit receiver that is a node, not a collector.

| | before | after |
|---|---|---|
| public | 9 | 7 |
| protected | 3 | 4 |
| private | 9 | 10 |

### Verification

The diff is a pure move — no body changed, no line of code added or removed.

`bundle exec rspec spec/lib/rbs_infer/project/` → 352 examples, 0 failures.

And a mutation, so the protected call is exercised rather than assumed: demoting
`collect_shapes` to private makes the cross-file concern specs fail
(`a concern included by its relative name …`), which is the path that reads one
collector from another. Restored, green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179Um6Qoek3LMYrqHKUPuos
