### PR TITLE
State the singleton splice in Ruby, so `extend` is `include`

### DIFF
--- a/lib/rbs_infer/project/ruby_runtime_generator.rb
+++ b/lib/rbs_infer/project/ruby_runtime_generator.rb
@@ -128,9 +128,19 @@ module RbsInfer::Project
         # and a module that overrides this now has a `super` to resolve against.
         # @rbs_infer |...
         def extend_object(obj)
-          # rb_include_module(rb_singleton_class(obj), self): the SINGLETON of `obj`
-          # gains `self`, which is why `extend` reaches the object and `include`
-          # reaches its instances.
+          # `rb_include_module(rb_singleton_class(obj), self)` — and this line IS
+          # that call, rather than a comment about it. The SINGLETON of `obj`
+          # gains `self`, which is why `extend` reaches the object where
+          # `include` reaches its instances.
+          #
+          # Written out because it makes `extend` DERIVED: everything it does is
+          # now `include` on another method table, so a reader that understands
+          # `include` understands `extend` for free. `append_features` gets no
+          # equivalent line — `mod.include(self)` there is circular, since
+          # `include` is what calls it — which is exactly why the ancestor splice
+          # of `include` is the one irreducible thing this file states
+          # (rbs_infer#311).
+          obj.singleton_class.include(self)
           obj
         end
 

--- a/lib/rbs_infer/project/ruby_runtime_generator.rb
+++ b/lib/rbs_infer/project/ruby_runtime_generator.rb
@@ -128,18 +128,6 @@ module RbsInfer::Project
         # and a module that overrides this now has a `super` to resolve against.
         # @rbs_infer |...
         def extend_object(obj)
-          # `rb_include_module(rb_singleton_class(obj), self)` — and this line IS
-          # that call, rather than a comment about it. The SINGLETON of `obj`
-          # gains `self`, which is why `extend` reaches the object where
-          # `include` reaches its instances.
-          #
-          # Written out because it makes `extend` DERIVED: everything it does is
-          # now `include` on another method table, so a reader that understands
-          # `include` understands `extend` for free. `append_features` gets no
-          # equivalent line — `mod.include(self)` there is circular, since
-          # `include` is what calls it — which is exactly why the ancestor splice
-          # of `include` is the one irreducible thing this file states
-          # (rbs_infer#311).
           obj.singleton_class.include(self)
           obj
         end

--- a/lib/rbs_infer/project/stored_block_replay_expander/call_graph.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/call_graph.rb
@@ -100,7 +100,14 @@ module RbsInfer::Project::StoredBlockReplayExpander
       @forwards.filter_map do |forward|
         next unless forward.owner == owner && forward.method == method
 
-        keeper_owner, keeper_method = keeper(source_provider, forward.callee)
+        # A forward through `singleton_class` looks the callee up in the
+        # argument's SINGLETON table, which is a different owner and so a
+        # different set of methods. Same distinction `Declarations#providers`
+        # draws for a bare call in a class body, asked of a forward
+        # (felixefelip/rbs_infer#311).
+        provider = forward.singleton ? Declarations.singleton_owner(source_provider) : source_provider
+
+        keeper_owner, keeper_method = keeper(provider, forward.callee)
         [keeper_owner, keeper_method] if keeper_owner
       end.uniq
     end

--- a/lib/rbs_infer/project/stored_block_replay_expander/call_graph.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/call_graph.rb
@@ -100,11 +100,6 @@ module RbsInfer::Project::StoredBlockReplayExpander
       @forwards.filter_map do |forward|
         next unless forward.owner == owner && forward.method == method
 
-        # A forward through `singleton_class` looks the callee up in the
-        # argument's SINGLETON table, which is a different owner and so a
-        # different set of methods. Same distinction `Declarations#providers`
-        # draws for a bare call in a class body, asked of a forward
-        # (felixefelip/rbs_infer#311).
         provider = forward.singleton ? Declarations.singleton_owner(source_provider) : source_provider
 
         keeper_owner, keeper_method = keeper(provider, forward.callee)

--- a/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
@@ -223,8 +223,9 @@ module RbsInfer::Project::StoredBlockReplayExpander
         @delegations << [owner, method_name, target, callee]
       end
 
