### PR TITLE
test: Example67 — a predicate proving a sibling method non-nil narrows nothing

### DIFF
--- a/spec/dummy/app/models/example67.rb
+++ b/spec/dummy/app/models/example67.rb
@@ -1,0 +1,54 @@
+# A predicate that proves a SIBLING METHOD non-nil establishes nothing, so a
+# guard in one method cannot pay for a dereference in another.
+#
+#   def spiking?      = source.windowed? && wide_enough?
+#   def wide_enough?  = source.window.size > 10
+#
+# `source.windowed?` is the whole reason `wide_enough?` is allowed to write
+# `source.window.size`, and Steep answers `Type (::Example67Window | nil) does
+# not have method size`.
+#
+# The precondition machinery already does its half: `.steep_contracts.yml` gets
+# `requires not_nil self.source.window` on `wide_enough?` and propagates it to
+# `spiking?` and `detect`, all `enforced: false`. It stops exactly where the
+# guard sits — `Contracts::Enforcement` enforces a contract only when every
+# visible call site satisfies it, and the call site of `wide_enough?` is behind
+# a `source.windowed?` that narrows nothing.
+#
+# The predicate-marker pipeline covers the same shape over an IVAR
+# (`def confirmed?; !@name.nil?; end` → `AfterConfirmed` with
+# `attr_reader name: ::String`, emitted by `PredicateMarkerSynthesizer` from
+# `when_true.ivars`). Over a method it produces nothing, for two reasons stated
+# in `example67_source.rb`. The consumer side is already there:
+# `LogicTypeInterpreter#apply_postconditions` refines a pure-send receiver
+# through `refine_node_type`, so a `when_true.self:
+# "::Example67Source & ::Example67Source::AfterWindowed"` carrying
+# `def window: () -> Example67Window` would narrow `source` across the `&&` with
+# no new consumer.
+#
+# Read off fizzy: `Card::ActivitySpike::Detector#has_activity_spike?` guards with
+# `card.entropic?` and `#recent_period` writes `card.entropy.auto_clean_period`.
+class Example67
+  attr_reader :source
+
+  def initialize(source)
+    @source = source
+  end
+
+  def detect
+    if spiking?
+      true
+    else
+      false
+    end
+  end
+
+  private
+    def spiking?
+      source.windowed? && wide_enough?
+    end
+
+    def wide_enough?
+      source.window.size > 10
+    end
+end

--- a/spec/dummy/app/models/example67_source.rb
+++ b/spec/dummy/app/models/example67_source.rb
@@ -1,0 +1,35 @@
+# The guarded half. `window` is nilable and `windowed?` is the predicate that
+# decides it — the pair a human reads as "past `windowed?`, `window` is there".
+#
+# Neither is an ivar, and this class declares no ivar at all. Both facts matter
+# to `Steep::Postconditions::Inferrer`: `build_env_for_class` returns nil when a
+# class has no declared ivar, so the predicate path never starts; and
+# `collect_when_true_nonnil_refinements` reads only
+# `truthy_result.env.instance_variable_types`, so a method slot would be dropped
+# even if it did.
+#
+# Read off fizzy: `Card::Entropic#entropy` / `#entropic?`.
+class Example67Source
+  def enabled?
+    window_size.positive?
+  end
+
+  def window_size
+    30
+  end
+
+  def window
+    Example67Window.for(self)
+  end
+
+  def windowed?
+    window.present?
+  end
+
+  # The static call site the contract enforcement needs: a method with no
+  # visible caller is never enforced, so without this the chain below could not
+  # be quitted even once the predicate does prove something.
+  def detect_spikes
+    Example67.new(self).detect
+  end
+end

--- a/spec/dummy/app/models/example67_window.rb
+++ b/spec/dummy/app/models/example67_window.rb
@@ -1,0 +1,21 @@
+# The value half of the predicate-slot gap (see `example67.rb`).
+#
+# `.for` is a nilable factory: the bare `return` makes the answer
+# `Example67Window?` no matter what is passed in, which is why the marker on the
+# ARGUMENT is beside the point here — the nilability is the factory's own.
+#
+# Read off fizzy: `Card::Entropy.for`, whose `return unless card.last_active_at`
+# does exactly this.
+class Example67Window
+  attr_reader :size
+
+  def self.for(source)
+    return unless source.enabled?
+
+    Example67Window.new(source.window_size)
+  end
+
+  def initialize(size)
+    @size = size
+  end
+end

