### PR TITLE
Read the `extend` link instead of assuming the hook ran

### DIFF
--- a/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
@@ -229,29 +229,46 @@ module RbsInfer::Project::StoredBlockReplayExpander
     end
 
     def collect_class_body_call(node)
-      case node.name
-      when :extend
-        return unless NodeReading.bare_or_self?(node) && node.arguments
+      return unless NodeReading.bare_or_self?(node)
 
+      record_extend(node)
+
+      if node.block.is_a?(Prism::BlockNode)
+        @shapes.stored_calls << StoredCall.new(owner: nil, subject: @names.current_scope, method: node.name.to_s,
+                                        block: node.block, source: @source)
+      elsif node.arguments
+        # One apply per argument. `apply(A, B)` asks for A's block AND B's,
+        # which is what a `*modules` forward means at runtime — each gets its
+        # own candidate, and each resolves (or declines) on its own evidence.
+        # Only single-argument calls used to be read at all, so the plural
+        # form resolved nothing (felixefelip/rbs_infer#253).
         node.arguments.arguments.each do |argument|
-          @names.record_extend(@names.current_scope, argument)
+          @shapes.apply_calls << ApplyCall.new(owner: nil, subject: @names.current_scope, method: node.name.to_s, argument: argument)
         end
-      else
-        return unless NodeReading.bare_or_self?(node)
+      end
+    end
 
-        if node.block.is_a?(Prism::BlockNode)
-          @shapes.stored_calls << StoredCall.new(owner: nil, subject: @names.current_scope, method: node.name.to_s,
-                                          block: node.block, source: @source)
-        elsif node.arguments
-          # One apply per argument. `apply(A, B)` asks for A's block AND B's,
-          # which is what a `*modules` forward means at runtime — each gets its
-          # own candidate, and each resolves (or declines) on its own evidence.
-          # Only single-argument calls used to be read at all, so the plural
-          # form resolved nothing (felixefelip/rbs_infer#253).
-          node.arguments.arguments.each do |argument|
-            @shapes.apply_calls << ApplyCall.new(owner: nil, subject: @names.current_scope, method: node.name.to_s, argument: argument)
-          end
-        end
+    # `extend Foo` written in a class body, as a DECLARATION: it says this scope
+    # may now call `Foo`'s DSL, which is what `providers` is built from.
+    #
+    # A note, not a branch. It used to be one — `when :extend` recorded this and
+    # returned, so the call never became an `ApplyCall` and `Object#extend` was
+    # reached by nothing. `include Foo` was never treated that way: it goes down
+    # the ordinary path, becomes an apply, and arrives at `append_features`
+    # through the transcribed `Module#include`. The two are the same shape of
+    # call and the difference was an accident of this method
+    # (felixefelip/rbs_infer#302).
+    #
+    # Both readings are needed and neither replaces the other. The declaration
+    # answers "who may call whose DSL", which a call site cannot: `Foo`'s methods
+    # become callable here whether or not anything resolves. The call site
+    # answers "what ran on what", which the declaration cannot: it is the only
+    # thing that says `Foo.extended(this_scope)` happened.
+    def record_extend(node)
+      return unless node.name == :extend && node.arguments
+
+      node.arguments.arguments.each do |argument|
+        @names.record_extend(@names.current_scope, argument)
       end
     end
 

--- a/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
@@ -231,7 +231,21 @@ module RbsInfer::Project::StoredBlockReplayExpander
     def collect_class_body_call(node)
       return unless NodeReading.bare_or_self?(node)
 