-      ShapeReader.forward_shapes(node.body, parameters).each do |parameter, callee|
-        @shapes.forwards << ForwardMethod.new(owner: owner, method: method_name, parameter: parameter, callee: callee)
+      ShapeReader.forward_shapes(node.body, parameters).each do |parameter, callee, singleton|
+        @shapes.forwards << ForwardMethod.new(owner: owner, method: method_name, parameter: parameter,
+                                              callee: callee, singleton: singleton)
       end
     end
 

--- a/lib/rbs_infer/project/stored_block_replay_expander/node_reading.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/node_reading.rb
@@ -111,14 +111,6 @@ module RbsInfer::Project::StoredBlockReplayExpander
       RbsInfer::Inference::SendCall.desugar(node) || node
     end
 
-    # Which handed object a receiver names, as `[parameter name, singleton?]`, or
-    # nil when it names none.
-    #
-    # Neutral about what is then DONE to that object: a block replayed onto it, a
-    # call forwarded to it, a module spliced into it. All three ask the same
-    # question of the receiver, and only the caller knows which one it is asking
-    # for (felixefelip/rbs_infer#311).
-    #
     # `base.class_eval` and `base.singleton_class.class_eval` are the same
     # relocation asked about two different method tables — `base`'s own, and
     # `base`'s singleton — which is exactly the difference between a DSL

--- a/lib/rbs_infer/project/stored_block_replay_expander/node_reading.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/node_reading.rb
@@ -111,8 +111,13 @@ module RbsInfer::Project::StoredBlockReplayExpander
       RbsInfer::Inference::SendCall.desugar(node) || node
     end
 
-    # Which object a replay runs ON, as `[parameter name, singleton?]`, or nil
-    # when the receiver is not one this pass will move a block onto.
+    # Which handed object a receiver names, as `[parameter name, singleton?]`, or
+    # nil when it names none.
+    #
+    # Neutral about what is then DONE to that object: a block replayed onto it, a
+    # call forwarded to it, a module spliced into it. All three ask the same
+    # question of the receiver, and only the caller knows which one it is asking
+    # for (felixefelip/rbs_infer#311).
     #
     # `base.class_eval` and `base.singleton_class.class_eval` are the same
     # relocation asked about two different method tables — `base`'s own, and
@@ -126,7 +131,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # `singleton_class` is a hop to a DIFFERENT OBJECT, and taking it is only
     # safe because that object is decided by the one we were handed. An
     # arbitrary receiver still declines, singleton or not.
-    def replayed_on(receiver, parameters)
+    def handed_receiver(receiver, parameters)
       return nil unless receiver
 
       if (inner = singleton_class_of(receiver))

--- a/lib/rbs_infer/project/stored_block_replay_expander/shape_reader.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/shape_reader.rb
@@ -80,7 +80,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
       call = dispatched(node)
       return nil unless REPLAY_METHODS.include?(call.name)
 
-      target, singleton = replayed_on(call.receiver, parameters)
+      target, singleton = handed_receiver(call.receiver, parameters)
       return nil unless target
 
       pass = call.block
@@ -125,7 +125,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
         next unless node.is_a?(Prism::CallNode)
         call = dispatched(node)
         next unless REPLAY_METHODS.include?(call.name)
-        target, singleton = replayed_on(call.receiver, parameters)
+        target, singleton = handed_receiver(call.receiver, parameters)
         next unless target
         block = call.block
         next unless block.is_a?(Prism::BlockNode)
@@ -318,12 +318,19 @@ module RbsInfer::Project::StoredBlockReplayExpander
       nodes(body).filter_map do |node|
         next unless node.is_a?(Prism::CallNode)
         call = dispatched(node)
-        receiver = call.receiver
-        next unless receiver.is_a?(Prism::LocalVariableReadNode) && parameters.include?(receiver.name.to_s)
+        # Through `singleton_class` as well as bare, which is the same hop
+        # `inward_replay_shape` takes for a block (felixefelip/rbs_infer#267) and
+        # says the same thing: WHICH method table the callee is found in.
+        # `Module#extend_object` is written `obj.singleton_class.include(self)`,
+        # and read bare that line is no shape at all — which is how `extend`
+        # could not be derived from `include` (felixefelip/rbs_infer#311).
+        handed = handed_receiver(call.receiver, parameters)
+        next unless handed
         arguments = call.arguments&.arguments || []
         next unless arguments.size == 1 && arguments.first.is_a?(Prism::SelfNode)
 