--- a/spec/dummy/sig/generated/.steep_contracts.yml
+++ b/spec/dummy/sig/generated/.steep_contracts.yml
@@ -133,6 +133,66 @@ methods:
           kind: self
         method: ticket
     enforced: false
+  Example67#detect:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: source
+        chain:
+        - window
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: source
+        chain:
+        - window
+        - size
+    enforced: false
+  Example67#spiking?:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: source
+        chain:
+        - window
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: source
+        chain:
+        - window
+        - size
+    enforced: false
+  Example67#wide_enough?:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: source
+        chain:
+        - window
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: source
+        chain:
+        - window
+        - size
+    enforced: false
   Post#author_name:
     requires:
     - kind: not_nil

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -1140,6 +1140,16 @@ postconditions:
   effects:
     may_write:
     - "@hallmark"
+- class: Example67
+  method: initialize
+  effects:
+    may_write:
+    - "@source"
+- class: Example67Window
+  method: initialize
+  effects:
+    may_write:
+    - "@size"
 - class: Example6::Foo
   method: name
   effects:

--- a/spec/dummy/sig/rbs_infer/app/models/example67.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example67.rbs
@@ -1,0 +1,11 @@
+class Example67
+  attr_reader source: Example67Source
+
+  def initialize: (Example67Source source) -> void
+  def detect: () -> bool
+
+  private
+
+  def spiking?: () -> bool
+  def wide_enough?: () -> bool
+end

--- a/spec/dummy/sig/rbs_infer/app/models/example67_source.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example67_source.rbs
@@ -1,0 +1,7 @@
+class Example67Source
+  def enabled?: () -> bool
+  def window_size: () -> Integer
+  def window: () -> Example67Window?
+  def windowed?: () -> bool
+  def detect_spikes: () -> bool
+end

--- a/spec/dummy/sig/rbs_infer/app/models/example67_window.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example67_window.rbs
@@ -1,0 +1,7 @@
+class Example67Window
+  def self.for: (Example67Source source) -> Example67Window?
+
+  attr_reader size: Integer
+
+  def initialize: (Integer size) -> void
+end

--- a/spec/expectations/models/example67.rbs
+++ b/spec/expectations/models/example67.rbs
@@ -1,0 +1,11 @@
+class Example67
+  attr_reader source: Example67Source
+
+  def initialize: (Example67Source source) -> void
+  def detect: () -> bool
+
+  private
+
+  def spiking?: () -> bool
+  def wide_enough?: () -> bool
+end

--- a/spec/expectations/models/example67_source.rbs
+++ b/spec/expectations/models/example67_source.rbs
@@ -1,0 +1,7 @@
+class Example67Source
+  def enabled?: () -> bool
+  def window_size: () -> Integer
+  def window: () -> Example67Window?
+  def windowed?: () -> bool
+  def detect_spikes: () -> bool
+end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -28,6 +28,13 @@ app/models/example63.rb:17:10: [error] Type `::Example63::Foo` does not have met
 app/models/example63.rb:22:10: [error] Type `::Example63::Foo` does not have method `greet`
 app/models/example63.rb:4:21: [warning] Cannot pass a value of type `::Proc` as a block-pass-argument of type `^(singleton(::Example63::Foo)) [self: singleton(::Example63::Foo)] -> U(_)`
 app/models/example63.rb:9:8: [warning] Method `::Example63::Foo#greet` is not declared in RBS
+app/models/example67.rb:39:7: [error] `spiking?` requires `self.source.window.size` to be non-nil here
+app/models/example67.rb:39:7: [error] `spiking?` requires `self.source.window` to be non-nil here
+app/models/example67.rb:48:26: [error] `wide_enough?` requires `self.source.window.size` to be non-nil here
+app/models/example67.rb:48:26: [error] `wide_enough?` requires `self.source.window` to be non-nil here
+app/models/example67.rb:52:20: [error] Type `(::Example67Window | nil)` does not have method `size`
+app/models/example67_source.rb:33:4: [error] `detect` requires `self.source.window.size` to be non-nil here
+app/models/example67_source.rb:33:4: [error] `detect` requires `self.source.window` to be non-nil here
 app/models/example7.rb:31:28: [error] Type `(::Integer | nil)` does not have method `abs`
 app/models/example7.rb:34:27: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/included_hook.rb:110:12: [warning] Method `::IncludedHook::Arbitrary#from_arbitrary` is not declared in RBS

