### PR TITLE
One collection for the expansion, and join the payload by slot instead of by method name

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -98,17 +98,12 @@ module RbsInfer
     # `class_eval`/`module_eval` on another. The contextual expander moves its
     # body to that statically resolved receiver before the ordinary collector
     # attributes the `def`s to the lexical source object (rbs_infer#238).
-    # Read from the source the replay resolution itself runs on — before the
-    # rewrite, whose appended reopenings hold no blocks and are not this file's
-    # call sites (felixefelip/rbs_infer#321).
-    @stored_block_bodies = RbsInfer::Project::StoredBlockReplayExpander.stored_block_bodies(
-      source, sources: @corpus.constant_sources
-    )
-    replay_expanded = RbsInfer::Project::StoredBlockReplayExpander.expand(source, sources: @corpus.constant_sources,
-                                                                          mixin_index: mixin_index)
-    if replay_expanded
-      @expanded_source = replay_expanded
-      source = replay_expanded
+    expansion = RbsInfer::Project::StoredBlockReplayExpander.expansion(source, sources: @corpus.constant_sources,
+                                                                       mixin_index: mixin_index)
+    @stored_block_bodies = expansion.bodies
+    if expansion.source
+      @expanded_source = expansion.source
+      source = expansion.source
     end
 
     # Inject `@type self:`/`@type instance:` for concerns/modules (and the

--- a/lib/rbs_infer/project/stored_block_replay_expander.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander.rb
@@ -92,7 +92,17 @@ module RbsInfer::Project
     # and replays it on whoever includes THAT, so the collector follows the hop
     # and answers with the class the block runs on
     # (felixefelip/rbs_infer#300).
-    Replay = Data.define(:target, :block, :kind, :call, :scope, :in_method, :source, :singleton, :extended)
+    # `slot` is the `[owner, ivar]` the block was kept in, or nil when it never
+    # was one — a block written in place, or the DSL's own `&block` parameter.
+    # The resolution already computes it to find the block at all, so recording
+    # it here is what lets a consumer ask which slot holds which block instead
+    # of matching a method NAME, which two owners can share
+    # (felixefelip/rbs_infer#321).
+    # What one expansion answers: the rewritten source (nil when nothing
+    # applies) and `{ owner => { ivar => [block source, …] } }`.
+    Expansion = Data.define(:source, :bodies)
+
+    Replay = Data.define(:target, :block, :kind, :call, :scope, :in_method, :source, :singleton, :extended, :slot)
 
     module_function
 
@@ -101,7 +111,16 @@ module RbsInfer::Project
     # `ConstantSources::NONE` as the explicit way to say "no project": defaulted,
     # a caller that forgot it would quietly resolve less
     # (docs/engineering/required-threaded-deps.md).
+    # The rewritten source, or nil when nothing applies.
     def expand(source, sources:, mixin_index:)
+      expansion(source, sources: sources, mixin_index: mixin_index).source
+    end
+
+    # Both answers off ONE collection: the rewritten source, and the block
+    # sources its slots hold. Asked separately they cost two full walks — the
+    # lexical pass, the corpus walk over the files this one names, and the
+    # resolution — for the same replays (felixefelip/rbs_infer#321).
+    def expansion(source, sources:, mixin_index:)
       # This file's own text is no longer the whole question. A concern writes
       # `base.class_eval do … end` in its own file and the `include` naming the
       # target is written in the host, which mentions no eval — so gating on the
@@ -109,37 +128,30 @@ module RbsInfer::Project
       # (felixefelip/rbs_infer#265). The project-wide answer keeps what the gate
       # was for: a project that writes neither an eval nor an inward `extend`
       # anywhere still pays nothing.
-      return nil unless possible?(source, sources)
+      return Expansion.new(source: nil, bodies: {}) unless possible?(source, sources)
 
       parsed = Prism.parse(source)
-      return nil unless parsed.success?
+      return Expansion.new(source: nil, bodies: {}) unless parsed.success?
 
       collector = Collector.new(source, sources: sources)
       replays = collector.collect(parsed.value)
       extensions = collector.extensions
-      return nil if replays.empty? && extensions.empty?
+      return Expansion.new(source: nil, bodies: {}) if replays.empty? && extensions.empty?
 
-      apply_replays(source, replays, extensions, mixin_index)
+      Expansion.new(source: apply_replays(source, replays, extensions, mixin_index),
+                    bodies: bodies_by_slot(replays))
     end
 
-    def stored_block_bodies(source, sources:)
-      return {} unless possible?(source, sources)
+    def bodies_by_slot(replays)
+      replays.each_with_object({}) do |replay, out|
+        owner, ivar = replay.slot
+        next unless owner
 
-      parsed = Prism.parse(source)
-      return {} unless parsed.success?
+        body = body_source(replay)
+        next unless body
 
