### PR TITLE
Name the call graph for what it walks, not for what motivated it

### DIFF
--- a/lib/rbs_infer/project/stored_block_replay_expander.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander.rb
@@ -139,7 +139,7 @@ module RbsInfer::Project
 
       # One reopening per (block, target) PAIR, not per block. A block replayed
       # onto two classes is two reopenings and both are real — `Collector`
-      # resolves each apply call site on its own, and two of them naming the
+      # resolves each module call on its own, and two of them naming the
       # same source is what a module reused by two classes looks like. Keyed on
       # the block alone this declined the whole file for exactly that shape
       # (felixefelip/rbs_infer#263).

--- a/lib/rbs_infer/project/stored_block_replay_expander/call_graph.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/call_graph.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
 module RbsInfer::Project::StoredBlockReplayExpander
-  # Where a DSL call ENDS UP, walked over the shapes a file was read as writing.
+  # Where a call ENDS UP, walked over the shapes a file was read as writing.
   #
-  # One question, asked from an apply call site: the applier forwards the
+  # Nothing about it is a DSL, which is what the old name (`DslGraph`) claimed:
+  # `Module#include` walks this graph too, and so does `Object#extend`. It is a
+  # graph of calls — forwards and delegations — and the DSLs that motivated it
+  # are read by exactly the same walk as the language's own methods
+  # (felixefelip/rbs_infer#311).
+  #
+  # One question, asked from a module call: the supplying module forwards the
   # argument somewhere, that somewhere may delegate again, and whatever it
   # finally reaches either holds a block in a slot or runs one where it stands.
   # Following that is a graph walk over the collected shapes — forwards to
@@ -21,12 +27,13 @@ module RbsInfer::Project::StoredBlockReplayExpander
   # guarantees that ordering — it is the last step of collecting, and the
   # resolution this graph belongs to does not start until it has run.
   #
-  # `dsl_providers` deliberately did NOT come along, though it is the other half
-  # of "which DSL answers this call": it reads the file's declarations, extends
-  # and superclasses — the state the VISITOR writes — where everything here
-  # reads the method shapes. Two disjoint sets of state in one object would be a
-  # worse seam than the one it removes; it belongs with the lexical scope.
-  class DslGraph
+  # `Declarations#providers` deliberately did NOT come along, though it is the
+  # other half of "which module supplies this call": it reads the file's
+  # declarations, extends and superclasses — the state the VISITOR writes —
+  # where everything here reads the method shapes. Two disjoint sets of state in
+  # one object would be a worse seam than the one it removes; it belongs with
+  # the lexical scope.
+  class CallGraph
     def initialize(replay_methods:, readers:, inward_replays:, literal_replays:,
                    forwards:, delegations:, storages:)
       @replay_methods = replay_methods
@@ -59,7 +66,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # simply answer nothing: `include` hands the argument to `append_features`
     # as well, and that method keeps no block, so it contributes no slot. The
     # count that decides ambiguity is therefore the number of forwards that
-    # reach a REPLAY, not the number written — a DSL applier is free to send its
+    # reach a REPLAY, not the number written — a supplying module is free to send its
     # argument other messages on the way (felixefelip/rbs_infer#259).
     def inward_slot(owner, method, source_provider)
       slots = keepers_for(owner, method, source_provider).filter_map do |keeper_owner, keeper_method|

--- a/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
@@ -10,7 +10,7 @@ require_relative "declarations"
 require_relative "shape_set"
 require_relative "resolution"
 require_relative "corpus"
-require_relative "dsl_graph"
+require_relative "call_graph"
 require_relative "node_reading"
 require_relative "shape_reader"
 require_relative "deferral_reader"
@@ -22,7 +22,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
   class Collector < Prism::Visitor
     include Shapes
 
-    # The `extend`s the apply calls in this file put on their targets. Populated
+    # The `extend`s the module calls in this file put on their targets. Populated
     # by `collect`, alongside the replays it answers with: both are what a call
     # site here does to a class here, read off the same resolution.
     attr_reader :extensions
