### PR TITLE
feat(markers): emit an After<Pred> marker for a predicate that proves a sibling METHOD

### DIFF
--- a/lib/rbs_infer/analyzer.rb
+++ b/lib/rbs_infer/analyzer.rb
@@ -394,6 +394,7 @@ module RbsInfer
       existing = by_name[marker.marker_name]
       if existing
         existing.overrides.merge!(marker.overrides) { |_key, old, _new| old }
+        existing.method_overrides.merge!(marker.method_overrides) { |_key, old, _new| old }
       else
         by_name[marker.marker_name] = marker
       end

--- a/lib/rbs_infer/markers/predicate_marker_synthesizer.rb
+++ b/lib/rbs_infer/markers/predicate_marker_synthesizer.rb
@@ -9,10 +9,20 @@ module RbsInfer::Markers
   #
   # Symmetric to `SetterMarkerSynthesizer` (which handles
   # `unconditional.ivars` narrowings — setters that assign literals
-  # to ivars). This one handles `when_true.ivars` — predicates whose
-  # truthy branch narrows ivars to a non-nil residual. Both produce
+  # to ivars). This one handles `when_true.ivars` AND
+  # `when_true.methods` — predicates whose truthy branch narrows an
+  # ivar, or a sibling method, to a non-nil residual. Both produce
   # `MarkerClass` structs with the same shape, and the analyzer
   # merges their outputs into a single set of nested classes.
+  #
+  # The method half is what a concern-shaped predicate needs:
+  #
+  #     def entropy;   Card::Entropy.for(self); end   # () -> Card::Entropy?
+  #     def entropic?; entropy.present?;        end
+  #
+  # There is no ivar anywhere, so the ivar reading has nothing to say; what
+  # `card.entropic?` proves is about `card.entropy`, and the marker restates it
+  # as `def entropy: () -> Card::Entropy`.
   class PredicateMarkerSynthesizer
     # Reuses `SetterMarkerSynthesizer::MarkerClass` so the analyzer
     # and `RbsBuilder` consume one shape regardless of origin.
@@ -45,10 +55,9 @@ module RbsInfer::Markers
       @inferred_entries.each do |entry|
         next unless normalize_class_name(entry.class_name) == @target_class
         next if entry.singleton
-        next if entry.when_true_ivars.nil? || entry.when_true_ivars.empty?
-
-        overrides = filter_observable_overrides(entry.when_true_ivars, reader_ivars)
-        next if overrides.empty?
+        overrides = filter_observable_overrides(entry.when_true_ivars || {}, reader_ivars)
+        method_overrides = format_method_overrides(entry.when_true_methods || {})
+        next if overrides.empty? && method_overrides.empty?
 
         marker_name = marker_short_name_for(entry.method_name)
         next unless marker_name
@@ -56,7 +65,8 @@ module RbsInfer::Markers
         markers << MarkerClass.new(
           method_name: entry.method_name.to_s,
           marker_name: marker_name,
-          overrides: overrides
+          overrides: overrides,
+          method_overrides: method_overrides
         )
       end
       markers.sort_by(&:marker_name)
@@ -84,6 +94,21 @@ module RbsInfer::Markers
         overrides[ivar_name] = format_type(refined_type)
       end
       overrides
+    end
+
+    # No observability filter, unlike the ivar path above. That one exists
+    # because a narrowed ivar with no reader cannot be seen from outside; a
+    # method has already answered the same question by existing. And the
+    # inferrer read the type off the built definition, so what it names is a
+    # method of the whole program — `read_at` on a Rails model comes from
+    # rbs_rails, not from the source file this class is generated from, and a
+    # second check against THAT file's members would drop exactly those.
+    def format_method_overrides(when_true_methods)
+      when_true_methods.each_with_object({}) do |(method_sym, refined_type), overrides|
+        name = method_sym.to_s
+        next if name.empty?
+        overrides[name] = format_type(refined_type)
+      end
     end
 
     # The `InferredEntry` carries `Steep::AST::Types::t` instances; we