-      collector = Collector.new(source, sources: sources)
-      bodies_by_slot(collector.storages, collector.collect(parsed.value))
-    end
-
-    def bodies_by_slot(storages, replays)
-      storages.each_with_object({}) do |storage, out|
-        bodies = replays.select { |replay| replay.call == storage.method }
-                        .filter_map { |replay| body_source(replay) }
-                        .uniq
-        next if bodies.empty?
-
-        (out[storage.owner] ||= {})[storage.ivar] = bodies
+        slot = (out[owner] ||= {})
+        slot[ivar] = ((slot[ivar] || []) + [body]).uniq
       end
     end
 

--- a/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
@@ -27,8 +27,6 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # site here does to a class here, read off the same resolution.
     attr_reader :extensions
 
-    def storages = @shapes.storages
-
     def initialize(source, sources:)
       @source = source
       @sources = sources

--- a/lib/rbs_infer/project/stored_block_replay_expander/resolution.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/resolution.rb
@@ -180,7 +180,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
 
       Replay.new(target: target, block: stored.block, kind: kind, call: stored.method,
                  scope: stored.subject, in_method: nil, source: stored.source, singleton: own.singleton,
-                 extended: handed_to_hosts?(target, stored.subject, providers))
+                 extended: handed_to_hosts?(target, stored.subject, providers), slot: nil)
     end
 
     # Whether a hook in `subject`'s provider chain hands this very module to
@@ -514,7 +514,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
       if (literal = literals.first)
         return Replay.new(target: subject, block: literal.block, kind: kind,
                           call: literal.call, scope: literal.scope, in_method: literal.method,
-                          source: literal.source, singleton: literal.singleton, extended: false)
+                          source: literal.source, singleton: literal.singleton, extended: false, slot: nil)
       end
 
       storage_owner, ivar, singleton = slots.first
@@ -528,7 +528,8 @@ module RbsInfer::Project::StoredBlockReplayExpander
 
       Replay.new(target: subject, block: blocks.first.block, kind: kind,
                  call: storage_method, scope: blocks.first.subject, in_method: nil,
-                 source: blocks.first.source, singleton: singleton, extended: false)
+                 source: blocks.first.source, singleton: singleton, extended: false,
+                 slot: [storage_owner, ivar])
     end
   end
 end


### PR DESCRIPTION
Cleans up two things #322 left behind. Both surfaced from one question — whether the payload could *reuse* the expander rather than sit beside it — and the answer in both cases was that it was re-deriving something the expander already had.

## One collection instead of two

`Analyzer#load_and_parse_target` called `stored_block_bodies` and then `expand`. Each built a `Collector` and ran the whole thing: the lexical pass, the corpus walk over every file this one names, and the resolution — for the same replays.

`expansion` now answers both off one collection:

```ruby
Expansion = Data.define(:source, :bodies)

def expand(source, sources:, mixin_index:)
  expansion(source, sources: sources, mixin_index: mixin_index).source
end
```

`expand` stays for callers that only want the source, which is what its one-in-one-out contract was protecting — and that contract was the justification for the separate call, which did not survive the measurement.

Median of 3 over the dummy's 86 models: **0.038s**, against two full collections before.

## Joined by slot, not by method name

The payload paired a block to a slot like this:

```ruby
bodies = replays.select { |replay| replay.call == storage.method }
```

`Storage` is `(owner, method, ivar)` and `Replay` carries no storage owner — only the call's name. Two storage methods sharing a name in different owners would each collect *both* blocks' bodies. `written_names` says as much about the general case: *"Reading the keeper's name in both cases only works while the two happen to be spelled alike."*

`Resolution#replay_for` already computes `[storage_owner, ivar]` — it has to, to find the block at all:

```ruby
storage_owner, ivar, singleton = slots.first
storage_method = @graph.storage_method_for(source_provider, storage_owner, ivar)
```

So `Replay` records it, and the payload becomes a lookup. **The search is gone rather than fixed** — there is no name matching left to get wrong, which is why this ships without a regression fixture: the mechanism the bug lived in no longer exists.

`slot` is nil for the two shapes that never pass through one (a block written in place; the DSL's own `&block` parameter), and is required at all three construction sites rather than defaulted — a replay that forgot it would silently drop its payload, which is the silent-wrong case `docs/engineering/required-threaded-deps.md` describes.

`Collector#storages`, added by #322, goes with the search that needed it.

## Verification

**1581 examples, 0 failures — with the expectations NOT regenerated.** That is the point of the run: the slot join produces byte-identical output to the name join across all 12 files that carry a payload, so this is a refactor and not a behaviour change.

## Note on scope

This does not give the payload a reader. Nothing consumes `::RbsInfer::Body[…]` today, and the three candidate consumers were each ruled out — the expander itself (#156, a pre-parse pass reading its own previous output), a second post-parse pass (#323, which does not survive the method boundary), and the `blocks:` sidecar (which needs the target, and the payload carries only the body). What this PR does is stop that emission from costing two collections and from pairing by a name two owners can share.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGYyGCxXCG4jcG5pkxEaSf