--- a/spec/expectations/steep_contracts.yml
+++ b/spec/expectations/steep_contracts.yml
@@ -133,6 +133,66 @@ methods:
           kind: self
         method: ticket
     enforced: false
+  Example67#detect:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: source
+        chain:
+        - window
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: source
+        chain:
+        - window
+        - size
+    enforced: false
+  Example67#spiking?:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: source
+        chain:
+        - window
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: source
+        chain:
+        - window
+        - size
+    enforced: false
+  Example67#wide_enough?:
+    requires:
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: source
+        chain:
+        - window
+    - kind: not_nil
+      expr:
+        kind: send
+        receiver:
+          kind: self
+        method: source
+        chain:
+        - window
+        - size
+    enforced: false
   Post#author_name:
     requires:
     - kind: not_nil

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -393,6 +393,39 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     assert_snapshot("models/example66_trackable", target_file: "app/models/example66_trackable.rb")
   end
 
+  # A predicate that proves a SIBLING METHOD non-nil narrows nothing, so a guard
+  # in one method cannot pay for a dereference in another:
+  #
+  #   def spiking?     = source.windowed? && wide_enough?
+  #   def wide_enough? = source.window.size > 10
+  #
+  # The precondition half already works — `steep_contracts.yml` carries
+  # `requires not_nil self.source.window` on `wide_enough?`, propagated up to
+  # `spiking?` and `detect`, and every one `enforced: false` because the call
+  # site behind `source.windowed?` satisfies nothing. `steep_baseline.txt`
+  # records the four `PreconditionUnsatisfied` and the `NoMethod` that follow.
+  #
+  # The missing half is the marker: `PredicateMarkerSynthesizer` emits an
+  # `After<Pred>` class from `when_true.ivars`, and
+  # `Postconditions::Inferrer#collect_when_true_nonnil_refinements` only ever
+  # fills that from `env.instance_variable_types` — a method slot is dropped, and
+  # for a class with no ivar at all `build_env_for_class` bails before looking.
+  # So `Example67Source` gets no `AfterWindowed`, and this snapshot has none.
+  #
+  # Read off fizzy: `Card::ActivitySpike::Detector#has_activity_spike?` guards
+  # with `card.entropic?` and `#recent_period` writes
+  # `card.entropy.auto_clean_period`.
+  it "example67 (a guard proving a sibling method non-nil) matches expected RBS" do
+    assert_snapshot("models/example67", target_file: "app/models/example67.rb")
+  end
+
+  # The guarded half — where the `AfterWindowed` marker would land. `window:
+  # () -> Example67Window?` is the slot and `windowed?: () -> bool` is the
+  # predicate that decides it; nothing in the snapshot ties the two together.
+  it "example67_source (the nilable slot and its predicate) matches expected RBS" do
+    assert_snapshot("models/example67_source", target_file: "app/models/example67_source.rb")
+  end
+
   # `send` with a literal symbol reaching a PRIVATE method — how MRI itself invokes the
   # mixin hooks (`rb_funcall` ignores visibility, and `included`/`append_features` are
   # private on `Module`), which is why the `Module#include` pseudo-code spells them that


### PR DESCRIPTION
## The gap

A predicate that proves a **sibling method** non-nil establishes nothing, so a guard in one method cannot pay for a dereference in another:

```ruby
class Example67
  def spiking?
    source.windowed? && wide_enough?
  end

  def wide_enough?
    source.window.size > 10
  end
end
```

`source.windowed?` is the whole reason `wide_enough?` is allowed to write `source.window.size`, and Steep answers:

```
app/models/example67.rb:52:20: [error] Type `(::Example67Window | nil)` does not have method `size`
```

`Example67Source` is the guarded half — `window: () -> Example67Window?` is the slot, `windowed?: () -> bool` is the predicate that decides it, and nothing ties the two together:

```ruby
class Example67Source
  def window
    Example67Window.for(self)     # nilable factory: `return unless source.enabled?`
  end

  def windowed?
    window.present?
  end
end
```

## What already works

The precondition half does its job in full. `steep check` writes into `.steep_contracts.yml`:

