### PR TITLE
test(dummy): pin the narrowing a concern-declared lifecycle callback proves

### DIFF
--- a/spec/dummy/app/models/post/notifiable.rb
+++ b/spec/dummy/app/models/post/notifiable.rb
@@ -5,6 +5,20 @@ module Post::Notifiable
 
   included do
     delegate :updated_at, to: :user, prefix: true
+
+    # The dominant Rails shape for a lifecycle callback, and the one
+    # `.steep_callbacks.yml` used to miss entirely: the macro in the concern's
+    # `included do`, the handler in the concern's body (felixefelip/rbs_rails#19).
+    #
+    # The callback runs on the HOST, so the record is past its validations and
+    # `user` — a required `belongs_to` — is non-nil. The handler is type-checked
+    # in the CONCERN, so the entry is keyed `Post::Notifiable` while the
+    # narrowing it applies is the host's `Post & Post::Validated`.
+    #
+    # `notification_payload` above is the control: the same `user.full_name`,
+    # reached from no callback, and it still reports `(::User | nil)` in the
+    # baseline. Only what the callback reaches is narrowed.
+    after_create_commit :notify_author_followers
   end
 
   def notification_title
@@ -35,5 +49,17 @@ module Post::Notifiable
 
   def deliver_notification(subscriber)
     EmailNotifier.new.notify(user, "post_notification")
+  end
+
+  # The callback handler. Nothing calls it in the source — Rails does, by
+  # symbol — so the narrowing can only come from the sidecar entry.
+  def notify_author_followers
+    author_digest_subject
+  end
+
+  # One hop past the handler: reachable only through it, so it is the transitive
+  # self-call closure that carries the narrowing this far.
+  def author_digest_subject
+    "#{user.full_name}: #{title}"
   end
 end

--- a/spec/dummy/sig/rbs_infer/.expanded/app/models/post.rb
+++ b/spec/dummy/sig/rbs_infer/.expanded/app/models/post.rb
@@ -158,6 +158,20 @@ end
 
 class Post
   delegate :updated_at, to: :user, prefix: true
+
+  # The dominant Rails shape for a lifecycle callback, and the one
+  # `.steep_callbacks.yml` used to miss entirely: the macro in the concern's
+  # `included do`, the handler in the concern's body (felixefelip/rbs_rails#19).
+  #
+  # The callback runs on the HOST, so the record is past its validations and
+  # `user` — a required `belongs_to` — is non-nil. The handler is type-checked
+  # in the CONCERN, so the entry is keyed `Post::Notifiable` while the
+  # narrowing it applies is the host's `Post & Post::Validated`.
+  #
+  # `notification_payload` above is the control: the same `user.full_name`,
+  # reached from no callback, and it still reports `(::User | nil)` in the
+  # baseline. Only what the callback reaches is narrowed.
+  after_create_commit :notify_author_followers
 end
 
 class Post

--- a/spec/dummy/sig/rbs_infer/app/models/post/notifiable.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/post/notifiable.rbs
@@ -10,5 +10,7 @@ class Post
     private
 
     def deliver_notification: (untyped subscriber) -> { body: String, from: String, sent_at: ActiveSupport::TimeWithZone, to: String? }
+    def notify_author_followers: () -> String
+    def author_digest_subject: () -> String
   end
 end

--- a/spec/dummy/sig/rbs_rails/.steep_callbacks.yml
+++ b/spec/dummy/sig/rbs_rails/.steep_callbacks.yml
@@ -5,3 +5,8 @@ callbacks:
   applies_self: Comment & Comment::Validated
   runs_before:
   - notify_post_author
+- class: Post::Notifiable
+  applies_self: Post & Post::Validated
+  runs_before:
+  - notify_author_followers
+  - author_digest_subject

--- a/spec/expectations/expanded/app/models/post.rb
+++ b/spec/expectations/expanded/app/models/post.rb
@@ -155,6 +155,20 @@ end
 
 class Post
   delegate :updated_at, to: :user, prefix: true