-        [receiver.name.to_s, call.name.to_s]
+        parameter, singleton = handed
+        [parameter, call.name.to_s, singleton]
       end.uniq
     end
 

--- a/lib/rbs_infer/project/stored_block_replay_expander/shape_reader.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/shape_reader.rb
@@ -318,12 +318,6 @@ module RbsInfer::Project::StoredBlockReplayExpander
       nodes(body).filter_map do |node|
         next unless node.is_a?(Prism::CallNode)
         call = dispatched(node)
-        # Through `singleton_class` as well as bare, which is the same hop
-        # `inward_replay_shape` takes for a block (felixefelip/rbs_infer#267) and
-        # says the same thing: WHICH method table the callee is found in.
-        # `Module#extend_object` is written `obj.singleton_class.include(self)`,
-        # and read bare that line is no shape at all — which is how `extend`
-        # could not be derived from `include` (felixefelip/rbs_infer#311).
         handed = handed_receiver(call.receiver, parameters)
         next unless handed
         arguments = call.arguments&.arguments || []

--- a/lib/rbs_infer/project/stored_block_replay_expander/shapes.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/shapes.rb
@@ -186,7 +186,14 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # NAMES to the method that replays. The inward direction needs it: the replay
     # runs on the source with the target passed in, so the target's own body
     # cannot be the one calling it.
-    ForwardMethod = Data.define(:owner, :method, :parameter, :callee)
+    #
+    # `singleton` is WHICH method table the callee is found in, and it travels
+    # with the forward for the same reason it travels with the three replay
+    # shapes: `mod.bazingado(self)` and `mod.singleton_class.bazingado(self)` are
+    # two different methods, and re-deriving which one from the call site is not
+    # possible once the shape has been collected. `Module#extend_object` is the
+    # second form (felixefelip/rbs_infer#311).
+    ForwardMethod = Data.define(:owner, :method, :parameter, :callee, :singleton)
 
     # `def bazingado(base = nil, &block)` whose body is
     # `(@holder ||= Holder.new).bazingado(base, &block)` — a method that keeps

--- a/lib/rbs_infer/project/stored_block_replay_expander/shapes.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/shapes.rb
@@ -186,13 +186,6 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # NAMES to the method that replays. The inward direction needs it: the replay
     # runs on the source with the target passed in, so the target's own body
     # cannot be the one calling it.
-    #
-    # `singleton` is WHICH method table the callee is found in, and it travels
-    # with the forward for the same reason it travels with the three replay
-    # shapes: `mod.bazingado(self)` and `mod.singleton_class.bazingado(self)` are
-    # two different methods, and re-deriving which one from the call site is not
-    # possible once the shape has been collected. `Module#extend_object` is the
-    # second form (felixefelip/rbs_infer#311).
     ForwardMethod = Data.define(:owner, :method, :parameter, :callee, :singleton)
 
     # `def bazingado(base = nil, &block)` whose body is

--- a/spec/dummy/sig/generated/steep_ruby_runtime/module.rb
+++ b/spec/dummy/sig/generated/steep_ruby_runtime/module.rb
@@ -66,9 +66,19 @@ class Module
   # and a module that overrides this now has a `super` to resolve against.
   # @rbs_infer |...
   def extend_object(obj)
-    # rb_include_module(rb_singleton_class(obj), self): the SINGLETON of `obj`
-    # gains `self`, which is why `extend` reaches the object and `include`
-    # reaches its instances.
+    # `rb_include_module(rb_singleton_class(obj), self)` — and this line IS
+    # that call, rather than a comment about it. The SINGLETON of `obj`
+    # gains `self`, which is why `extend` reaches the object where
+    # `include` reaches its instances.
+    #
+    # Written out because it makes `extend` DERIVED: everything it does is
+    # now `include` on another method table, so a reader that understands
+    # `include` understands `extend` for free. `append_features` gets no
+    # equivalent line — `mod.include(self)` there is circular, since
+    # `include` is what calls it — which is exactly why the ancestor splice
+    # of `include` is the one irreducible thing this file states
+    # (rbs_infer#311).
+    obj.singleton_class.include(self)
     obj
   end
 