--- a/lib/rbs_infer/markers/setter_marker_synthesizer.rb
+++ b/lib/rbs_infer/markers/setter_marker_synthesizer.rb
@@ -31,7 +31,18 @@ module RbsInfer::Markers
     #   method_name  : "set_default_name"        (no `self.` prefix; singletons already filtered)
     #   marker_name  : "AfterSetDefaultName"     (short form — used as a nested class inside parent)
     #   overrides    : { "name" => "String" }    (ivar name without leading `@` → narrowed type str)
-    MarkerClass = Struct.new(:method_name, :marker_name, :overrides, keyword_init: true)
+    #   method_overrides : { "window" => "Window" } (method name → narrowed RETURN type str)
+    #
+    # `overrides` restates an ivar's reader, `method_overrides` restates a plain
+    # method — the same refinement over the two things a class can expose. A
+    # marker carries whichever the predicate proved; usually one, sometimes both.
+    MarkerClass = Struct.new(:method_name, :marker_name, :overrides, :method_overrides, keyword_init: true) do
+      # Assigns back rather than returning a fresh hash: `merge_markers` mutates
+      # what it reads, and a throwaway would swallow the union silently.
+      def method_overrides
+        self[:method_overrides] ||= {}
+      end
+    end
 
     # @param members [Array<RbsInfer::Inference::Member>] members of the target class
     # @param ivar_write_types_per_method [Hash{String=>Hash{String=>String}}]

--- a/lib/rbs_infer/signatures/rbs_builder.rb
+++ b/lib/rbs_infer/signatures/rbs_builder.rb
@@ -393,6 +393,12 @@ module RbsInfer::Signatures
       marker.overrides.sort_by { |name, _| name }.each do |ivar_name, type_str|
         out << "#{override_indent}attr_reader #{ivar_name}: #{type_str}"
       end
+      # A method slot is restated as a plain `def`, not as an `attr_reader`:
+      # `attr_reader x: T` in RBS also declares `@x`, and the class has no such
+      # ivar — the predicate proved something about a method's ANSWER.
+      marker.method_overrides.sort_by { |name, _| name }.each do |method_name, type_str|
+        out << "#{override_indent}def #{method_name}: () -> #{type_str}"
+      end
       out << "#{member_indent}end"
       out
     end

--- a/spec/dummy/app/models/example67.rb
+++ b/spec/dummy/app/models/example67.rb
@@ -1,30 +1,23 @@
-# A predicate that proves a SIBLING METHOD non-nil establishes nothing, so a
-# guard in one method cannot pay for a dereference in another.
+# A predicate that proves a SIBLING METHOD non-nil, paying for a dereference in
+# another method.
 #
 #   def spiking?      = source.windowed? && wide_enough?
 #   def wide_enough?  = source.window.size > 10
 #
 # `source.windowed?` is the whole reason `wide_enough?` is allowed to write
-# `source.window.size`, and Steep answers `Type (::Example67Window | nil) does
-# not have method size`.
+# `source.window.size`, and it is now what makes it type-check.
 #
-# The precondition machinery already does its half: `.steep_contracts.yml` gets
-# `requires not_nil self.source.window` on `wide_enough?` and propagates it to
-# `spiking?` and `detect`, all `enforced: false`. It stops exactly where the
-# guard sits — `Contracts::Enforcement` enforces a contract only when every
-# visible call site satisfies it, and the call site of `wide_enough?` is behind
-# a `source.windowed?` that narrows nothing.
+# The precondition machinery always did its half: `.steep_contracts.yml` gets
+# `requires not_nil self.source.window` on `wide_enough?`, and
+# `Contracts::Enforcement` enforces it once every visible call site satisfies
+# it. What no call site could satisfy was the guard — so the requirement kept
+# propagating up to `spiking?` and `detect` as `enforced: false`, and the body
+# was checked with `source.window` still nilable.
 #
