### PR TITLE
Pin the dispatcher-on-a-base-class gap as a plain example

### DIFF
--- a/spec/dummy/app/models/example65.rb
+++ b/spec/dummy/app/models/example65.rb
@@ -1,0 +1,43 @@
+# The template method — a handler each subclass implements, reached only through
+# a dispatcher the BASE class defines. ActiveJob is the case that surfaced it
+# (`perform` is never called by the app, `MyJob.perform_later(user)` is), and
+# this is the same shape with no framework in it (felixefelip/rbs_infer#331).
+#
+# Every argument is unambiguous at the call site: a reader of `Example65Caller`
+# knows `Example65Greeter#handle` takes a `String` and `Example65Adder#handle` an `Integer`. The
+# pipeline does not, and the snapshot records that.
+#
+# Why it does not: `Example65Greeter.dispatch(...)` IS accepted as a call site, by
+# ancestry — the RBS says `dispatch`'s owner is `Example65::Dispatcher` — and
+# `NewCallCollector#ancestry_match_key` then keys the evidence on the bare
+# method name, dropping the concrete receiver it holds. Every subclass's
+# arguments merge into that one parameter, and `handle` gets nothing.
+#
+# What the fix has to preserve is the receiver, and the two subclasses here are
+# what prove it did: they take unrelated types, so a filter too loose to
+# separate them shows up as one taking the other's.
+#
+# The two handlers live in their own files for a measured reason: with all three
+# `handle` methods in ONE file, every one of them reported the first's return
+# type (`Example65Adder#handle`, which adds two Integers, came out `String`). That
+# is a
+# separate defect, and keeping it out of this file keeps this example about the
+# parameters. (They are top-level constants because Zeitwerk names a file's
+# constant after the file: `example65_greeter.rb` must define `Example65Greeter`.)
+class Example65
+  class Dispatcher
+    # As ActiveJob writes it: the queue collapsed, the handler built and handed
+    # the caller's arguments, and returned.
+    def self.dispatch(*args, **kwargs)
+      handler = new
+      handler.handle(*args, **kwargs)
+      handler
+    end
+
+    # Abstract, exactly as `ActiveJob::Execution#perform` is — the arity is
+    # `(*)` and the body raises, so the base states nothing about the arguments.
+    def handle(*)
+      raise NotImplementedError
+    end
+  end
+end

--- a/spec/dummy/app/models/example65_adder.rb
+++ b/spec/dummy/app/models/example65_adder.rb
@@ -1,0 +1,8 @@
+# The other handler, taking types that share nothing with `Greeter`'s. That is
+# the point of having two: the receiver is the only thing separating their call
+# sites, so if the fix loses it, one of these takes the other's arguments.
+class Example65Adder < Example65::Dispatcher
+  def handle(count, step:)
+    count + step
+  end
+end

--- a/spec/dummy/app/models/example65_caller.rb
+++ b/spec/dummy/app/models/example65_caller.rb
@@ -1,0 +1,12 @@
+# The two call sites, in another file, as a real dispatch site is. Each one
+# names its own subclass, which is the whole of what the inference needs and
+# the whole of what it currently discards.
+class Example65Caller
+  def greet
+    Example65Greeter.dispatch("ada", greeting: "hello")
+  end
+
+  def add
+    Example65Adder.dispatch(1, step: 2)
+  end
+end

--- a/spec/dummy/app/models/example65_greeter.rb
+++ b/spec/dummy/app/models/example65_greeter.rb
@@ -1,0 +1,8 @@
+# One of the two concrete handlers. In its own file, like `Example60`'s pair:
+# three same-named `handle` methods in ONE file made every one of them report
+# the first's return type, which would have muddied what this example is for.
+class Example65Greeter < Example65::Dispatcher
+  def handle(name, greeting:)
+    "#{greeting}, #{name}"
+  end
+end

--- a/spec/dummy/sig/rbs_infer/app/models/example65.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example65.rbs
@@ -1,0 +1,7 @@
+class Example65
+  class Dispatcher
+    def self.dispatch: (*(String | { greeting: String } | Integer | { step: Integer }) args, **untyped) -> Object
+
+    def handle: (*untyped) -> untyped
+  end
+end

--- a/spec/dummy/sig/rbs_infer/app/models/example65_adder.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example65_adder.rbs
@@ -1,0 +1,3 @@
+class Example65Adder < Example65::Dispatcher
+  def handle: (untyped count, step: untyped) -> untyped
+end

--- a/spec/dummy/sig/rbs_infer/app/models/example65_caller.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example65_caller.rbs
@@ -1,0 +1,4 @@
+class Example65Caller
+  def greet: () -> Object
+  def add: () -> Object
+end

--- a/spec/dummy/sig/rbs_infer/app/models/example65_greeter.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example65_greeter.rbs
@@ -1,0 +1,3 @@
+class Example65Greeter < Example65::Dispatcher
+  def handle: (untyped name, greeting: untyped) -> String
+end

--- a/spec/expectations/models/example65.rbs
+++ b/spec/expectations/models/example65.rbs
@@ -1,0 +1,7 @@
+class Example65
+  class Dispatcher
+    def self.dispatch: (*(String | { greeting: String } | Integer | { step: Integer }) args, **untyped) -> Object
+
+    def handle: (*untyped) -> untyped
+  end
+end