--- a/spec/dummy/sig/generated/steep_ruby_runtime/module.rb
+++ b/spec/dummy/sig/generated/steep_ruby_runtime/module.rb
@@ -66,18 +66,6 @@ class Module
   # and a module that overrides this now has a `super` to resolve against.
   # @rbs_infer |...
   def extend_object(obj)
-    # `rb_include_module(rb_singleton_class(obj), self)` — and this line IS
-    # that call, rather than a comment about it. The SINGLETON of `obj`
-    # gains `self`, which is why `extend` reaches the object where
-    # `include` reaches its instances.
-    #
-    # Written out because it makes `extend` DERIVED: everything it does is
-    # now `include` on another method table, so a reader that understands
-    # `include` understands `extend` for free. `append_features` gets no
-    # equivalent line — `mod.include(self)` there is circular, since
-    # `include` is what calls it — which is exactly why the ancestor splice
-    # of `include` is the one irreducible thing this file states
-    # (rbs_infer#311).
     obj.singleton_class.include(self)
     obj
   end

--- a/spec/lib/rbs_infer/project/call_graph_spec.rb
+++ b/spec/lib/rbs_infer/project/call_graph_spec.rb
@@ -3,17 +3,7 @@
 require "spec_helper"
 require "rbs_infer"
 
-# `CallGraph` answers where a call ends up, walked over the shapes a file was
-# read as writing. Asked directly here, because the one thing this file pins is
-# not reachable through `expand` yet: `Module#extend_object` is the only forward
-# in the corpus written through `singleton_class`, and nothing asks the graph
-# about `extend_object` until the ancestry table is derived from it
-# (felixefelip/rbs_infer#311, step 3). A branch no example reaches is a branch
-# nobody has checked.
 RSpec.describe RbsInfer::Project::StoredBlockReplayExpander::CallGraph do
-  # Fully qualified rather than `include`d: the block a `describe` takes is
-  # `class_eval`'d, so its lexical scope is this file's top level and a constant
-  # named in a helper never reaches the example group's ancestors.
   SHAPES = RbsInfer::Project::StoredBlockReplayExpander::Shapes
 
   def graph(forwards:, delegations: [])
@@ -22,11 +12,10 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander::CallGraph do
   end
 
   def forward(callee:, singleton:)
-    SHAPES::ForwardMethod.new(owner: "Module", method: "hand_over", parameter: "obj", callee: callee, singleton: singleton)
+    SHAPES::ForwardMethod.new(owner: "Module", method: "hand_over", parameter: "obj",
+                              callee: callee, singleton: singleton)
   end
 
-  # `mod.include(self)`: the callee is looked up where the argument's own
-  # methods are.
   it "looks a bare forward up in the argument's provider" do
     reached = graph(forwards: [forward(callee: "include", singleton: false)])
               .keepers_for("Module", "hand_over", "DSL")
@@ -34,9 +23,6 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander::CallGraph do
     expect(reached).to eq([["DSL", "include"]])
   end
 
-  # `mod.singleton_class.include(self)`: a different object, so a different
-  # method table, so a different owner. Reading both the same way would report a
-  # method the argument does not answer to.
   it "looks a forward through `singleton_class` up in the argument's singleton" do
     reached = graph(forwards: [forward(callee: "include", singleton: true)])
               .keepers_for("Module", "hand_over", "DSL")
@@ -44,8 +30,6 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander::CallGraph do
     expect(reached).to eq([["singleton(DSL)", "include"]])
   end
 
-  # Both spellings in one body reach two distinct methods, and the graph reports
-  # two — which is what makes the flag worth carrying rather than re-deriving.
   it "reports the two tables as two destinations" do
     reached = graph(forwards: [forward(callee: "include", singleton: false),
                                forward(callee: "include", singleton: true)])
@@ -54,10 +38,9 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander::CallGraph do
     expect(reached).to eq([["DSL", "include"], ["singleton(DSL)", "include"]])
   end
 
-  # The delegation hop still applies on top: `keeper` is asked of the owner the
-  # table lookup landed on, not of the raw provider.
   it "follows a delegation from the singleton owner" do