-      record_extend(node)
+      # `extend Foo` is read here AND below, and the two readings answer
+      # different questions. This one is the declaration: it says this scope may
+      # now call `Foo`'s DSL, which is what `providers` is built from — true
+      # whether or not anything resolves, so no call site can answer it. The one
+      # below is the call site: it is the only thing that says
+      # `Foo.extended(this_scope)` happened, which no declaration can answer.
+      #
+      # Which is why this must not `return`. It used to, and `Object#extend` was
+      # then reached by nothing — while `include Foo` went down the ordinary path
+      # and reached `append_features` through the transcribed `Module#include`.
+      # Same shape of call, and the difference was an accident of this method
+      # (felixefelip/rbs_infer#302).
+      if node.name == :extend && node.arguments
+        node.arguments.arguments.each { |argument| @names.record_extend(@names.current_scope, argument) }
+      end
 
       if node.block.is_a?(Prism::BlockNode)
         @shapes.stored_calls << StoredCall.new(owner: nil, subject: @names.current_scope, method: node.name.to_s,
@@ -245,30 +259,6 @@ module RbsInfer::Project::StoredBlockReplayExpander
         node.arguments.arguments.each do |argument|
           @shapes.apply_calls << ApplyCall.new(owner: nil, subject: @names.current_scope, method: node.name.to_s, argument: argument)
         end
-      end
-    end
-
-    # `extend Foo` written in a class body, as a DECLARATION: it says this scope
-    # may now call `Foo`'s DSL, which is what `providers` is built from.
-    #
-    # A note, not a branch. It used to be one — `when :extend` recorded this and
-    # returned, so the call never became an `ApplyCall` and `Object#extend` was
-    # reached by nothing. `include Foo` was never treated that way: it goes down
-    # the ordinary path, becomes an apply, and arrives at `append_features`
-    # through the transcribed `Module#include`. The two are the same shape of
-    # call and the difference was an accident of this method
-    # (felixefelip/rbs_infer#302).
-    #
-    # Both readings are needed and neither replaces the other. The declaration
-    # answers "who may call whose DSL", which a call site cannot: `Foo`'s methods
-    # become callable here whether or not anything resolves. The call site
-    # answers "what ran on what", which the declaration cannot: it is the only
-    # thing that says `Foo.extended(this_scope)` happened.
-    def record_extend(node)
-      return unless node.name == :extend && node.arguments
-
-      node.arguments.arguments.each do |argument|
-        @names.record_extend(@names.current_scope, argument)
       end
     end
 

--- a/lib/rbs_infer/project/stored_block_replay_expander/resolution.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/resolution.rb
@@ -187,7 +187,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
       return [] unless seen.add?([subject, source_subject])
 
       deferral = deferral_for(subject, method, source_subject, providers)
-      return [] if deferral && holds_slot?(subject, source_subject, deferral.slot, providers)
+      return [] if deferral && holds_slot?(subject, deferral.slot, providers)
 
       replays = [direct_replay(subject, method, source_subject, providers)].compact
       return replays unless deferral
@@ -210,7 +210,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
         next unless source_subject
 
         deferral = deferral_for(apply.subject, apply.method, source_subject, providers)
-        next unless deferral && holds_slot?(apply.subject, source_subject, deferral.slot, providers)
+        next unless deferral && holds_slot?(apply.subject, deferral.slot, providers)
 
         registered = @deferred_registry[apply.subject]
         registered << source_subject unless registered.include?(source_subject)
@@ -238,19 +238,51 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # taken, evaluated per call site.
     #
     # Not by reading the predicate. What the predicate asks (`does base have
-    # @_dependencies`) is answered by the method that PUTS it there: a `SlotInit`
-    # in the DSL's own chain says the objects handed to that DSL hold the slot,
-    # and `@names.providers` says which those are. So `Post::Commentable`, which
-    # extends the concern DSL, holds it and defers; `Post`, which extends
-    # nothing, does not and replays. A DSL whose slot nothing in the corpus
-    # initialises holds for nobody, which is the same "nothing to say" every
-    # other lookup here answers with.
-    def holds_slot?(subject, source_subject, slot, providers)
-      providers.any? do |owner, subjects|
-        next false unless subjects.include?(source_subject) && subjects.include?(subject)
+    # @_dependencies`) is answered by the method that PUTS it there — and by the
+    # call site that RUNS that method. Both halves are needed, and the second is
+    # the one this used to be missing: it asked only whether some DSL both
+    # subjects extend had a method writing the slot onto a parameter, so a
+    # `def self.setup(base)` nothing ever calls reported every extender of that
+    # DSL as holding the slot. The answers were right for the DSLs we have, and
+    # right by luck — the pass could not tell a hook from a method nobody calls
+    # (felixefelip/rbs_infer#302).
+    #
+    # Read forwards instead, from the call site out: `extend Deferring` written
+    # in `Example62::Middle` is an apply call; the applier is `Object#extend`,
+    # transcribed from `rb_obj_extend`, which forwards its argument to
+    # `extend_object` and then `extended`; and `Deferring.extended` writes
+    # `@deferred` onto its parameter. Every link is read off source — nothing
+    # here spells `extend` or `extended`, and `keepers_for` is the same walk
+    # `deferral_for` already makes for the block.
+    #
+    # A property of the SUBJECT alone, which is why the source subject the
+    # callers used to pass is gone. The predicate is about the object the DSL was
+    # handed; which module was being handed to it when the question came up
+    # decides nothing.
+    def holds_slot?(subject, slot, providers)
+      appliers = providers.select { |_, subjects| subjects.include?(subject) }.keys
 
+      (@shapes.apply_calls + @shapes.foreign_applies).any? do |apply|
+        next false unless apply.subject == subject
+
+        argument = @names.resolve(apply.argument, apply.subject)
+        next false unless argument
+
+        sources = providers.select { |_, subjects| subjects.include?(argument) }.keys
+
+        appliers.product(sources).any? do |applier, source_provider|
+          writes_slot?(@graph.keepers_for(applier, apply.method, source_provider), slot)
+        end
+      end
+    end
+
+    # Whether any of the methods a call reaches initialises `slot` on what it was
+    # handed. The hooks arrive as `[owner, method]` pairs, which is what a
+    # `SlotInit` is keyed by.
+    def writes_slot?(hooks, slot)
+      hooks.any? do |hook_owner, hook_method|
         @shapes.slot_inits.any? do |init|
-          init.ivar == slot && [owner, Declarations.singleton_owner(owner)].include?(init.owner)
+          init.ivar == slot && init.owner == hook_owner && init.method == hook_method
         end
       end
     end
@@ -318,7 +350,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
       return [] unless seen.add?([subject, source_subject])
 
       deferral = deferral_for(subject, method, source_subject, providers)
-      return [] if deferral && holds_slot?(subject, source_subject, deferral.slot, providers)
+      return [] if deferral && holds_slot?(subject, deferral.slot, providers)
 
       direct = direct_extensions(subject, method, source_subject, providers)
       return direct unless deferral

--- a/spec/lib/rbs_infer/project/stored_block_replay_expander_spec.rb
+++ b/spec/lib/rbs_infer/project/stored_block_replay_expander_spec.rb
@@ -1838,11 +1838,27 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
     # The inward shape needs `include` to reach the hook, which is what the Ruby
     # runtime sidecar transcribes for a real project. Spelled out here so the
     # example stands on its own.
+    #
+    # `extend` is transcribed for the same reason and is load-bearing in the same
+    # way: it is what says `DSL.extended(Mid)` RAN, and therefore that `Mid` holds
+    # the slot the DSL branches on. Without it the waypoint holds nothing and the
+    # block lands there instead of on `Host` — which is the point of reading the
+    # link rather than assuming it (felixefelip/rbs_infer#302). The real
+    # transcription forwards to `extend_object` as well; that link reaches no
+    # method here and so contributes nothing, exactly as `append_features` does
+    # not for this DSL.
     def chain(dsl, waypoint: true)
       <<~RUBY
         class Module
           def include(*modules)
             modules.reverse_each { |mod| mod.send(:apply, self) }
+            self
+          end
+        end
+
+        class Object
+          def extend(*modules)
+            modules.reverse_each { |mod| mod.send(:extended, self) }
             self
           end
         end
@@ -1880,6 +1896,27 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
     # `Host` gets nothing, because a `class_eval` runs where it stands.
     it "lands on the target that does not hold the slot" do
       expanded = expand(chain(dsl, waypoint: false))
+
+      expect(expanded).to include("module Mid\n  def greet")
+      expect(expanded).not_to include("class Host\n  def greet")
+    end
+
+    # The whole difference between asking and asserting, and the reason the
+    # transcription of `extend` exists (felixefelip/rbs_infer#302).
+    #
+    # Rename the hook and nothing else: `setup` writes the very same slot onto
+    # the very same parameter, and `extend DSL` no longer runs it, because
+    # `Object#extend` calls `extended`. So nobody holds `@deps`, `Mid` is an
+    # ordinary includer, and the block lands there.
+    #
+    # Reading only "some method of a DSL both are subjects of writes the slot",
+    # as this used to, every extender of `DSL` still holds it and the block still
+    # goes to `Host` — the same answer, from evidence that says nothing. That is
+    # the assertion this example exists to fail.
+    it "declines a slot-writing method nothing calls" do
+      nobody_calls_it = dsl.sub("def self.extended(base)", "def self.setup(base)")
+
+      expanded = expand(chain(nobody_calls_it))
 
       expect(expanded).to include("module Mid\n  def greet")
       expect(expanded).not_to include("class Host\n  def greet")
@@ -1978,7 +2015,12 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
         "Src" => "module Src\n  extend DSL\n  keep do\n    def greet; end\n  end\nend\n",
         "Mid" => "module Mid\n  extend DSL\n  include Src\nend\n",
         "Module" => "class Module\n  def include(*modules)\n" \
-                    "    modules.reverse_each { |mod| mod.send(:apply, self) }\n    self\n  end\nend\n"
+                    "    modules.reverse_each { |mod| mod.send(:apply, self) }\n    self\n  end\nend\n",
+        # The half that says `DSL.extended(Mid)` ran, so `Mid` holds the slot and
+        # registers rather than replaying. Absorbed from another file here, which
+        # is where a real project reads it from too — the runtime sidecar.
+        "Object" => "class Object\n  def extend(*modules)\n" \
+                    "    modules.reverse_each { |mod| mod.send(:extended, self) }\n    self\n  end\nend\n"
       )
 
       expanded = expand("class Host\n  include Mid\nend\n", sources: elsewhere)