-# The predicate-marker pipeline covers the same shape over an IVAR
-# (`def confirmed?; !@name.nil?; end` → `AfterConfirmed` with
-# `attr_reader name: ::String`, emitted by `PredicateMarkerSynthesizer` from
-# `when_true.ivars`). Over a method it produces nothing, for two reasons stated
-# in `example67_source.rb`. The consumer side is already there:
-# `LogicTypeInterpreter#apply_postconditions` refines a pure-send receiver
-# through `refine_node_type`, so a `when_true.self:
-# "::Example67Source & ::Example67Source::AfterWindowed"` carrying
-# `def window: () -> Example67Window` would narrow `source` across the `&&` with
-# no new consumer.
+# The guard now establishes: `Example67Source::AfterWindowed` restates
+# `window` non-nil, `windowed?`'s `when_true.self` intersects it into `source`
+# across the `&&`, and `wide_enough?`'s contract is discharged at its one call
+# site. `spiking?` and `detect` carry no requirement at all any more.
 #
 # Read off fizzy: `Card::ActivitySpike::Detector#has_activity_spike?` guards with
 # `card.entropic?` and `#recent_period` writes `card.entropy.auto_clean_period`.

--- a/spec/dummy/app/models/example67_source.rb
+++ b/spec/dummy/app/models/example67_source.rb
@@ -1,12 +1,13 @@
 # The guarded half. `window` is nilable and `windowed?` is the predicate that
-# decides it — the pair a human reads as "past `windowed?`, `window` is there".
+# decides it — the pair a human reads as "past `windowed?`, `window` is there",
+# and the pair the `AfterWindowed` marker in this file's RBS now states.
 #
-# Neither is an ivar, and this class declares no ivar at all. Both facts matter
-# to `Steep::Postconditions::Inferrer`: `build_env_for_class` returns nil when a
-# class has no declared ivar, so the predicate path never starts; and
-# `collect_when_true_nonnil_refinements` reads only
-# `truthy_result.env.instance_variable_types`, so a method slot would be dropped
-# even if it did.
+# Neither is an ivar, and this class declares no ivar at all. Both facts used to
+# stop `Steep::Postconditions::Inferrer` cold: `build_env_for_class` turned away
+# a class with no declared ivar before the interpreter was asked, and
+# `collect_when_true_nonnil_refinements` read only
+# `truthy_result.env.instance_variable_types`, so a method slot was dropped even
+# when the env existed.
 #
 # Read off fizzy: `Card::Entropic#entropy` / `#entropic?`.
 class Example67Source
@@ -27,8 +28,8 @@ class Example67Source
   end
 
   # The static call site the contract enforcement needs: a method with no
-  # visible caller is never enforced, so without this the chain below could not
-  # be quitted even once the predicate does prove something.
+  # visible caller is never enforced, so without this the chain in `example67.rb`
+  # could not be quitted however well the predicate proves its half.
   def detect_spikes
     Example67.new(self).detect
   end

--- a/spec/dummy/sig/generated/.steep_contracts.yml
+++ b/spec/dummy/sig/generated/.steep_contracts.yml
@@ -133,46 +133,6 @@ methods:
           kind: self
         method: ticket
     enforced: false
-  Example67#detect:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: source
-        chain:
-        - window
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: source
-        chain:
-        - window
-        - size
-    enforced: false
-  Example67#spiking?:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: source
-        chain:
-        - window
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: source
-        chain:
-        - window
-        - size
-    enforced: false
   Example67#wide_enough?:
     requires:
     - kind: not_nil
@@ -192,7 +152,6 @@ methods:
         chain:
         - window
         - size
-    enforced: false
   Post#author_name:
     requires:
     - kind: not_nil

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -68,6 +68,12 @@ postconditions:
     Current.viewer_name:
       gate_ivar: "@__rbs_infer__performed"
       type: "::String"
