### PR TITLE
Fix the two failing specs, and the shipping gap the second one pointed at

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Loaded automatically when running inside a Rails app via [`RbsInfer::Railtie`](l
 
 | Task | Source generator | Output dir |
 |---|---|---|
+| `rake rbs_infer:ruby_runtime:all` | `RbsInfer::Project::RubyRuntimeGenerator` | `sig/generated/steep_ruby_runtime/` |
 | `rake rbs_infer:enumerize:all` | `RbsInfer::Extensions::Enumerize::Generator` | `sig/rbs_enumerize/` |
 | `rake rbs_infer:devise:all` | `RbsInfer::Extensions::Devise::Generator` | `sig/generated/steep_devise_runtime/` |
 | `rake rbs_infer:rails_custom:all` | `RbsInfer::Extensions::Rails::CustomGenerator` | `sig/rbs_rails_custom/` |

--- a/lib/rbs_infer/railtie.rb
+++ b/lib/rbs_infer/railtie.rb
@@ -5,6 +5,7 @@ require "rails/railtie"
 module RbsInfer
   class Railtie < Rails::Railtie
     rake_tasks do
+      load File.expand_path("tasks/rbs_infer_ruby_runtime.rake", __dir__)
       load File.expand_path("extensions/enumerize/tasks/rbs_infer_enumerize.rake", __dir__)
       load File.expand_path("extensions/carrierwave/tasks/rbs_infer_carrierwave.rake", __dir__)
       load File.expand_path("extensions/devise/tasks/rbs_infer_devise.rake", __dir__)

--- a/lib/rbs_infer/tasks/rbs_infer_ruby_runtime.rake
+++ b/lib/rbs_infer/tasks/rbs_infer_ruby_runtime.rake
@@ -6,8 +6,7 @@ namespace :rbs_infer do
   namespace :ruby_runtime do
     desc "Generate the language-runtime pseudo-code sidecar for Steep (sig/generated/steep_ruby_runtime/)"
     task :all do
-      app_dir = defined?(Rails) ? Rails.root.to_s : Dir.pwd
-      dir = RbsInfer::Project::RubyRuntimeGenerator.new(app_dir: app_dir).generate
+      dir = RbsInfer::Project::RubyRuntimeGenerator.new(app_dir: Rails.root.to_s).generate
       puts "Generated language-runtime pseudo-code: #{dir}"
     end
   end

--- a/lib/rbs_infer/tasks/rbs_infer_ruby_runtime.rake
+++ b/lib/rbs_infer/tasks/rbs_infer_ruby_runtime.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative "../project/ruby_runtime_generator"
+
+namespace :rbs_infer do
+  namespace :ruby_runtime do
+    desc "Generate the language-runtime pseudo-code sidecar for Steep (sig/generated/steep_ruby_runtime/)"
+    task :all do
+      app_dir = defined?(Rails) ? Rails.root.to_s : Dir.pwd
+      dir = RbsInfer::Project::RubyRuntimeGenerator.new(app_dir: app_dir).generate
+      puts "Generated language-runtime pseudo-code: #{dir}"
+    end
+  end
+end

--- a/spec/bin/rbs_infer_spec.rb
+++ b/spec/bin/rbs_infer_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "rbs_infer/project/ruby_runtime_generator"
 require "tmpdir"
 require "fileutils"
 require "open3"
@@ -452,6 +453,10 @@ RSpec.describe "bin/rbs_infer" do
           signature "sig"
         end
       RUBY
+
+      # A transcrição da linguagem, que todo projeto tem em disco: sem ela o
+      # `extend` não chega na emenda e o bloco não sai do lugar (#311).
+      RbsInfer::Project::RubyRuntimeGenerator.new(app_dir: @tmpdir).generate
 
       # A transcrição que o gerador de AR-runtime emite, reduzida ao que este
       # caso lê: `class_methods` guardando o bloco num `ClassMethods`.

--- a/spec/bin/rbs_infer_spec.rb
+++ b/spec/bin/rbs_infer_spec.rb
@@ -454,8 +454,6 @@ RSpec.describe "bin/rbs_infer" do
         end
       RUBY
 
-      # A transcrição da linguagem, que todo projeto tem em disco: sem ela o
-      # `extend` não chega na emenda e o bloco não sai do lugar (#311).
       RbsInfer::Project::RubyRuntimeGenerator.new(app_dir: @tmpdir).generate
 
       # A transcrição que o gerador de AR-runtime emite, reduzida ao que este

--- a/spec/lib/rbs_infer/signatures/rbs_definition_resolver_spec.rb
+++ b/spec/lib/rbs_infer/signatures/rbs_definition_resolver_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RbsInfer::Signatures::RbsDefinitionResolver do
 
   describe "#type_param_string" do
     it "renders the exact params of a generic core class" do
-      expect(resolver.type_param_string("Array")).to eq("[unchecked out Elem]")
+      expect(resolver.type_param_string("Array")).to eq("[unchecked out E]")
       expect(resolver.type_param_string("Hash")).to eq("[unchecked out K, unchecked out V]")
     end
 


### PR DESCRIPTION
**1579 examples, 0 failures** — the whole suite, in the environment the lock now pins.

## 1. `rbs_definition_resolver_spec` — a third party's spelling

The spec pinned `Array[unchecked out Elem]`; rbs 4.2.0 renamed it to `E`. The implementation only renders what RBS declares (`entry.type_params.map(&:to_s)`), so there was nothing to fix in rbs_infer.

`Hash[K, V]` did not change — and its assertion never ran, because the `Array` one failed first.

## 2. `class_methods do` in `spec/bin` — my regression, from #314

Bisected: green at `d9337c1` (#313), red at `a4f1047` (#314).

It is the exact cost I wrote into #314's own description — *"the pass now REQUIRES the runtime sidecar in the corpus"* — filed as a risk when it had already broken a real test. I did not see it because **I never ran `spec/bin/`**: three times this week I called the suite green having run 1547 of 1579 examples.

The fixture built a temp project with the AR-runtime sidecar and without the language's. It now generates both, which is what a real project has on disk.

## And the defect the spec was pointing at

Asked how a *user of the gem* would produce that sidecar, the answer was: they could not.

| | |
|---|---|
| `extensions/rails/tasks/` | 6 rake tasks |
| `ruby_runtime` | no task, not in the Railtie, not in the README — only a `Makefile` target used for the dummy |

So since #314 an application's `extend` resolves to nothing, silently, and there is no command to fix it.

Added `lib/rbs_infer/tasks/rbs_infer_ruby_runtime.rake` — under `tasks/`, **not** `extensions/rails/tasks/`, because `RubyRuntimeGenerator` is core: its own comment says `include` is plain Ruby and that is why it is not an extension. Loaded from the Railtie, listed in the README's generator table, and run for real:

```
$ rake rbs_infer:ruby_runtime:all
Generated language-runtime pseudo-code: .../sig/generated/steep_ruby_runtime
```

## Still open, separately

- `spec/dummy/sig/rbs_infer/sig/generated/steep_ruby_runtime/module.rbs` has no expectation — the only runtime sidecar without one, and since #314 the most load-bearing. It moved this week (`prepend_features: (Module mod)` → `(untyped mod)`) and nothing caught it.
- The root `Gemfile` uses `path: "../steep"`, which does not resolve from a git worktree; `spec/dummy/Gemfile` already uses an absolute path for the same gem.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179Um6Qoek3LMYrqHKUPuos