-    delegation = SHAPES::Delegation.new(owner: "singleton(DSL)", method: "include", target: "Holder", callee: "keep")
+    delegation = SHAPES::Delegation.new(owner: "singleton(DSL)", method: "include",
+                                        target: "Holder", callee: "keep")
     reached = graph(forwards: [forward(callee: "include", singleton: true)], delegations: [delegation])
               .keepers_for("Module", "hand_over", "DSL")
 

--- a/spec/lib/rbs_infer/project/call_graph_spec.rb
+++ b/spec/lib/rbs_infer/project/call_graph_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rbs_infer"
+
+# `CallGraph` answers where a call ends up, walked over the shapes a file was
+# read as writing. Asked directly here, because the one thing this file pins is
+# not reachable through `expand` yet: `Module#extend_object` is the only forward
+# in the corpus written through `singleton_class`, and nothing asks the graph
+# about `extend_object` until the ancestry table is derived from it
+# (felixefelip/rbs_infer#311, step 3). A branch no example reaches is a branch
+# nobody has checked.
+RSpec.describe RbsInfer::Project::StoredBlockReplayExpander::CallGraph do
+  # Fully qualified rather than `include`d: the block a `describe` takes is
+  # `class_eval`'d, so its lexical scope is this file's top level and a constant
+  # named in a helper never reaches the example group's ancestors.
+  SHAPES = RbsInfer::Project::StoredBlockReplayExpander::Shapes
+
+  def graph(forwards:, delegations: [])
+    described_class.new(replay_methods: [], readers: [], inward_replays: [], literal_replays: [],
+                        forwards: forwards, delegations: delegations, storages: [])
+  end
+
+  def forward(callee:, singleton:)
+    SHAPES::ForwardMethod.new(owner: "Module", method: "hand_over", parameter: "obj", callee: callee, singleton: singleton)
+  end
+
+  # `mod.include(self)`: the callee is looked up where the argument's own
+  # methods are.
+  it "looks a bare forward up in the argument's provider" do
+    reached = graph(forwards: [forward(callee: "include", singleton: false)])
+              .keepers_for("Module", "hand_over", "DSL")
+
+    expect(reached).to eq([["DSL", "include"]])
+  end
+
+  # `mod.singleton_class.include(self)`: a different object, so a different
+  # method table, so a different owner. Reading both the same way would report a
+  # method the argument does not answer to.
+  it "looks a forward through `singleton_class` up in the argument's singleton" do
+    reached = graph(forwards: [forward(callee: "include", singleton: true)])
+              .keepers_for("Module", "hand_over", "DSL")
+
+    expect(reached).to eq([["singleton(DSL)", "include"]])
+  end
+
+  # Both spellings in one body reach two distinct methods, and the graph reports
+  # two — which is what makes the flag worth carrying rather than re-deriving.
+  it "reports the two tables as two destinations" do
+    reached = graph(forwards: [forward(callee: "include", singleton: false),
+                               forward(callee: "include", singleton: true)])
+              .keepers_for("Module", "hand_over", "DSL")
+
+    expect(reached).to eq([["DSL", "include"], ["singleton(DSL)", "include"]])
+  end
+
+  # The delegation hop still applies on top: `keeper` is asked of the owner the
+  # table lookup landed on, not of the raw provider.
+  it "follows a delegation from the singleton owner" do
+    delegation = SHAPES::Delegation.new(owner: "singleton(DSL)", method: "include", target: "Holder", callee: "keep")
+    reached = graph(forwards: [forward(callee: "include", singleton: true)], delegations: [delegation])
+              .keepers_for("Module", "hand_over", "DSL")
+
+    expect(reached).to eq([["Holder", "keep"]])
+  end
+end

--- a/spec/lib/rbs_infer/project/ruby_runtime_generator_spec.rb
+++ b/spec/lib/rbs_infer/project/ruby_runtime_generator_spec.rb
@@ -96,19 +96,11 @@ RSpec.describe RbsInfer::Project::RubyRuntimeGenerator do
       end
     end
 