+- class: Assignment
+  method: assigned?
+  when_true:
+    methods:
+      post: "::Post"
+    self: "::Assignment & ::Assignment::AfterAssigned"
 - class: Board
   method: initialize
   effects:
@@ -1145,6 +1151,12 @@ postconditions:
   effects:
     may_write:
     - "@source"
+- class: Example67Source
+  method: windowed?
+  when_true:
+    methods:
+      window: "::Example67Window"
+    self: "::Example67Source & ::Example67Source::AfterWindowed"
 - class: Example67Window
   method: initialize
   effects:
@@ -1295,6 +1307,12 @@ postconditions:
   effects:
     may_write:
     - "@__store_settings_channel"
+- class: Notification
+  method: read?
+  when_true:
+    methods:
+      read_at: "::ActiveSupport::TimeWithZone"
+    self: "::Notification & ::Notification::AfterRead"
 - class: Notification::GeneratedStoreAccessors
   method: channel
   effects:

--- a/spec/dummy/sig/rbs_infer/app/models/assignment.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/assignment.rbs
@@ -4,4 +4,8 @@ class Assignment < ApplicationRecord
   private
 
   def log_post_user_name: () -> untyped
+
+  class AfterAssigned
+    def post: () -> ::Post
+  end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example67_source.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example67_source.rbs
@@ -4,4 +4,8 @@ class Example67Source
   def window: () -> Example67Window?
   def windowed?: () -> bool
   def detect_spikes: () -> bool
+
+  class AfterWindowed
+    def window: () -> ::Example67Window
+  end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/notification.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/notification.rbs
@@ -3,4 +3,8 @@ class Notification < ApplicationRecord
   def mute!: () -> String
   def read?: () -> bool
   def headline: () -> String
+
+  class AfterRead
+    def read_at: () -> ::ActiveSupport::TimeWithZone
+  end
 end

--- a/spec/expectations/models/assignment.rbs
+++ b/spec/expectations/models/assignment.rbs
@@ -4,4 +4,8 @@ class Assignment < ApplicationRecord
   private
 
   def log_post_user_name: () -> untyped
+
+  class AfterAssigned
+    def post: () -> ::Post
+  end
 end

--- a/spec/expectations/models/example67_source.rbs
+++ b/spec/expectations/models/example67_source.rbs
@@ -4,4 +4,8 @@ class Example67Source
   def window: () -> Example67Window?
   def windowed?: () -> bool
   def detect_spikes: () -> bool
+
+  class AfterWindowed
+    def window: () -> ::Example67Window
+  end
 end

--- a/spec/expectations/models/notification.rbs
+++ b/spec/expectations/models/notification.rbs
@@ -3,4 +3,8 @@ class Notification < ApplicationRecord
   def mute!: () -> String
   def read?: () -> bool
   def headline: () -> String
+
+  class AfterRead
+    def read_at: () -> ::ActiveSupport::TimeWithZone
+  end
 end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -28,13 +28,6 @@ app/models/example63.rb:17:10: [error] Type `::Example63::Foo` does not have met
 app/models/example63.rb:22:10: [error] Type `::Example63::Foo` does not have method `greet`
 app/models/example63.rb:4:21: [warning] Cannot pass a value of type `::Proc` as a block-pass-argument of type `^(singleton(::Example63::Foo)) [self: singleton(::Example63::Foo)] -> U(_)`
 app/models/example63.rb:9:8: [warning] Method `::Example63::Foo#greet` is not declared in RBS