@@ -251,13 +251,13 @@ module RbsInfer::Project::StoredBlockReplayExpander
         @shapes.stored_calls << StoredCall.new(owner: nil, subject: @names.current_scope, method: node.name.to_s,
                                         block: node.block, source: @source)
       elsif node.arguments
-        # One apply per argument. `apply(A, B)` asks for A's block AND B's,
+        # One module call per argument. `apply(A, B)` asks for A's block AND B's,
         # which is what a `*modules` forward means at runtime — each gets its
         # own candidate, and each resolves (or declines) on its own evidence.
         # Only single-argument calls used to be read at all, so the plural
         # form resolved nothing (felixefelip/rbs_infer#253).
         node.arguments.arguments.each do |argument|
-          @shapes.apply_calls << ApplyCall.new(owner: nil, subject: @names.current_scope, method: node.name.to_s, argument: argument)
+          @shapes.module_calls << ModuleCall.new(owner: nil, subject: @names.current_scope, method: node.name.to_s, argument: argument)
         end
       end
     end
@@ -268,7 +268,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # nothing else, so an `apply` written elsewhere would name a target this
     # rewrite cannot reach — but the DSL those calls arrive at may be declared
     # anywhere. For a reopening of a core class it always is: `Module#include`
-    # is how `ActiveSupport::Concern` writes the applier, and no file that USES
+    # is how `ActiveSupport::Concern` writes the module that supplies it, and no file that USES
     # a concern declares it (felixefelip/rbs_infer#256).
     #
     # `Corpus` decides which files those are and in what order; what to do with
@@ -291,7 +291,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # Every constant this file NAMES but may not declare, as
     # `[naming scope, node]`.
     #
-    # `extend`'s and a superclass's, which say where the applier's own methods
+    # `extend`'s and a superclass's, which say where the supplying module's own methods
     # come from — and the APPLY ARGUMENT, which says where the block does.
     # `include IncludedHook::Shared` names the module holding the block, and it
     # is the only mention of it in the file: without asking about it the module
@@ -300,7 +300,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # ordinary shape of a concern — declared in its own file, used from
     # another — rather than an exotic one (felixefelip/rbs_infer#265).
     def external_constants
-      @names.named_constants + @shapes.apply_calls.map { |apply| [apply.subject, apply.argument] }
+      @names.named_constants + @shapes.module_calls.map { |module_call| [module_call.subject, module_call.argument] }
     end
 
     def absorb(shapes)

--- a/lib/rbs_infer/project/stored_block_replay_expander/declarations.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/declarations.rb
@@ -154,7 +154,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
     end
 
     # Every constant this file NAMES in a position that says where methods come
-    # from — an `extend` and a superclass. The apply arguments are the collector's
+    # from — an `extend` and a superclass. The module-call arguments are the collector's
     # to add, being call sites rather than declarations.
     def named_constants
       @extends + @superclasses
@@ -197,7 +197,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
       # `Module`'s. To the caller this is indistinguishable from the two
       # relations above — the method arrives with no receiver either way — but it
       # is neither an `extend` nor an ancestor of the SUBJECT, so nothing above
-      # can express it, and a DSL whose applier is written as a core reopening
+      # can express it, and a DSL whose supplying module is written as a core reopening
       # had no provider at all (felixefelip/rbs_infer#256).
       @kinds.each do |subject, kind|
         CORE_SELF_CHAINS.fetch(kind, []).each { |ancestor| table[ancestor] << subject }

--- a/lib/rbs_infer/project/stored_block_replay_expander/node_reading.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/node_reading.rb
@@ -148,7 +148,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # The receiver used to go unread here, which happened to be harmless while
     # every shape it could take meant the same thing. It no longer does: the
     # rewrite emits a reopening of the SUBJECT — the class whose body wrote the
-    # apply call — so a replay written on anything else (`Other.class_eval`) is
+    # module call — so a replay written on anything else (`Other.class_eval`) is
     # a block running on a class this pass never resolved, and naming the
     # subject would be an answer about the wrong one.
     def own_receiver(receiver)

--- a/lib/rbs_infer/project/stored_block_replay_expander/resolution.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/resolution.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "shapes"
-require_relative "dsl_graph"
+require_relative "call_graph"
 
 module RbsInfer::Project::StoredBlockReplayExpander
   # The last phase: which class each collected block actually lands on.