-    # `rb_include_module(rb_singleton_class(obj), self)` written OUT, not
-    # described. It is the one ancestry statement of the two that can be: written
-    # in `append_features` the same line would be circular, since `include` is
-    # what calls it. So `extend` is derived from `include` and the core has one
-    # irreducible splice to state instead of two (felixefelip/rbs_infer#311).
     it "splices into the singleton in Ruby, so `extend` is `include` on another table" do
       Dir.mktmpdir do |dir|
         source = source_of(dir, "module.rb")
 
         expect(source).to include("    obj.singleton_class.include(self)\n")
-        # As CODE, anchored: the comment above it names the circular line in
-        # order to say why it is not written, and a bare substring would read
-        # the explanation as the thing explained.
         expect(source.scan(/^\s+mod\.include\(self\)$/)).to be_empty
       end
     end

--- a/spec/lib/rbs_infer/project/ruby_runtime_generator_spec.rb
+++ b/spec/lib/rbs_infer/project/ruby_runtime_generator_spec.rb
@@ -92,7 +92,24 @@ RSpec.describe RbsInfer::Project::RubyRuntimeGenerator do
       Dir.mktmpdir do |dir|
         source = source_of(dir, "module.rb")
 
-        expect(source).to match(/def extend_object\(obj\)(?:\n\s*#.*)*\n\s+obj\n\s+end/)
+        expect(source).to match(/def extend_object\(obj\).*\n    obj\n  end/m)
+      end
+    end
+
+    # `rb_include_module(rb_singleton_class(obj), self)` written OUT, not
+    # described. It is the one ancestry statement of the two that can be: written
+    # in `append_features` the same line would be circular, since `include` is
+    # what calls it. So `extend` is derived from `include` and the core has one
+    # irreducible splice to state instead of two (felixefelip/rbs_infer#311).
+    it "splices into the singleton in Ruby, so `extend` is `include` on another table" do
+      Dir.mktmpdir do |dir|
+        source = source_of(dir, "module.rb")
+
+        expect(source).to include("    obj.singleton_class.include(self)\n")
+        # As CODE, anchored: the comment above it names the circular line in
+        # order to say why it is not written, and a bare substring would read
+        # the explanation as the thing explained.
+        expect(source.scan(/^\s+mod\.include\(self\)$/)).to be_empty
       end
     end
 

--- a/spec/lib/rbs_infer/project/shape_reader_spec.rb
+++ b/spec/lib/rbs_infer/project/shape_reader_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rbs_infer"
+require "prism"
+
+# `ShapeReader` is a module of pure functions — a body and the names it was
+# handed go in, a tuple or nil comes out — and its own comment says so: the
+# readings "can be checked against a source string with nothing else set up"
+# (felixefelip/rbs_infer#303). Until now nothing did; they were exercised only
+# through `expand`, which answers about a whole file.
+#
+# This file starts with the one reading `extend` depends on
+# (felixefelip/rbs_infer#311).
+RSpec.describe RbsInfer::Project::StoredBlockReplayExpander::ShapeReader do
+  # The single `def` in `source`, with the names it was handed — which is the
+  # method's parameters plus the parameters of blocks passed to calls on them,
+  # exactly as `Collector#collect_method_shape` computes them.
+  def forwards(source)
+    node = RbsInfer::Analyzer.find_all_nodes(Prism.parse(source).value) { |n| n.is_a?(Prism::DefNode) }.first
+    handed = RbsInfer::Project::StoredBlockReplayExpander::NodeReading.handed_names(node.body, RbsInfer::Project::StoredBlockReplayExpander::NodeReading.parameter_names(node.parameters))
+    described_class.forward_shapes(node.body, handed)
+  end
+
+  # `mod.bazingado(self)` — the hop this shape was written for.
+  it "reads a forward to a method of the object it was handed" do
+    expect(forwards("def bazinga(mod) = mod.bazingado(self)")).to eq([["mod", "bazingado", false]])
+  end
+
+  # The same hop asked about the other method table, which is what
+  # `Module#extend_object` is written as. Read bare, this line was no shape at
+  # all — and that is how `extend` could not be derived from `include`.
+  it "reads a forward through `singleton_class`, and says which table" do
+    expect(forwards(<<~RUBY)).to eq([["obj", "include", true]])
+      def extend_object(obj)
+        obj.singleton_class.include(self)
+        obj
+      end
+    RUBY
+  end
+
+  # The two are distinguished, not merged: `mod.include(self)` and
+  # `mod.singleton_class.include(self)` reach different methods, and a shape
+  # that answered the same for both would send a block to the wrong table.
+  it "tells the two tables apart in one body" do
+    expect(forwards(<<~RUBY)).to eq([["mod", "include", false], ["mod", "include", true]])
+      def both(mod)
+        mod.include(self)
+        mod.singleton_class.include(self)
+      end
+    RUBY
+  end
+
+  # Through a `send`, because that is how the transcriptions reach a private
+  # hook — `rb_funcall` dispatches ignoring visibility.
+  it "reads the hop through `send`" do
+    expect(forwards("def extend_object(obj) = obj.singleton_class.send(:include, self)"))
+      .to eq([["obj", "include", true]])
+  end
+
+  # The parameter restriction is the whole conservatism, and `singleton_class`
+  # does not relax it: the hop is safe only because the object it lands on is
+  # decided by the one we were handed.
+  it "declines a receiver it was not handed" do
+    expect(forwards("def go(mod) = Other.singleton_class.include(self)")).to be_empty
+  end
+
+  # `singleton_class` takes no arguments. A same-named method that does is
+  # somebody else's and says nothing about a method table.
+  it "declines a `singleton_class` that takes arguments" do
+    expect(forwards("def go(mod) = mod.singleton_class(:x).include(self)")).to be_empty
+  end
+
+  # What makes it a FORWARD is that `self` arrives at the callee. A call that
+  # passes anything else is an ordinary message the method happens to send.
+  it "declines a call that does not hand `self` over" do
+    expect(forwards("def go(mod) = mod.singleton_class.include(Other)")).to be_empty
+  end
+end

--- a/spec/lib/rbs_infer/project/shape_reader_spec.rb
+++ b/spec/lib/rbs_infer/project/shape_reader_spec.rb
@@ -4,32 +4,18 @@ require "spec_helper"
 require "rbs_infer"
 require "prism"
 
-# `ShapeReader` is a module of pure functions — a body and the names it was
-# handed go in, a tuple or nil comes out — and its own comment says so: the
-# readings "can be checked against a source string with nothing else set up"
-# (felixefelip/rbs_infer#303). Until now nothing did; they were exercised only
-# through `expand`, which answers about a whole file.
-#
-# This file starts with the one reading `extend` depends on
-# (felixefelip/rbs_infer#311).
 RSpec.describe RbsInfer::Project::StoredBlockReplayExpander::ShapeReader do
-  # The single `def` in `source`, with the names it was handed — which is the
-  # method's parameters plus the parameters of blocks passed to calls on them,
-  # exactly as `Collector#collect_method_shape` computes them.
   def forwards(source)
     node = RbsInfer::Analyzer.find_all_nodes(Prism.parse(source).value) { |n| n.is_a?(Prism::DefNode) }.first
-    handed = RbsInfer::Project::StoredBlockReplayExpander::NodeReading.handed_names(node.body, RbsInfer::Project::StoredBlockReplayExpander::NodeReading.parameter_names(node.parameters))
+    reading = RbsInfer::Project::StoredBlockReplayExpander::NodeReading
+    handed = reading.handed_names(node.body, reading.parameter_names(node.parameters))
     described_class.forward_shapes(node.body, handed)
   end
 
-  # `mod.bazingado(self)` — the hop this shape was written for.
   it "reads a forward to a method of the object it was handed" do
     expect(forwards("def bazinga(mod) = mod.bazingado(self)")).to eq([["mod", "bazingado", false]])
   end
 
-  # The same hop asked about the other method table, which is what
-  # `Module#extend_object` is written as. Read bare, this line was no shape at
-  # all — and that is how `extend` could not be derived from `include`.
   it "reads a forward through `singleton_class`, and says which table" do
     expect(forwards(<<~RUBY)).to eq([["obj", "include", true]])
       def extend_object(obj)
@@ -39,9 +25,6 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander::ShapeReader do
     RUBY
   end
 
-  # The two are distinguished, not merged: `mod.include(self)` and
-  # `mod.singleton_class.include(self)` reach different methods, and a shape
-  # that answered the same for both would send a block to the wrong table.
   it "tells the two tables apart in one body" do
     expect(forwards(<<~RUBY)).to eq([["mod", "include", false], ["mod", "include", true]])
       def both(mod)
@@ -51,28 +34,19 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander::ShapeReader do
     RUBY
   end
 
-  # Through a `send`, because that is how the transcriptions reach a private
-  # hook — `rb_funcall` dispatches ignoring visibility.
   it "reads the hop through `send`" do
     expect(forwards("def extend_object(obj) = obj.singleton_class.send(:include, self)"))
       .to eq([["obj", "include", true]])
   end
 
-  # The parameter restriction is the whole conservatism, and `singleton_class`
-  # does not relax it: the hop is safe only because the object it lands on is
-  # decided by the one we were handed.
   it "declines a receiver it was not handed" do
     expect(forwards("def go(mod) = Other.singleton_class.include(self)")).to be_empty
   end
 
-  # `singleton_class` takes no arguments. A same-named method that does is
-  # somebody else's and says nothing about a method table.
   it "declines a `singleton_class` that takes arguments" do
     expect(forwards("def go(mod) = mod.singleton_class(:x).include(self)")).to be_empty
   end
 
-  # What makes it a FORWARD is that `self` arrives at the callee. A call that
-  # passes anything else is an ordinary message the method happens to send.
   it "declines a call that does not hand `self` over" do
     expect(forwards("def go(mod) = mod.singleton_class.include(Other)")).to be_empty
   end


### PR DESCRIPTION
Step 2 of 3 in #311. `RubyRuntimeGenerator` modelled **dispatch** and declined, in a
comment, to model **ancestry**. `Module#extend_object` now writes the line instead of
describing it:

```ruby
def extend_object(obj)
  obj.singleton_class.include(self)
  obj
end
```

That makes `extend` **derived**: everything it does is `include` on another method table.
`append_features` gets no equivalent — `mod.include(self)` there is circular, since
`include` is what calls it — which is exactly why the ancestor splice of `include` is the
one irreducible thing this file states, and why the core ends up knowing *one* method name
instead of two.

## The line as the issue proposed it was not read

Measuring that came first:

```
def extend_object   obj.singleton_class.include(self)   forwards = []
def append_features mod.include(self)                   forwards = [["mod", "include"]]
```

`forward_shapes` required a bare `LocalVariableReadNode` receiver, so the hop through
`singleton_class` collected nothing. Writing the line alone would have been prose in Ruby:
true, and invisible. (#311 is updated with this.)

## The reader already existed, under a name that hid it

`NodeReading#replayed_on` answers `[handed name, singleton?]`, through `singleton_class` or
bare — and nothing in it is about replays. A block moved onto the object, a call forwarded
to it, and a module spliced into it all ask the receiver the same question; only the caller
knows which one it is asking. Renamed **`handed_receiver`** and reused, rather than writing
a second reader of the same shape.

So a forward now carries `singleton`, the way all three replay shapes already do, and
`CallGraph#keepers_for` honours it: the callee of a singleton forward is looked up in the
argument's **singleton owner**, a different owner and so a different set of methods. Same
distinction `Declarations#providers` draws for a bare call in a class body, asked of a
forward.

## Two new spec files, because two things were unreachable

**`shape_reader_spec.rb`** — the file `ShapeReader`'s own comment says should exist
(*"the readings can be checked against a source string with nothing else set up"*, #303)
and did not. Seven examples: both spellings told apart in one body, the hop through `send`,
and the three declines the parameter restriction owes.

**`call_graph_spec.rb`** — because the singleton branch in `keepers_for` is reached by
nothing until step 3: `extend_object` is never the method a module call names. A branch no
example reaches is a branch nobody has checked.

## This does not move the dummy

Expected, and worth stating plainly: the flag is read and the graph honours it, but the
consumer is the fixpoint in step 3. The Steep baseline is unchanged and the generated
sidecar RBS is **byte-identical** — only the `.rb` moved. That is why the two new specs are
direct rather than end-to-end.

## Verification

- 1398 unit examples green but for the pre-existing environmental failure (rbs 4.2.0 names
  `Array`'s parameter `E`; the spec expects `Elem`).
- Integration green but for `example55/foo` and `ActiveRecord runtime`, both of which
  reproduce on `origin/main`.
- Steep baseline on the dummy unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179Um6Qoek3LMYrqHKUPuos