-app/models/example67.rb:39:7: [error] `spiking?` requires `self.source.window.size` to be non-nil here
-app/models/example67.rb:39:7: [error] `spiking?` requires `self.source.window` to be non-nil here
-app/models/example67.rb:48:26: [error] `wide_enough?` requires `self.source.window.size` to be non-nil here
-app/models/example67.rb:48:26: [error] `wide_enough?` requires `self.source.window` to be non-nil here
-app/models/example67.rb:52:20: [error] Type `(::Example67Window | nil)` does not have method `size`
-app/models/example67_source.rb:33:4: [error] `detect` requires `self.source.window.size` to be non-nil here
-app/models/example67_source.rb:33:4: [error] `detect` requires `self.source.window` to be non-nil here
 app/models/example7.rb:31:28: [error] Type `(::Integer | nil)` does not have method `abs`
 app/models/example7.rb:34:27: [error] Type `(::String | nil)` does not have method `upcase`
 app/models/included_hook.rb:110:12: [warning] Method `::IncludedHook::Arbitrary#from_arbitrary` is not declared in RBS

--- a/spec/expectations/steep_contracts.yml
+++ b/spec/expectations/steep_contracts.yml
@@ -133,46 +133,6 @@ methods:
           kind: self
         method: ticket
     enforced: false
-  Example67#detect:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: source
-        chain:
-        - window
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: source
-        chain:
-        - window
-        - size
-    enforced: false
-  Example67#spiking?:
-    requires:
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: source
-        chain:
-        - window
-    - kind: not_nil
-      expr:
-        kind: send
-        receiver:
-          kind: self
-        method: source
-        chain:
-        - window
-        - size
-    enforced: false
   Example67#wide_enough?:
     requires:
     - kind: not_nil
@@ -192,7 +152,6 @@ methods:
         chain:
         - window
         - size
-    enforced: false
   Post#author_name:
     requires:
     - kind: not_nil

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -393,24 +393,18 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     assert_snapshot("models/example66_trackable", target_file: "app/models/example66_trackable.rb")
   end
 
-  # A predicate that proves a SIBLING METHOD non-nil narrows nothing, so a guard
-  # in one method cannot pay for a dereference in another:
+  # A predicate that proves a SIBLING METHOD non-nil, so a guard in one method
+  # pays for a dereference in another:
   #
   #   def spiking?     = source.windowed? && wide_enough?
   #   def wide_enough? = source.window.size > 10
   #
-  # The precondition half already works — `steep_contracts.yml` carries
-  # `requires not_nil self.source.window` on `wide_enough?`, propagated up to
-  # `spiking?` and `detect`, and every one `enforced: false` because the call
-  # site behind `source.windowed?` satisfies nothing. `steep_baseline.txt`
-  # records the four `PreconditionUnsatisfied` and the `NoMethod` that follow.
-  #
-  # The missing half is the marker: `PredicateMarkerSynthesizer` emits an
-  # `After<Pred>` class from `when_true.ivars`, and
-  # `Postconditions::Inferrer#collect_when_true_nonnil_refinements` only ever
-  # fills that from `env.instance_variable_types` — a method slot is dropped, and
-  # for a class with no ivar at all `build_env_for_class` bails before looking.
-  # So `Example67Source` gets no `AfterWindowed`, and this snapshot has none.
+  # This snapshot pins the CONSUMER end: nothing about `Example67` itself
+  # changes, which is the point — the whole fix lands on `Example67Source`, and
+  # what this file gets is `steep_contracts.yml` losing the `spiking?` and
+  # `detect` entries entirely and `wide_enough?` losing its `enforced: false`.
+  # `steep_baseline.txt` lost the four `PreconditionUnsatisfied` and the
+  # `NoMethod` along with them.
   #
   # Read off fizzy: `Card::ActivitySpike::Detector#has_activity_spike?` guards
   # with `card.entropic?` and `#recent_period` writes
@@ -419,9 +413,10 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     assert_snapshot("models/example67", target_file: "app/models/example67.rb")
   end
 