--- a/spec/expectations/models/example65_adder.rbs
+++ b/spec/expectations/models/example65_adder.rbs
@@ -1,0 +1,3 @@
+class Example65Adder < Example65::Dispatcher
+  def handle: (untyped count, step: untyped) -> untyped
+end

--- a/spec/expectations/models/example65_caller.rbs
+++ b/spec/expectations/models/example65_caller.rbs
@@ -1,0 +1,4 @@
+class Example65Caller
+  def greet: () -> Object
+  def add: () -> Object
+end

--- a/spec/expectations/models/example65_greeter.rbs
+++ b/spec/expectations/models/example65_greeter.rbs
@@ -1,0 +1,3 @@
+class Example65Greeter < Example65::Dispatcher
+  def handle: (untyped name, greeting: untyped) -> String
+end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -302,6 +302,32 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     assert_snapshot("models/example61_caller", target_file: "app/models/example61_caller.rb")
   end
 
+  # felixefelip/rbs_infer#331. The template method: a handler each subclass
+  # implements, reached only through a dispatcher the BASE defines. The call
+  # sites in `Example65Caller` state every argument, and `Greeter.dispatch(...)`
+  # IS read as a call site — by ancestry, which keys the evidence on the bare
+  # method name and drops the concrete receiver. So both subclasses' arguments
+  # merge into the base's `*args` and neither `handle` gets any.
+  #
+  # These four snapshots exist to be updated by the fix: `Greeter#handle` should
+  # read `(String name, greeting: String)`, `Adder#handle` `(Integer count,
+  # step: Integer)`, and neither may take the other's.
+  it "example65 (a dispatcher on the base class) does not yet reach the handlers" do
+    assert_snapshot("models/example65", target_file: "app/models/example65.rb")
+  end
+
+  it "example65_greeter (one handler) matches expected RBS" do
+    assert_snapshot("models/example65_greeter", target_file: "app/models/example65_greeter.rb")
+  end
+
+  it "example65_adder (the other handler, unrelated types) matches expected RBS" do
+    assert_snapshot("models/example65_adder", target_file: "app/models/example65_adder.rb")
+  end
+
+  it "example65_caller (the two dispatch sites) matches expected RBS" do
+    assert_snapshot("models/example65_caller", target_file: "app/models/example65_caller.rb")
+  end
+
   # felixefelip/rbs_infer#300. A DSL that DEFERS: `append_features` registers the
   # module on the target when the target is one of its own, so `Middle` is a
   # waypoint and `hallmark` lands on `Example62`. `super` is the criterion — it


### PR DESCRIPTION
#329 pinned this through ActiveJob, where the framework does the dispatching. `example65` is the same shape with nothing framework about it — the plain template method: a handler each subclass implements, reached only through a dispatcher the base class defines.

```ruby
class Example65
  class Dispatcher
    def self.dispatch(*args, **kwargs)
      handler = new
      handler.handle(*args, **kwargs)
      handler
    end

    def handle(*) = raise NotImplementedError   # as ActiveJob::Execution#perform is
  end
end

class Example65Greeter < Example65::Dispatcher
  def handle(name, greeting:) = "#{greeting}, #{name}"
end

class Example65Adder < Example65::Dispatcher
  def handle(count, step:) = count + step
end
```

`Example65Caller` states every argument at the two dispatch sites, in another file, as a real one does. The snapshots record that none of it arrives:

```rbs
Dispatcher.dispatch: (*(String | { greeting: String } | Integer | { step: Integer }) args, **untyped) -> Object
Example65Greeter#handle: (untyped name, greeting: untyped) -> String
Example65Adder#handle: (untyped count, step: untyped) -> untyped
```

The call sites **are** read — by ancestry, which keys the evidence on the bare method name and drops the concrete receiver (`NewCallCollector#ancestry_match_key`). So both subclasses' arguments merge into the base's `*args` and neither handler gets any.

## Why two handlers, taking unrelated types

The receiver is the only thing separating their call sites. A fix whose receiver filter is too loose shows up here as one handler taking the other's arguments — a visibly wrong snapshot rather than silence. That is the whole reason not to write one handler.

The base declares `handle(*)` raising `NotImplementedError`, exactly as `ActiveJob::Execution#perform` does, so it states nothing about the arguments and no new steep diagnostic appears.

## Measured along the way, recorded in the source

- The handlers are in **separate files** because with all three `handle` methods in one file, every one of them reported the first's return type — `Example65Adder#handle`, which adds two Integers, came out `String`. That is a separate defect; keeping it out of this file keeps the example about the parameters.
- They are **top-level constants** (`Example65Greeter`, not `Example65::Greeter`) because Zeitwerk names a file's constant after the file. The nested spelling broke `rake rbs_rails:all`.

## Status

Tracked by #331. These four snapshots exist to be updated by the fix: `Example65Greeter#handle` should read `(String name, greeting: String)`, `Example65Adder#handle` `(Integer count, step: Integer)`, and neither may take the other's.

Full suite: 1601 examples, 0 failures. Steep baseline unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGYyGCxXCG4jcG5pkxEaSf