### PR DESCRIPTION
Second half of #302. #309 transcribed `Object#extend`, but nothing reached it: an `extend`
written in a class body was **diverted before it could be a call site**.

```ruby
when :extend
  return unless bare_or_self?(node) && node.arguments
  node.arguments.arguments.each { |a| @names.record_extend(current_scope, a) }
else
  # …everything else becomes a StoredCall or an ApplyCall
```

`include Foo` was never treated that way — it goes down the ordinary path, becomes an
apply, and arrives at `append_features` through the transcribed `Module#include`. The two
are the same shape of call; the difference was an accident of this method.

## `extend` is now read twice

Not a branch any more — a note beside the ordinary path. Both readings are needed and
neither replaces the other:

| reading | answers | the other cannot |
|---|---|---|
| the **declaration** (`record_extend` → `providers`) | who may call whose DSL | `Foo`'s methods become callable whether or not anything resolves |
| the **call site** (`ApplyCall`) | what ran on what | it is the only thing that says `Foo.extended(this_scope)` happened |

## What that fixes

`holds_slot?` asked whether some DSL both subjects extend had a method writing the slot
onto a parameter — and never whether that method **runs**. The answers were right for the
DSLs we have, and right by luck: the pass could not tell a hook from a method nobody
calls.

It now reads forwards, from the call site out. Measured on the dummy's `example62`:

