### PR TITLE
Track the synced steep (2.1.0) in both lockfiles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../steep
   specs:
-    steep (2.1.0.dev)
+    steep (2.1.0)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
       fileutils (>= 1.1.0)
@@ -13,7 +13,7 @@ PATH
       parser (>= 3.2)
       prism (>= 0.25.0)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (~> 4.0)
+      rbs (~> 4.2)
       securerandom (>= 0.1)
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 5)

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -17,7 +17,7 @@ PATH
 PATH
   remote: /home/felipefelix/workspaces/steep
   specs:
-    steep (2.1.0.dev)
+    steep (2.1.0)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
       fileutils (>= 1.1.0)
@@ -29,7 +29,7 @@ PATH
       parser (>= 3.2)
       prism (>= 0.25.0)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (~> 4.0)
+      rbs (~> 4.2)
       securerandom (>= 0.1)
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 5)


### PR DESCRIPTION
Companion to felixefelip/steep#159, which merges `upstream/master` into the steep fork — 112 commits, forked at `d9e1884e` (2026-05-28).

Both lockfiles resolve steep through a path (`../steep` here, an absolute path in `spec/dummy/`), so both record what that merge lands:

- `steep (2.1.0.dev)` → `steep (2.1.0)`
- its `rbs (~> 4.0)` → `rbs (~> 4.2)` constraint

Nothing else changes. Notably, the headline of that sync — Ruby 3.4's `it` block parameter, which needed `Prism::Translation::Parser33` → `Parser34` across the checker — moves no expectation in this repo: the full suite is **1582 examples, 0 failures** against that branch, snapshot and expanded-source specs included.

Merge felixefelip/steep#159 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGYyGCxXCG4jcG5pkxEaSf