-  # The guarded half — where the `AfterWindowed` marker would land. `window:
-  # () -> Example67Window?` is the slot and `windowed?: () -> bool` is the
-  # predicate that decides it; nothing in the snapshot ties the two together.
+  # The guarded half, and where the marker lands. `window: () -> Example67Window?`
+  # is the slot, `windowed?: () -> bool` is the predicate that decides it, and
+  # `class AfterWindowed` is what ties them: a `def`, not an `attr_reader`, since
+  # the subject is a method's answer and this class has no ivar to declare.
   it "example67_source (the nilable slot and its predicate) matches expected RBS" do
     assert_snapshot("models/example67_source", target_file: "app/models/example67_source.rb")
   end

--- a/spec/lib/rbs_infer/markers/predicate_marker_synthesizer_spec.rb
+++ b/spec/lib/rbs_infer/markers/predicate_marker_synthesizer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe RbsInfer::Markers::PredicateMarkerSynthesizer do
     Member.new(kind: kind, name: name, signature: "#{name}: untyped", visibility: :public)
   end
 
-  def entry(class_name:, method_name:, when_true_ivars: {}, when_true_self_type_string: nil, ivars: {}, self_type_string: nil, singleton: false)
+  def entry(class_name:, method_name:, when_true_ivars: {}, when_true_methods: {}, when_true_self_type_string: nil, ivars: {}, self_type_string: nil, singleton: false)
     InferredEntry.new(
       class_name: class_name,
       method_name: method_name,
@@ -23,6 +23,7 @@ RSpec.describe RbsInfer::Markers::PredicateMarkerSynthesizer do
       ivars: ivars,
       self_type_string: self_type_string,
       when_true_ivars: when_true_ivars,
+      when_true_methods: when_true_methods,
       when_true_self_type_string: when_true_self_type_string
     )
   end
@@ -48,6 +49,71 @@ RSpec.describe RbsInfer::Markers::PredicateMarkerSynthesizer do
     expect(markers.size).to eq(1)
     expect(markers.first.marker_name).to eq("AfterConfirmed")
     expect(markers.first.overrides).to eq({ "name" => "::String" })
+  end
+
+  it "emits a marker for a predicate whose when_true narrows a sibling method" do
+    # The concern shape: `def entropic?; entropy.present?; end`. There is no
+    # ivar and no reader — the subject is a method, and the marker restates it
+    # as a `def`, not as an `attr_reader` (which would also declare an `@window`
+    # this class does not have).
+    markers = described_class.synthesize(
+      inferred_entries: [
+        entry(
+          class_name: "Source",
+          method_name: :windowed?,
+          when_true_methods: { window: string_type },
+          when_true_self_type_string: "::Source & ::Source::AfterWindowed"
+        )
+      ],
+      target_class: "Source",
+      members: []
+    )
+
+    expect(markers.size).to eq(1)
+    expect(markers.first.marker_name).to eq("AfterWindowed")
+    expect(markers.first.overrides).to eq({})
+    expect(markers.first.method_overrides).to eq({ "window" => "::String" })
+  end
+
+  it "carries both readings when a predicate narrows an ivar and a method at once" do
+    markers = described_class.synthesize(
+      inferred_entries: [
+        entry(
+          class_name: "Source",
+          method_name: :both?,
+          when_true_ivars: { :"@cache" => string_type },
+          when_true_methods: { window: string_type },
+          when_true_self_type_string: "::Source & ::Source::AfterBoth"
+        )
+      ],
+      target_class: "Source",
+      members: [member(kind: :attr_reader, name: "cache")]
+    )
+
+    expect(markers.size).to eq(1)
+    expect(markers.first.overrides).to eq({ "cache" => "::String" })
+    expect(markers.first.method_overrides).to eq({ "window" => "::String" })
+  end
+
+  # No `members` filter for the method half: the inferrer read the type off the
+  # BUILT definition, so a Rails column reader (`read_at`, from rbs_rails) is a
+  # real method of the program even though it appears nowhere in the source file
+  # this class is generated from.
+  it "keeps a method slot the target file does not declare" do
+    markers = described_class.synthesize(
+      inferred_entries: [
+        entry(
+          class_name: "Notification",
+          method_name: :read?,
+          when_true_methods: { read_at: string_type },
+          when_true_self_type_string: "::Notification & ::Notification::AfterRead"
+        )
+      ],
+      target_class: "Notification",
+      members: []
+    )
+
+    expect(markers.first.method_overrides).to eq({ "read_at" => "::String" })
   end
 
   it "skips ivars without a corresponding attr_reader/attr_accessor" do