```
APPLY_CALLS  ["Example62::Middle", "extend", "Deferring"]     <- new here
FORWARDS     ["Object", "extend", "mod", "extended"]          <- #309
SLOT_INITS   ["singleton(Example62::Deferring)", "extended", "base", "@deferred"]
```

`keepers_for` — the same walk `deferral_for` already makes for the block — joins the
three. **No line spells `extend` or `extended`;** the transcription is what says the hook
runs.

`source_subject` leaves the signature with it. The predicate is about the object the DSL
was handed; which module was being handed to it when the question came up decides nothing.

## The acceptance example

Rename the hook and change nothing else — same slot, same parameter, but nothing calls it:

```ruby
nobody_calls_it = dsl.sub("def self.extended(base)", "def self.setup(base)")
```

The block now lands on the waypoint instead of the host. Under the old reading every
extender of `DSL` still held the slot and the block still went to `Host` — the same
answer, from evidence that says nothing.

**Mutation-tested:** restoring the provider-based answer fails exactly that example, and
nothing else.

## The fixtures had to write the other half

Both spec fixtures already wrote `class Module; def include` by hand — "spelled out here
so the example stands on its own". They now write `class Object; def extend` beside it.
That is the intended effect, not a workaround: the evidence is required now rather than
assumed.

## Still open in #302

`Example62::Shared` and `Middle` do not yet declare `self.@deferred`. That is the
ivar-emission half — a different pass — and it is what closes the issue.

## Verification

- `spec/lib/`: 1387 examples, 1 failure — pre-existing and environmental (rbs 4.2.0 names
  `Array`'s parameter `E`; the spec expects `Elem`).
- `spec/integration/`: green but for `example55/foo` and `ActiveRecord runtime`, both of
  which reproduce on `origin/main`.
- **Steep baseline on the dummy unchanged**, and `example62`'s RBS unchanged — the guard
  the issue asks for: the deferral answers must not move, only their evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179Um6Qoek3LMYrqHKUPuos