```yaml
Example67#wide_enough?:
  requires:
  - kind: not_nil
    expr: { kind: send, receiver: { kind: self }, method: source, chain: [window] }
  enforced: false
```

and propagates it up the chain — `wide_enough?` → `spiking?` → `detect`, every one `enforced: false`. `Contracts::Enforcement` enforces a contract only when every visible call site satisfies it, and the call site sitting behind `source.windowed?` satisfies nothing. So the propagation stops exactly where the guard is.

The consumer side is there too. `LogicTypeInterpreter#apply_postconditions` refines a pure-send receiver through `refine_node_type`, so a

```yaml
when_true:
  self: "::Example67Source & ::Example67Source::AfterWindowed"
```

with `Example67Source::AfterWindowed` declaring `def window: () -> Example67Window` would narrow `source` across the `&&` with **no new consumer code**.

## What is missing

The predicate-marker pipeline already covers this exact shape over an **ivar**: `def confirmed?; !@name.nil?; end` yields `AfterConfirmed` with `attr_reader name: ::String`, emitted by `RbsInfer::Markers::PredicateMarkerSynthesizer` from `when_true.ivars`. Over a **method** it yields nothing, for two reasons in `Steep::Postconditions::Inferrer`:

1. `build_env_for_class` returns `nil` outright when the class declares no ivar — so the predicate path never starts. `Example67Source`, like fizzy's `Card::Entropic`, has none.
2. `collect_when_true_nonnil_refinements` reads only `truthy_result.env.instance_variable_types`. A method slot would be dropped even if the env existed — and the synthetic env it evaluates in is built with an empty `pure_method_calls`, so the interpreter has no slot to refine in the first place.

Seeding that env with the self-sends the real check already typed makes the interpreter answer, for both spellings:

```
== ZPSource#windowed?          seeds=[["window", "(::ZPWindow | nil)"]]
   truthy pure_calls=[["window", "::ZPWindow"]]
== ZPSource#present_windowed?  seeds=[["window", "(::ZPWindow | nil)"]]
   truthy pure_calls=[["window", "::ZPWindow"]]
```

(`present?` narrows like `!x.nil?` because activesupport's RBS declares `NilClass#present?: () -> false`, so the union partitions.)

## Read off fizzy

```
app/models/card/activity_spike/detector.rb:38:20: [error]
  Type `(::Card::Entropy | nil)` does not have method `auto_clean_period`
```

`Detector#has_activity_spike?` guards with `card.entropic?`; `#recent_period` writes `card.entropy.auto_clean_period`. `Card::Entropy.for` opens with `return unless card.last_active_at`, so its answer is `Card::Entropy?` whatever marker the argument carries — no `Validated` narrowing reaches it, which is why this is a different gap from felixefelip/rbs_rails#20 rather than another instance of it.

## What this PR contains

Only the example. The baseline absorbs the diagnostics it produces:

```
+app/models/example67.rb:39:7:  [error] `spiking?` requires `self.source.window.size` to be non-nil here
+app/models/example67.rb:39:7:  [error] `spiking?` requires `self.source.window` to be non-nil here
+app/models/example67.rb:48:26: [error] `wide_enough?` requires `self.source.window.size` to be non-nil here
+app/models/example67.rb:48:26: [error] `wide_enough?` requires `self.source.window` to be non-nil here
+app/models/example67.rb:52:20: [error] Type `(::Example67Window | nil)` does not have method `size`
+app/models/example67_source.rb:33:4: [error] `detect` requires `self.source.window.size` to be non-nil here
+app/models/example67_source.rb:33:4: [error] `detect` requires `self.source.window` to be non-nil here
```

plus the three `enforced: false` contract entries in `spec/expectations/steep_contracts.yml`. The fix's PRs — one in the steep fork, one here — are what delete them.

Full suite green (1625 examples, 0 failures); RBS regenerated to a fixed point (rbs_infer ⇄ steep until stable).

### Aside, not fixed here

Writing the factory as fizzy does — a receiverless `new(source.window_size)` inside `def self.for` — leaves `attr_reader size: untyped`; spelling it `Example67Window.new(...)` gives `size: Integer`. So `.new` call sites are only collected with an explicit constant receiver. That is why fizzy's `Card::Entropy#auto_clean_period` is `untyped`. Out of scope here; the example uses the explicit receiver so the diagnostic is about nilability alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGYyGCxXCG4jcG5pkxEaSf