### PR DESCRIPTION
Pairs with **felixefelip/steep#160** — merge that first; this PR is inert without it.

## What it does

Steep now infers `when_true.methods` — the zero-arity self-methods a predicate proves non-nil on its truthy exit — and names a marker in `when_true.self`. Something has to *declare* that marker, or the sidecar points at a class RBS does not have and `apply_postconditions` silently no-ops.

`PredicateMarkerSynthesizer` already did this for `when_true.ivars` (`def confirmed?; !@name.nil?; end` → `class AfterConfirmed { attr_reader name: ::String }`). It now carries the method reading alongside, on a new `method_overrides` slot of the shared `MarkerClass`:

```rbs
class Example67Source
  def window: () -> Example67Window?
  def windowed?: () -> bool

  class AfterWindowed
    def window: () -> ::Example67Window
  end
end
```

A plain `def`, not an `attr_reader`: `attr_reader x: T` in RBS also declares `@x`, and this class has no such ivar — what the predicate proved is about a method's *answer*.

## No observability filter on this half

The ivar path requires a matching `attr_reader`/`attr_accessor`, because a narrowed ivar with no reader cannot be seen from outside. A method has already answered that question by existing.

And the filter would be actively wrong here. The inferrer read the type off the **built definition**, so what it names is a method of the whole program: `Notification#read_at` comes from rbs_rails, not from the source file this class is generated from, and a second check against *that file's* members would drop exactly the Rails cases. Visibility is filtered where the definition is in hand, on the Steep side.

## Measured on the dummy

Example67 (#336) closes. Its seven baseline diagnostics are gone:

```
-app/models/example67.rb:39:7:  `spiking?` requires `self.source.window` to be non-nil here
-app/models/example67.rb:48:26: `wide_enough?` requires `self.source.window` to be non-nil here
-app/models/example67.rb:52:20: Type `(::Example67Window | nil)` does not have method `size`
-app/models/example67_source.rb:33:4: `detect` requires `self.source.window` to be non-nil here
   (+3 more)
```

`spec/expectations/steep_contracts.yml` drops the `Example67#spiking?` and `Example67#detect` entries outright — the guard discharges the requirement, so nothing propagates — and `Example67#wide_enough?` loses its `enforced: false`, which is what lets its body narrow:

```diff
-  Example67#spiking?:
-    requires: [...]
-    enforced: false
   Example67#wide_enough?:
     requires: [...]
-    enforced: false
```

Two real Rails predicates come along, both already in the dummy and neither written for this:

```diff
 class Assignment < ApplicationRecord
   def assigned?: () -> bool     # post.present?
+  class AfterAssigned
+    def post: () -> ::Post
+  end

 class Notification < ApplicationRecord
   def read?: () -> bool         # read_at.present?
+  class AfterRead
+    def read_at: () -> ::ActiveSupport::TimeWithZone
+  end
```

No new diagnostics anywhere; the baseline only loses entries.

## Example67's comments

Updated from "here is the gap" to "here is what closes it" — the sources and the two snapshot specs. The snapshot for `Example67` itself is unchanged, which is the point: the whole fix lands on `Example67Source`, and what the consumer gets is the contract entries disappearing.

## Tests

3 new unit specs on the synthesizer (a method-only marker, ivar and method together, a slot the target file does not declare). Full suite green: 1628 examples, 0 failures. RBS regenerated to a fixed point (rbs_infer ⇄ steep until stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGYyGCxXCG4jcG5pkxEaSf