@@ -31,13 +31,13 @@ module RbsInfer::Project::StoredBlockReplayExpander
       @source = source
       @deferred_registry = Hash.new { |hash, key| hash[key] = [] }
       @extensions = []
-      @graph = DslGraph.new(replay_methods: shapes.replay_methods, readers: shapes.readers,
+      @graph = CallGraph.new(replay_methods: shapes.replay_methods, readers: shapes.readers,
                             inward_replays: shapes.inward_replays, literal_replays: shapes.literal_replays,
                             forwards: shapes.forwards, delegations: shapes.resolved_delegations,
                             storages: shapes.storages)
     end
 
-    # The `extend`s the apply calls put on their targets. Populated by `run`
+    # The `extend`s the module calls put on their targets. Populated by `run`
     # alongside the replays it answers with: both are what a call site here does
     # to a class here, read off the same resolution.
     attr_reader :extensions
@@ -60,11 +60,11 @@ module RbsInfer::Project::StoredBlockReplayExpander
       resolved = @shapes.stored_calls.filter_map { |stored| resolve_own_block(stored, providers) }
                               .select { |replay| replay.source.equal?(@source) }
 
-      @extensions = @shapes.apply_calls.flat_map { |apply| resolve_extensions(apply, providers) }.uniq
+      @extensions = @shapes.module_calls.flat_map { |module_call| resolve_extensions(module_call, providers) }.uniq
 
-      resolved += @shapes.apply_calls.flat_map { |apply| resolve_apply(apply, providers) }
+      resolved += @shapes.module_calls.flat_map { |module_call| resolve_module_call(module_call, providers) }
 
-      # Two apply calls naming the same source in the same class body are one
+      # Two module calls naming the same source in the same class body are one
       # replay written twice, not two — the block relocates to that class once.
       # Keyed on the block's own SOURCE as well as its offset, since two files
       # hold blocks at the same offset all the time and a location says nothing
@@ -77,8 +77,8 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # The block a DSL call runs where it stands, or nil when the file does not
     # decide it.
     #
-    # The same call `resolve_apply`'s chain treats as STORAGE, asked the other
-    # question: not "which earlier block does this apply", but "does the method
+    # The same call `resolve_module_call`'s chain treats as STORAGE, asked the other
+    # question: not "which earlier block does this call apply", but "does the method
     # this call reaches run the block right here". A DSL may do either, and one
     # that does both is not a contradiction — the block runs now AND is kept for
     # later — so this is resolved on its own evidence rather than counted
@@ -100,7 +100,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
 
       # Two providers answering one call with two different targets is one
       # runtime dispatch this pass cannot pick a winner for — the same count
-      # `resolve_apply` declines on.
+      # `resolve_module_call` declines on.
       candidates.first if candidates.size == 1
     end
 
@@ -158,11 +158,11 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # the common case rather than an exotic one. Nothing is ambiguous there:
     # each call site names its own target, and the block simply runs twice, as
     # it does at runtime (felixefelip/rbs_infer#263).
-    def resolve_apply(apply, providers)
-      source_subject = @names.resolve(apply.argument, apply.subject)
+    def resolve_module_call(module_call, providers)
+      source_subject = @names.resolve(module_call.argument, module_call.subject)
       return [] unless source_subject
 
-      resolve_application(apply.subject, apply.method, source_subject, providers, Set.new)
+      replays_landed(module_call.subject, module_call.method, source_subject, providers, Set.new)
     end
 
     # One application of a module to a class, as the replays it lands there —
@@ -183,7 +183,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
     #
     # `seen` guards the recursion rather than a depth limit: two concerns can
     # register each other, and a pair that does must not hang the pass.
-    def resolve_application(subject, method, source_subject, providers, seen)
+    def replays_landed(subject, method, source_subject, providers, seen)
       return [] unless seen.add?([subject, source_subject])
 
       deferral = deferral_for(subject, method, source_subject, providers)
@@ -193,7 +193,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
       return replays unless deferral
 
       replays + @deferred_registry[source_subject].flat_map do |held|
-        resolve_application(subject, deferral.recall, held, providers, seen)
+        replays_landed(subject, deferral.recall, held, providers, seen)
       end
     end
 
@@ -202,31 +202,31 @@ module RbsInfer::Project::StoredBlockReplayExpander
     #
     # A registration is a fact about the module that made it, not about the file
     # asking — so this walks the absorbed call sites too, and the entries it
-    # writes are read back by `resolve_application` in whatever file finally
+    # writes are read back by `replays_landed` in whatever file finally
     # closes the hop.
     def register_deferrals(providers)
-      (@shapes.apply_calls + @shapes.foreign_applies).each do |apply|
-        source_subject = @names.resolve(apply.argument, apply.subject)
+      (@shapes.module_calls + @shapes.foreign_module_calls).each do |module_call|
+        source_subject = @names.resolve(module_call.argument, module_call.subject)
         next unless source_subject
 
-        deferral = deferral_for(apply.subject, apply.method, source_subject, providers)
-        next unless deferral && holds_slot?(apply.subject, deferral.slot, providers)
+        deferral = deferral_for(module_call.subject, module_call.method, source_subject, providers)
+        next unless deferral && holds_slot?(module_call.subject, deferral.slot, providers)
 
-        registered = @deferred_registry[apply.subject]
+        registered = @deferred_registry[module_call.subject]
         registered << source_subject unless registered.include?(source_subject)
       end
     end
 
     # The deferral the DSL behind one application writes, or nil when it always
     # replays where it stands. Same two-sided walk `direct_replay` makes — the
-    # applier answers for the subject, the keeper for the module — because the
+    # one provider answers for the subject, the keeper for the module — because the
     # method that defers is the one the module's own provider supplies.
     def deferral_for(subject, method, source_subject, providers)
-      appliers = providers.select { |_, subjects| subjects.include?(subject) }.keys
-      sources = providers.select { |_, subjects| subjects.include?(source_subject) }.keys
+      subject_providers = providers.select { |_, subjects| subjects.include?(subject) }.keys
+      source_providers = providers.select { |_, subjects| subjects.include?(source_subject) }.keys
 
-      found = appliers.product(sources).flat_map do |applier, source_provider|
-        @graph.keepers_for(applier, method, source_provider).flat_map do |keeper_owner, keeper_method|
+      found = subject_providers.product(source_providers).flat_map do |subject_provider, source_provider|
+        @graph.keepers_for(subject_provider, method, source_provider).flat_map do |keeper_owner, keeper_method|
           @shapes.deferrals.select { |deferral| deferral.owner == keeper_owner && deferral.method == keeper_method }
         end
       end.uniq
@@ -248,7 +248,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # (felixefelip/rbs_infer#302).
     #
     # Read forwards instead, from the call site out: `extend Deferring` written
-    # in `Example62::Middle` is an apply call; the applier is `Object#extend`,
+    # in `Example62::Middle` is a module call; the supplying module is `Object#extend`,
     # transcribed from `rb_obj_extend`, which forwards its argument to
     # `extend_object` and then `extended`; and `Deferring.extended` writes
     # `@deferred` onto its parameter. Every link is read off source — nothing
@@ -260,18 +260,18 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # handed; which module was being handed to it when the question came up
     # decides nothing.
     def holds_slot?(subject, slot, providers)
-      appliers = providers.select { |_, subjects| subjects.include?(subject) }.keys
+      subject_providers = providers.select { |_, subjects| subjects.include?(subject) }.keys
 
-      (@shapes.apply_calls + @shapes.foreign_applies).any? do |apply|
-        next false unless apply.subject == subject
+      (@shapes.module_calls + @shapes.foreign_module_calls).any? do |module_call|
+        next false unless module_call.subject == subject
 
-        argument = @names.resolve(apply.argument, apply.subject)
+        argument = @names.resolve(module_call.argument, module_call.subject)
         next false unless argument
 
-        sources = providers.select { |_, subjects| subjects.include?(argument) }.keys
+        source_providers = providers.select { |_, subjects| subjects.include?(argument) }.keys
 
-        appliers.product(sources).any? do |applier, source_provider|
-          writes_slot?(@graph.keepers_for(applier, apply.method, source_provider), slot)
+        subject_providers.product(source_providers).any? do |subject_provider, source_provider|
+          writes_slot?(@graph.keepers_for(subject_provider, module_call.method, source_provider), slot)
         end
       end
     end
@@ -290,7 +290,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # The one block an application relocates, or nil when the file does not
     # decide it.
     #
-    # Two provider questions, not one. The applier is dispatched on the
+    # Two provider questions, not one. The supplying module is dispatched on the
     # SUBJECT (`banana` arrives in `Bar`'s body) and the callee it forwards
     # to on the ARGUMENT (`mod.send(:bananed, self)` runs on `Baz`), so the
     # two are answered by whatever supplies each — which need not be the
@@ -298,11 +298,11 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # own shape breaks: `Module#include` reaches for `append_features`, a
     # method of the concern (felixefelip/rbs_infer#256).
     def direct_replay(subject, method, source_subject, providers)
-      appliers = providers.select { |_, subjects| subjects.include?(subject) }.keys
-      sources = providers.select { |_, subjects| subjects.include?(source_subject) }.keys
+      subject_providers = providers.select { |_, subjects| subjects.include?(subject) }.keys
+      source_providers = providers.select { |_, subjects| subjects.include?(source_subject) }.keys
 
-      candidates = appliers.product(sources).filter_map do |applier, source_provider|
-        replay_for(subject, method, applier, source_provider, source_subject)
+      candidates = subject_providers.product(source_providers).filter_map do |subject_provider, source_provider|
+        replay_for(subject, method, subject_provider, source_provider, source_subject)
       end
 
       # One block per call site. Two providers answering with two DIFFERENT
@@ -318,9 +318,9 @@ module RbsInfer::Project::StoredBlockReplayExpander
       candidates.first
     end
 
-    # The `extend`s one apply call site puts on its target.
+    # The `extend`s one module call puts on its target.
     #
-    # The same walk `resolve_apply` makes, over the same providers, and separate
+    # The same walk `resolve_module_call` makes, over the same providers, and separate
     # from it on purpose: an `extend` and a block replay are two effects of one
     # hook — `ActiveSupport::Concern#append_features` does both — so neither may
     # count as evidence against the other. A concern with a `ClassMethods` and
@@ -331,11 +331,11 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # answering `included` for one subject is one runtime dispatch that this
     # pass cannot pick a winner for, so it says nothing. Several `extend`s from
     # one provider are not that — see `inward_extend_shapes`.
-    def resolve_extensions(apply, providers)
-      source_subject = @names.resolve(apply.argument, apply.subject)
+    def resolve_extensions(module_call, providers)
+      source_subject = @names.resolve(module_call.argument, module_call.subject)
       return [] unless source_subject
 
-      extensions_for(apply.subject, apply.method, source_subject, providers, Set.new)
+      extensions_for(module_call.subject, module_call.method, source_subject, providers, Set.new)
     end
 
     # The `extend`s one application puts on its target, following the same
@@ -364,11 +364,11 @@ module RbsInfer::Project::StoredBlockReplayExpander
       kind = @names.own_kind(subject)
       return [] unless kind
 
-      appliers = providers.select { |_, subjects| subjects.include?(subject) }.keys
-      sources = providers.select { |_, subjects| subjects.include?(source_subject) }.keys
+      subject_providers = providers.select { |_, subjects| subjects.include?(subject) }.keys
+      source_providers = providers.select { |_, subjects| subjects.include?(source_subject) }.keys
 
-      answers = appliers.product(sources).filter_map do |applier, source_provider|
-        names = extension_names(applier, method, source_provider, source_subject)
+      answers = subject_providers.product(source_providers).filter_map do |subject_provider, source_provider|
+        names = extension_names(subject_provider, method, source_provider, source_subject)
         names unless names.empty?
       end.uniq
       return [] unless answers.size == 1
@@ -434,7 +434,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
       @names.kind_of(name) ? name : nil
     end
 
-    def replay_for(subject, method, applier, source_provider, source_subject)
+    def replay_for(subject, method, subject_provider, source_provider, source_subject)
       # Both directions answer with the SLOT — and with the object that owns
       # it, which is not always the provider: a delegating DSL method keeps
       # the block on something it holds. From there the chain is one and the
@@ -442,12 +442,12 @@ module RbsInfer::Project::StoredBlockReplayExpander
       # source wrote under that name holds the block. Asking both and
       # requiring a single answer is what keeps a file that somehow reads as
       # both from being resolved by declaration order.
-      slots = [@graph.outward_slot(applier, method),
-               @graph.inward_slot(applier, method, source_provider)].compact.uniq
+      slots = [@graph.outward_slot(subject_provider, method),
+               @graph.inward_slot(subject_provider, method, source_provider)].compact.uniq
       # And the third way to reach a block: not through a slot at all,
       # because the replaying method wrote it in place. Counted together
       # with the slots, so a file reading as both still declines.
-      literals = @graph.literal_replays_for(applier, method, source_provider)
+      literals = @graph.literal_replays_for(subject_provider, method, source_provider)
       return nil unless slots.size + literals.size == 1
 
       kind = @names.own_kind(subject)
@@ -460,7 +460,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
       end
 
       storage_owner, ivar, singleton = slots.first
-      # The SOURCE's provider, not the applier's: the name being looked up
+      # The SOURCE's provider, not the supplying module's: the name being looked up
       # is the one the source wrote in its own body.
       storage_method = @graph.storage_method_for(source_provider, storage_owner, ivar)
       return nil unless storage_method

--- a/lib/rbs_infer/project/stored_block_replay_expander/shape_set.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/shape_set.rb
@@ -18,7 +18,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
   #
   # Held rather than copied: the arrays are handed out and mutated in place, so
   # a reader taken early keeps seeing what is appended later. That was
-  # load-bearing until the phases were split — `DslGraph` used to be built
+  # load-bearing until the phases were split — `CallGraph` used to be built
   # before the last delegations were concatenated onto the very array it had
   # been handed, and only worked because it was the same object. It no longer
   # relies on it: `resolve_shapes` finishes before any resolution starts. The
@@ -26,7 +26,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
   # in another, but nothing now depends on a write landing after a read.
   class ShapeSet
     COLLECTIONS = %i[storages readers replay_methods inward_replays literal_replays forwards
-                     stored_calls apply_calls foreign_applies deferrals slot_inits
+                     stored_calls module_calls foreign_module_calls deferrals slot_inits
                      resolved_delegations resolved_inward_extends resolved_own_replays].freeze
 
     COLLECTIONS.each { |name| attr_reader(name) }
@@ -37,18 +37,18 @@ module RbsInfer::Project::StoredBlockReplayExpander
 
     # Takes on everything another file said.
     #
-    # Every collection but one is a straight concatenation. `apply_calls` is the
+    # Every collection but one is a straight concatenation. `module_calls` is the
     # exception and the asymmetry is the point: another file's call sites are
     # read for ONE question — which modules it registered on a waypoint — and
     # never emitted from, because this pass rewrites one source and a call site
     # elsewhere names a target it cannot reopen. So they land in
-    # `foreign_applies`, where nothing that emits will look
+    # `foreign_module_calls`, where nothing that emits will look
     # (felixefelip/rbs_infer#300).
     def merge(other)
-      (COLLECTIONS - %i[apply_calls foreign_applies]).each do |name|
+      (COLLECTIONS - %i[module_calls foreign_module_calls]).each do |name|
         public_send(name).concat(other.public_send(name))
       end
-      @foreign_applies.concat(other.apply_calls)
+      @foreign_module_calls.concat(other.module_calls)
       self
     end
 

--- a/lib/rbs_infer/project/stored_block_replay_expander/shapes.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/shapes.rb
@@ -36,7 +36,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
     #
     # That leaves out `Kernel`, and knowingly: it is a module, so nothing at
     # runtime distinguishes it from the two above. A `module Kernel` reopening
-    # holding a DSL applier is not a shape worth reading the live process for.
+    # holding a supplying module is not a shape worth reading the live process for.
     #
     # Deliberately NOT the ancestors RBS knows, either. That query answers
     # (measured: `singleton(::Example39::Bar)` + `banana` -> `::Module`), but
@@ -75,7 +75,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # the string they index. The rewrite slices it to move the body, and the
     # block may come from another file (see `absorb`).
     StoredCall = Data.define(:owner, :subject, :method, :block, :source)
-    ApplyCall = Data.define(:owner, :subject, :method, :argument)
+    ModuleCall = Data.define(:owner, :subject, :method, :argument)
 
     # The same replay written from the other end — `base.class_eval(&@block)`,
     # where `self` is the module that KEPT the block and the target arrives as a
@@ -178,7 +178,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # and so is only known at the call site.
     InwardExtend = Data.define(:owner, :method, :parameter, :name, :dynamic, :creates)
 
-    # One `extend` an apply call site puts on its target, resolved: the class or
+    # One `extend` a module call puts on its target, resolved: the class or
     # module to reopen, and the module its singleton gains.
     Extension = Data.define(:target, :kind, :name)
 


### PR DESCRIPTION
Step 1 of 3 in #311. **Pure rename** — no line of logic changes, so the whole thing is
reviewable by inspection. It goes first because with the right names, deleting the
`extend` name check in step 3 reads as removing an inconsistency rather than as an
optimisation.

| from | to |
|---|---|
| `DslGraph` (`dsl_graph.rb`) | `CallGraph` (`call_graph.rb`) |
| `ApplyCall` | `ModuleCall` |
| `apply_calls` / `foreign_applies` | `module_calls` / `foreign_module_calls` |
| `resolve_apply` | `resolve_module_call` |
| `resolve_application` | `replays_landed` |
| `appliers` / `applier` | `subject_providers` / `subject_provider` |
| `sources` | `source_providers` |

Nothing about the graph is a DSL, which is what the old name claimed: `Module#include`
walks it, and so does `Object#extend`. `ModuleCall` forms the right pair with
`StoredCall` — one carries a block, the other names a module, which is exactly how the
collector splits them. `replays_landed` is what the method's own first line already said
it was: *"one application of a module to a class, as the replays it lands there."*

## `sources` was not in the plan

It came out of the rename. It held **providers**, not subjects — so the two identical
lines sitting next to each other now say they are one query asked of both sides of the
call:

```ruby
subject_providers = providers.select { |_, s| s.include?(subject) }.keys
source_providers  = providers.select { |_, s| s.include?(source_subject) }.keys
```

## The prose is the evidence

The mechanical substitution broke **23 passages of prose**, and that is what shows the
name was ambiguous rather than merely ugly. `apply` was doing two jobs:

- in `` `apply(Baz)` ``, `def apply(source)` and `mod.apply(self)` it was the fixture's
  **literal method name**;
- in *"an apply call site"* it was the **concept**.

Collapsing them produced `` `module_call(Baz)` ``, which is no method at all. The literals
are restored to `apply` — the fixture may call its method whatever it likes, and the pass
not caring is the whole point — and the concept is now spelled out as "a module call".

While the two shared a word, the code could be read as though the pass recognised a method
named `apply`. It never did.

## What deliberately stays

**`providers`.** Not DSL-named, and honest: the table is `owner -> subjects`. The precise
name would be `singleton_ancestors`, but the table is **inverted** and today it still mixes
ancestry with the `extend` name check. It gets renamed in **step 3**, when it becomes only
the ancestry — naming it now for what we want it to become would be making the same
mistake again.

**`subject`, `keeper`, `storage`, `forward`, `source_subject`.** Each says what it is, and
none came from a fixture.

## Verification

- 362 project examples and 1387 unit examples green, but for the pre-existing
  environmental failure (rbs 4.2.0 names `Array`'s parameter `E`; the spec expects `Elem`).
- Integration green but for `example55/foo` and `ActiveRecord runtime`, both of which
  reproduce on `origin/main`.
- Steep baseline on the dummy unchanged.
- No spec referenced any of the renamed production names, so the change is confined to
  `lib/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179Um6Qoek3LMYrqHKUPuos
