### PR TITLE
Enqueue a job from the dummy, pinning the perform_later gap

### DIFF
--- a/spec/dummy/app/controllers/posts_controller.rb
+++ b/spec/dummy/app/controllers/posts_controller.rb
@@ -46,6 +46,7 @@ class PostsController < ApplicationController
     build_filtering_for_current_user
     publisher = PostPublisher.new(@post)
     if publisher.call
+      AuthorDigestJob.perform_later(@post, recipient: @post.user.email)
       redirect_to @post, notice: "Post published."
     else
       redirect_to @post, alert: "Post could not be published."

--- a/spec/dummy/app/controllers/users/avatars_controller.rb
+++ b/spec/dummy/app/controllers/users/avatars_controller.rb
@@ -7,6 +7,7 @@ class Users::AvatarsController < ApplicationController
 
   def update
     if @user.update(avatar_params)
+      AvatarThumbnailJob.perform_later(@user, sizes: [64, 128])
       redirect_to @user, notice: "Avatar updated."
     else
       render :edit, status: :unprocessable_entity

--- a/spec/dummy/app/jobs/author_digest_job.rb
+++ b/spec/dummy/app/jobs/author_digest_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# The `perform_later` fixture: a job whose arguments exist ONLY at its enqueue
+# site (`PostsController#publish`), which is the shape the ActiveJob runtime
+# sidecar exists for. A human reads `AuthorDigestJob.perform_later(@post,
+# recipient: @post.user.email)` and knows `post` is a `Post & Post::Validated`
+# and `recipient` a `String`.
+#
+# It does not infer them yet — the sidecar's forward lives on `ActiveJob::Base`,
+# shared by every job, so the evidence lands on that class's `*args` instead of
+# here. The expectation pins the gap; the PR that closes it is the one that
+# changes this file's RBS.
+class AuthorDigestJob < ApplicationJob
+  def perform(post, recipient:)
+    {
+      to: recipient,
+      subject: post.notification_title,
+      excerpt: post.notification_excerpt
+    }
+  end
+end

--- a/spec/dummy/app/jobs/avatar_thumbnail_job.rb
+++ b/spec/dummy/app/jobs/avatar_thumbnail_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# The second `perform_later` fixture, and the reason there are two: its arguments
+# share nothing with `AuthorDigestJob`'s. One job is enqueued with a `Post` and a
+# `String`, this one with a `User` and an `Array[Integer]`, from a different
+# controller — so what lands on `ActiveJob::Base.perform_later`'s `*args` is the
+# union of two unrelated jobs' signatures, which no single `perform` could ever
+# accept.
+#
+# That union IS the limitation, stated in RBS: the forward lives on the shared
+# base class, so it cannot tell which job a call site meant.
+class AvatarThumbnailJob < ApplicationJob
+  def perform(user, sizes:)
+    sizes.map do |size|
+      { owner: user.name, width: size }
+    end
+  end
+end

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -1775,7 +1775,6 @@ method_entry_facts:
   method: perform_later
   consts:
     Current.author_name: "::String"
-    Current.user: "((::User & ::User::Validated) | ::User)"
     Current.viewer_name: "::String"
 - class: ApplicationController
   method: log_user_author_name

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -1771,6 +1771,12 @@ method_entry_facts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
     Current.viewer_name: "::String"
+- class: ActiveJob::Base
+  method: perform_later
+  consts:
+    Current.author_name: "::String"
+    Current.user: "((::User & ::User::Validated) | ::User)"
+    Current.viewer_name: "::String"
 - class: ApplicationController
   method: log_user_author_name
   self_methods:

--- a/spec/dummy/sig/rbs_infer/app/jobs/author_digest_job.rbs
+++ b/spec/dummy/sig/rbs_infer/app/jobs/author_digest_job.rbs
@@ -1,0 +1,3 @@
+class AuthorDigestJob < ApplicationJob
+  def perform: (untyped post, recipient: untyped) -> { to: untyped, subject: untyped, excerpt: untyped }
+end

--- a/spec/dummy/sig/rbs_infer/app/jobs/avatar_thumbnail_job.rbs
+++ b/spec/dummy/sig/rbs_infer/app/jobs/avatar_thumbnail_job.rbs
@@ -1,0 +1,3 @@
+class AvatarThumbnailJob < ApplicationJob
+  def perform: (untyped user, sizes: untyped) -> Array[Hash[Symbol, untyped]]
+end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_activejob_runtime/active_job_base.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_activejob_runtime/active_job_base.rbs
@@ -1,5 +1,5 @@
 module ActiveJob
   class Base
-    def self.perform_later: (*(Post | { recipient: String? }) args, **untyped) -> ActiveJob::Base
+    def self.perform_later: (*(Post | { recipient: String? } | User & User::Validated | { sizes: Array[untyped] }) args, **untyped) -> ActiveJob::Base
   end
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_activejob_runtime/active_job_base.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_activejob_runtime/active_job_base.rbs
@@ -1,5 +1,5 @@
 module ActiveJob
   class Base
-    def self.perform_later: (*untyped args, **untyped) -> ActiveJob::Base
+    def self.perform_later: (*(Post | { recipient: String? }) args, **untyped) -> ActiveJob::Base
   end
 end

--- a/spec/expectations/jobs/author_digest_job.rbs
+++ b/spec/expectations/jobs/author_digest_job.rbs
@@ -1,0 +1,3 @@
+class AuthorDigestJob < ApplicationJob
+  def perform: (untyped post, recipient: untyped) -> { to: untyped, subject: untyped, excerpt: untyped }
+end