+
+  # The dominant Rails shape for a lifecycle callback, and the one
+  # `.steep_callbacks.yml` used to miss entirely: the macro in the concern's
+  # `included do`, the handler in the concern's body (felixefelip/rbs_rails#19).
+  #
+  # The callback runs on the HOST, so the record is past its validations and
+  # `user` — a required `belongs_to` — is non-nil. The handler is type-checked
+  # in the CONCERN, so the entry is keyed `Post::Notifiable` while the
+  # narrowing it applies is the host's `Post & Post::Validated`.
+  #
+  # `notification_payload` above is the control: the same `user.full_name`,
+  # reached from no callback, and it still reports `(::User | nil)` in the
+  # baseline. Only what the callback reaches is narrowed.
+  after_create_commit :notify_author_followers
 end
 
 class Post

--- a/spec/expectations/models/post/notifiable.rbs
+++ b/spec/expectations/models/post/notifiable.rbs
@@ -10,5 +10,7 @@ class Post
     private
 
     def deliver_notification: (untyped subscriber) -> { body: String, from: String, sent_at: ActiveSupport::TimeWithZone, to: String? }
+    def notify_author_followers: () -> String
+    def author_digest_subject: () -> String
   end
 end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -31,7 +31,7 @@ app/models/example63.rb:9:8: [warning] Method `::Example63::Foo#greet` is not de
 app/models/example7.rb:31:28: [error] Type `(::Integer | nil)` does not have method `abs`
 app/models/example7.rb:34:27: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/included_hook.rb:110:12: [warning] Method `::IncludedHook::Arbitrary#from_arbitrary` is not declared in RBS
-app/models/post/notifiable.rb:28:24: [error] Type `(::User | nil)` does not have method `full_name`
+app/models/post/notifiable.rb:42:24: [error] Type `(::User | nil)` does not have method `full_name`
 app/models/send_dispatch.rb:107:33: [error] `public_send` cannot call `stamp` on `::SendDispatch`, which declares it private
 app/models/send_dispatch.rb:114:26: [error] `send` names `no_such_method_anywhere`, which type `::SendDispatch` does not have
 app/models/send_dispatch.rb:119:39: [error] Unexpected positional argument


### PR DESCRIPTION
Pairs with **felixefelip/rbs_rails#19**, which reads lifecycle callbacks out of a concern's `included do`. This is the dummy-side measurement.

## What was missing

The dummy only ever exercised an after-validation callback written at the top of a model class body — `Comment#notify_post_author`, from `after_save :notify_post_author`. The shape a real Rails app writes is the other one: the macro in a concern's `included do`, the handler in the concern's own body. That produced no sidecar entry at all, which is the fizzy report this pairs with:

```
app/models/user/accessor.rb:22  Type `(::Account | nil)` does not have method `boards`
```

— inside `grant_access_to_boards`, a method reached only from `after_create_commit`, on a model whose `account` is a required `belongs_to`. A human reading that file knows the record is validated there; the tooling did not.

## The fixture

`Post::Notifiable` now carries the shape:

```ruby
included do
  after_create_commit :notify_author_followers
end

private
  def notify_author_followers
    author_digest_subject
  end

  def author_digest_subject
    "#{user.full_name}: #{title}"
  end
```

`author_digest_subject` sits one hop past the handler and is reachable only through it, so the transitive self-call closure is exercised too, not just the entry point. Both deref `user`, a required `belongs_to`.

The entry rbs_rails now emits is keyed by the **concern** — that is the `module_context` Steep checks the handler in — while the narrowing it applies is the **host's**:

```yaml
- class: Post::Notifiable
  applies_self: Post & Post::Validated
  runs_before:
  - notify_author_followers
  - author_digest_subject
```

Both methods type-check clean. `notification_payload` in the same file is the control: the same `user.full_name`, reached from no callback, and it still reports `(::User | nil)`. The only baseline line that moves is that error's line number — the entry narrows what it should and nothing more.

## Checks

- `bundle exec rspec` — 1582 examples, 0 failures
- `spec/integration/steep_dummy_spec.rb` — clean against the refreshed baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGYyGCxXCG4jcG5pkxEaSf