--- a/spec/expectations/jobs/avatar_thumbnail_job.rbs
+++ b/spec/expectations/jobs/avatar_thumbnail_job.rbs
@@ -1,0 +1,3 @@
+class AvatarThumbnailJob < ApplicationJob
+  def perform: (untyped user, sizes: untyped) -> Array[Hash[Symbol, untyped]]
+end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -1,4 +1,4 @@
-app/controllers/posts_controller.rb:76:4: [error] The method cannot return a value of type `nil` because declared as type `::PostFiltering`
+app/controllers/posts_controller.rb:77:4: [error] The method cannot return a value of type `nil` because declared as type `::PostFiltering`
 app/models/concerns/test/filtrable.rb:16:13: [error] Type `(::Post & ::Test::Filtrable)` does not have method `adddd`
 app/models/concerns/test/filtrable.rb:16:4: [error] Type `(::Post & ::Test::Filtrable)` does not have method `asdasd`
 app/models/eval_reopen.rb:61:6: [warning] Method `::Object#by_instance_eval` is not declared in RBS

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -1383,6 +1383,14 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     assert_snapshot("jobs/author_digest_job", target_class: "AuthorDigestJob", target_file: "app/jobs/author_digest_job.rb")
   end
 
+  # The second enqueue site, from another controller, with arguments sharing
+  # nothing with the first job's. Both land on `ActiveJob::Base.perform_later`'s
+  # `*args`, so that parameter is now the union of two unrelated signatures —
+  # which is the limitation itself, written in RBS.
+  it "AvatarThumbnailJob does not yet infer them either, and widens the shared forward" do
+    assert_snapshot("jobs/avatar_thumbnail_job", target_class: "AvatarThumbnailJob", target_file: "app/jobs/avatar_thumbnail_job.rb")
+  end
+
   it "EmailNotifier service matches expected RBS" do
     assert_snapshot("services/email_notifier", target_class: "EmailNotifier", target_file: "app/services/email_notifier.rb")
   end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -1373,6 +1373,16 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     assert_snapshot("jobs/profile_formatter_job", target_class: "ProfileFormatterJob", target_file: "app/jobs/profile_formatter_job.rb")
   end
 
+  # The `perform_later` gap, pinned. `PostsController#publish` enqueues this job
+  # with a `Post` and a `String`, and the ActiveJob sidecar's forward carries
+  # both — but only as far as `ActiveJob::Base.perform_later`'s `*args`, which
+  # every job in the app shares. So `perform` stays `untyped` here. Whichever
+  # change routes the enqueue site's receiver into the forward is the one that
+  # updates this expectation.
+  it "AuthorDigestJob does not yet infer the arguments its perform_later site states" do
+    assert_snapshot("jobs/author_digest_job", target_class: "AuthorDigestJob", target_file: "app/jobs/author_digest_job.rb")
+  end
+
   it "EmailNotifier service matches expected RBS" do
     assert_snapshot("services/email_notifier", target_class: "EmailNotifier", target_file: "app/services/email_notifier.rb")
   end


### PR DESCRIPTION
Follow-up to #328, which shipped the ActiveJob runtime sidecar without a single `perform_later` call site in the dummy — so nothing exercised it and nothing recorded what it does and does not do.

Two jobs, enqueued from two controllers, in functionality each one already implied:

```ruby
# PostsController#publish, after the post is published
AuthorDigestJob.perform_later(@post, recipient: @post.user.email)

# Users::AvatarsController#update, after the avatar is replaced
AvatarThumbnailJob.perform_later(@user, sizes: [64, 128])
```

`AuthorDigestJob#perform(post, recipient:)` builds its digest by reading back through `Post::Notifiable` (`notification_title`, `notification_excerpt`), so it reuses what the dummy already models. A human reads either enqueue site and knows every argument's type.

## What it pins

The evidence provably reaches the forward, and provably stops there. Two jobs sharing nothing put four unrelated branches on one parameter:

```rbs
def self.perform_later: (*(Post | { recipient: String? } | User & User::Validated | { sizes: Array[untyped] }) args, **untyped) -> ActiveJob::Base
```

No `perform` in the app could accept that — which is the limitation stated in RBS. The forward lives on the class every job shares, so it cannot tell which job a call site meant. Both jobs still infer nothing:

```rbs
class AuthorDigestJob < ApplicationJob
  def perform: (untyped post, recipient: untyped) -> { to: untyped, subject: untyped, excerpt: untyped }
end

class AvatarThumbnailJob < ApplicationJob
  def perform: (untyped user, sizes: untyped) -> Array[Hash[Symbol, untyped]]
end
```

All three are snapshotted, and the examples are named for the gap. Whichever change routes the enqueue site's receiver into the forward is the one that updates them — that is the point of the fixture.

One job alone was not enough: with a single signature the union reads like ordinary widening rather than the defect it is. It takes a second, unrelated job to make the parameter impossible.

## Notes

- `Array[untyped]` rather than `Array[Integer]`: element types of an array literal are a separate open gap (`docs/tasks/type_inference_gaps.md`), unrelated to this one.
- `.steep_postconditions.yml` loses the forward's `Current.user` entry fact — with a second call site that does not set it, it no longer holds at every call, which is the correct reading.

## Verification

- Dummy converged in two passes; a third pass was identical.
- Steep baseline moves one line in `posts_controller.rb` (76 → 77, the enqueue line), no new diagnostic.
- Full suite: 1591 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGYyGCxXCG4jcG5pkxEaSf
