### PR TITLE
test: Example68 grows the three shapes fizzy actually writes

### DIFF
--- a/spec/dummy/app/models/example68.rb
+++ b/spec/dummy/app/models/example68.rb
@@ -1,59 +1,75 @@
 # A `==` against a non-nil value proves its RECEIVER non-nil, and through a `&.`
 # chain that reaches the root:
 #
-#   def matched?
-#     latest&.label&.to_s == "opened" && latest.stamp > 0
+#   def matched?(suffix)
+#     latest&.marker&.to_s == "opened_#{suffix}" && latest.stamp > 0
 #   end
 #
-# `nil == "opened"` is false, so a truthy comparison means the left side was not
+# `nil == "opened_x"` is false, so a truthy comparison means the left side was not
 # nil; and `x&.m` answers nil whenever `x` is, so a non-nil answer means `x` was
-# not nil either. Both steps hold for any receiver — the nil component of a union
+# not nil either. Both steps hold for any receiver — the nil member of a union
 # dispatches `==` to identity, and `&.` is defined by that very short-circuit.
 #
-# The five methods below are the same guard written five ways. They separated two
-# independent gaps, and both are closed:
+# The methods below are one guard written many ways. Each writing was a separate
+# gap, and all are closed:
 #
 #   1  latest && latest.stamp
-#   2  latest&.label && latest.stamp                      <- (B)
+#   2  latest&.label && latest.stamp                             <- (B)
 #   2b entry&.label && entry.stamp
-#   3  latest&.label&.to_s == "opened" && latest.stamp    <- (A) and (B)
-#   4  entry&.label&.to_s == "opened" && entry.stamp      <- (A)
+#   3  latest&.label&.to_s == "opened" && latest.stamp           <- (A) and (B)
+#   4  entry&.label&.to_s == "opened" && entry.stamp             <- (A)
+#   5  latest&.label&.to_s == "opened_#{suffix}" && …            <- (C)
+#   6  latest&.marker&.to_s == "opened_#{suffix}" && …           <- (C), untyped link
+#   7  last_post&.title&.to_s == "draft_#{suffix}" && …          <- (C), record root
 #
-# (A) The comparison was never the problem: Steep types `==` as
+# (A) The comparison was never the problem for a LITERAL: Steep types `==` as
 #     `Logic::ReceiverIsArg` and already partitions the receiver's union against
 #     the literal, dropping `nil` from the truthy side. What it had nowhere to put
 #     that answer was a `:csend` node — `refine_node_type` had no branch for one,
 #     so the fact stopped at the chain and never reached `latest`. It now walks
-#     down: a truthy type that cannot be nil proves the `&.`'s receiver non-nil,
-#     one link per `&.`, and only on the truthy side (a nil answer is ambiguous
-#     between "receiver was nil" and "the call answered nil").
+#     down, one link per `&.`, and only on the truthy side (a nil answer is
+#     ambiguous between "receiver was nil" and "the call answered nil").
 #
 # (B) a `&.` narrowed its receiver only when that receiver was a local. `:csend`
 #     synthesis joins the env back to its pre-call state because the CALL may not
 #     have happened — but the RECEIVER always ran, and `TypeEnv#join` keeps a pure
 #     call only when both sides hold it, so the registration made while
-#     synthesizing the receiver was dropped. It is now carried across the join,
-#     which composes down a chain: each `&.` carries its own receiver.
+#     synthesizing the receiver was dropped. It is now carried across the join.
+#
+# (C) and none of that fires on the shape fizzy actually writes.
+#     `literal_var_type_case_select` switches on the argument NODE's type and
+#     knows `:nil`, `:true`, `:false`, `:int`, `:str`, `:sym` — an interpolation
+#     is a `:dstr` and answers nothing, so the whole `ReceiverIsArg` branch
+#     declines. Worse, one unresolved link anywhere makes the comparison itself
+#     `untyped`, and `guess_type_from_method` knows `is_a?`, `nil?`, `!` and
+#     `===`, not `==`, so there is no logic type to dispatch on at all.
+#
+#     Nil-ness needs neither. `a == b` dispatches on `a`; a nil `a` resolves `==`
+#     to identity; `b`'s type says it is never nil. So the fact is about `a`'s
+#     VALUE, and it travels a chain whose own types say nothing — an `untyped`
+#     link is walked THROUGH, and only links with a nilable type are refined.
+#
+# 5, 6 and 7 are the three things fizzy has and 1-4 did not: an interpolated
+# right-hand side, an `untyped` link in the middle (`Event#action` is
+# `def action; super.inquiry; end`), and a root whose non-nil member is an
+# intersection (`(Event & Event::Validated)?`).
 #
 # Read off fizzy: `Card::ActivitySpike::Detector#card_was_just?`, where
 # `last_event&.action&.to_s == "card_#{action}" && last_event.created_at` answered
 # `Type ((::Event & ::Event::Validated) | nil) does not have method created_at`.
 #
-# The two markers in this class's RBS are the other half of the same reading, and
-# they are about CALLERS: a truthy `labelled_and_stamped?` (or
-# `matched_and_stamped?`) means `latest` is there.
+# The markers in this class's RBS are the other half of the same reading, and they
+# are about CALLERS: a truthy `matched_untyped_link?` means `latest` is there.
 class Example68
-  def entries
-    [Example68Entry.new("opened", 1), Example68Entry.new(nil, 0)]
+  def store
+    Example68Store.new
   end
 
-  # Nilable the way `card.events.order(:created_at).last` is: the collection may
-  # be empty. `label` is nilable on its own account, so the chain is nilable
-  # twice over and a non-nil answer settles both.
+  # A ONE-LINE forwarder, like fizzy's
+  # `def last_event; card.events.order(:created_at).last; end` — which is what
+  # the delegation registry reads as a delegate.
   def latest
-    return nil if entries.empty?
-
-    entries.last
+    store.newest
   end
 
   # 1. The plain guard. Nothing between the receiver and the `&&`.
@@ -84,5 +100,36 @@ class Example68
   def matched_via_local?
     entry = latest
     entry&.label&.to_s == "opened" && entry.stamp > 0
+  end
+
+  # 5. fizzy's ACTUAL right-hand side: an interpolation, not a literal.
+  #    `literal_var_type_case_select` switches on the argument NODE's type and
+  #    knows `:nil`, `:true`, `:false`, `:int`, `:str`, `:sym`. A `:dstr` matches
+  #    none of them, so it answers nothing and the whole `ReceiverIsArg` branch
+  #    declines — there is no literal to partition the union against, and nil is
+  #    never dropped. Nothing about the chain; 3 and 4 above hide it by using a
+  #    bare `"opened"`.
+  def matched_interpolated?(suffix)
+    latest&.label&.to_s == "opened_#{suffix}" && latest.stamp > 0
+  end
+
+  # 6. fizzy's shape entire: an interpolation on the right AND an `untyped` link
+  #    in the chain. `latest&.marker` is `untyped`, so the whole comparison is —
+  #    and `guess_type_from_method` knows `is_a?`, `nil?`, `!` and `===`, not
+  #    `==`, so there is no logic type to dispatch on either.
+  def matched_untyped_link?(suffix)
+    latest&.marker&.to_s == "opened_#{suffix}" && latest.stamp > 0
+  end
+
+  # 7. The last structural difference from fizzy: a root whose non-nil member is
+  #    an INTERSECTION, not a plain class. `last_post` is
+  #    `(Post & Post::Validated)?` exactly as fizzy's `last_event` is
+  #    `(Event & Event::Validated)?`.
+  def last_post
+    Post.order(:created_at).last
+  end
+
+  def matched_on_a_record?(suffix)
+    last_post&.title&.to_s == "draft_#{suffix}" && last_post.created_at > Time.current
   end
 end

--- a/spec/dummy/app/models/example68_entry.rb
+++ b/spec/dummy/app/models/example68_entry.rb
@@ -9,4 +9,12 @@ class Example68Entry
     @label = label
     @stamp = stamp
   end
+
+  # An `untyped` link, with no diagnostic of its own — `Object#public_send` is
+  # declared `-> untyped`. fizzy gets one the same way without meaning to:
+  # `Event#action` is `def action; super.inquiry; end`, `inquiry` resolves
+  # nowhere, and rbs_infer writes `() -> untyped`.
+  def marker
+    method(:label).call
+  end
 end

--- a/spec/dummy/app/models/example68_store.rb
+++ b/spec/dummy/app/models/example68_store.rb
@@ -1,0 +1,15 @@
+# The collection `Example68#latest` forwards to. Split out for one reason: it
+# lets `latest` be a ONE-LINE forwarder, which is what fizzy's `last_event`
+# (`card.events.order(:created_at).last`) is, and what the delegation registry
+# reads as a delegate.
+class Example68Store
+  def entries
+    [Example68Entry.new("opened", 1), Example68Entry.new(nil, 0)]
+  end
+
+  def newest
+    return nil if entries.empty?
+
+    entries.last
+  end
+end

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -1,6 +1,12 @@
 ---
 version: 1
 postconditions:
+- class: Account
+  method: matches?
+  when_true:
+    methods:
+      display_name: "::String"
+    self: "::Account & ::Account::AfterMatches"
 - class: ActionController::Base
   method: head
   unconditional:
@@ -1174,6 +1180,24 @@ postconditions:
     methods:
       latest: "::Example68Entry"
     self: "::Example68 & ::Example68::AfterMatchedAndStamped"
+- class: Example68
+  method: matched_interpolated?
+  when_true:
+    methods:
+      latest: "::Example68Entry"
+    self: "::Example68 & ::Example68::AfterMatchedInterpolated"
+- class: Example68
+  method: matched_on_a_record?
+  when_true:
+    methods:
+      last_post: "(::Post & ::Post::Validated)"
+    self: "::Example68 & ::Example68::AfterMatchedOnARecord"
+- class: Example68
+  method: matched_untyped_link?
+  when_true:
+    methods:
+      latest: "::Example68Entry"
+    self: "::Example68 & ::Example68::AfterMatchedUntypedLink"
 - class: Example68Entry
   method: initialize
   effects:

--- a/spec/dummy/sig/rbs_infer/app/models/account.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/account.rbs
@@ -1,4 +1,8 @@
 class Account < ApplicationRecord
   def label: () -> String
   def matches?: ((Post & Post::Validated) post) -> bool
+
+  class AfterMatches
+    def display_name: () -> ::String
+  end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example68.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example68.rbs
@@ -1,17 +1,33 @@
 class Example68
-  def entries: () -> Array[Example68Entry]
+  def store: () -> Example68Store
   def latest: () -> Example68Entry?
   def present_and_stamped?: () -> bool?
   def labelled_and_stamped?: () -> bool
   def labelled_via_local?: () -> bool
   def matched_and_stamped?: () -> bool
   def matched_via_local?: () -> bool
+  def matched_interpolated?: (untyped suffix) -> bool
+  def matched_untyped_link?: (untyped suffix) -> bool
+  def last_post: () -> (Post & Post::Validated)?
+  def matched_on_a_record?: (untyped suffix) -> bool
 
   class AfterLabelledAndStamped
     def latest: () -> ::Example68Entry
   end
 
   class AfterMatchedAndStamped
+    def latest: () -> ::Example68Entry
+  end
+
+  class AfterMatchedInterpolated
+    def latest: () -> ::Example68Entry
+  end
+
+  class AfterMatchedOnARecord
+    def last_post: () -> (::Post & ::Post::Validated)
+  end
+
+  class AfterMatchedUntypedLink
     def latest: () -> ::Example68Entry
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example68_entry.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example68_entry.rbs
@@ -3,4 +3,5 @@ class Example68Entry
   attr_reader stamp: Integer
 
   def initialize: ((String | nil) label, Integer stamp) -> void
+  def marker: () -> untyped
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example68_store.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example68_store.rbs
@@ -1,0 +1,4 @@
+class Example68Store
+  def entries: () -> Array[Example68Entry]
+  def newest: () -> Example68Entry?
+end

--- a/spec/expectations/models/account.rbs
+++ b/spec/expectations/models/account.rbs
@@ -1,4 +1,8 @@
 class Account < ApplicationRecord
   def label: () -> String
   def matches?: ((Post & Post::Validated) post) -> bool
+
+  class AfterMatches
+    def display_name: () -> ::String
+  end
 end

--- a/spec/expectations/models/example68.rbs
+++ b/spec/expectations/models/example68.rbs
@@ -1,17 +1,33 @@
 class Example68
-  def entries: () -> Array[Example68Entry]
+  def store: () -> Example68Store
   def latest: () -> Example68Entry?
   def present_and_stamped?: () -> bool?
   def labelled_and_stamped?: () -> bool
   def labelled_via_local?: () -> bool
   def matched_and_stamped?: () -> bool
   def matched_via_local?: () -> bool
+  def matched_interpolated?: (untyped suffix) -> bool
+  def matched_untyped_link?: (untyped suffix) -> bool
+  def last_post: () -> (Post & Post::Validated)?
+  def matched_on_a_record?: (untyped suffix) -> bool
 
   class AfterLabelledAndStamped
     def latest: () -> ::Example68Entry
   end
 
   class AfterMatchedAndStamped
+    def latest: () -> ::Example68Entry
+  end
+
+  class AfterMatchedInterpolated
+    def latest: () -> ::Example68Entry
+  end
+
+  class AfterMatchedOnARecord
+    def last_post: () -> (::Post & ::Post::Validated)
+  end
+
+  class AfterMatchedUntypedLink
     def latest: () -> ::Example68Entry
   end
 end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -422,10 +422,13 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
   end
 
   # A `==` against a non-nil value proves its receiver non-nil, and a `&.` chain
-  # carries that to the root. Five writings of one guard separated two independent
-  # gaps — `refine_node_type` having no `:csend` branch to put the comparison's
-  # answer in, and the `:csend` env join dropping the receiver's own pure-call
-  # registration — and the baseline now records none of them.
+  # carries that to the root. Seven writings of one guard separated three gaps —
+  # `refine_node_type` having no `:csend` branch to put a literal comparison's
+  # answer in; the `:csend` env join dropping the receiver's own pure-call
+  # registration; and neither of those firing at all on the shape fizzy writes,
+  # where an interpolated right-hand side and an `untyped` link leave the
+  # comparison with no logic type to dispatch on. The baseline records none of
+  # them.
   #
   # What the snapshot pins is the pair of markers, which is the same reading aimed
   # the other way: a truthy `labelled_and_stamped?` or `matched_and_stamped?` tells


### PR DESCRIPTION
Pairs with **felixefelip/steep#162**, and stacks on **#338** (Example68) — review that first.

## The literal was hiding three things

Example68 closed with a bare `"opened"` on the right-hand side. fizzy writes `"card_#{action}"`, and that one difference is why `detector.rb:50` kept failing after #161 merged. Each ingredient is now its own variant:

|  | shape | what it adds |
|---|---|---|
| 5 | `latest&.label&.to_s == "opened_#{suffix}" && latest.stamp` | an interpolation |
| 6 | `latest&.marker&.to_s == "opened_#{suffix}" && latest.stamp` | + an `untyped` link |
| 7 | `last_post&.title&.to_s == "draft_#{suffix}" && last_post.created_at` | + an intersection root |

`literal_var_type_case_select` switches on the argument NODE's type and knows `:nil`, `:true`, `:false`, `:int`, `:str`, `:sym` — an interpolation is a `:dstr` and answers nothing, so the whole `ReceiverIsArg` branch declines. And one unresolved link anywhere makes the comparison itself `untyped`, while `guess_type_from_method` knows `is_a?`, `nil?`, `!` and `===`, not `==` — so there is no logic type to dispatch on at all.

Variant 7's root is `(Post & Post::Validated)?`, the same shape as fizzy's `last_event: () -> (Event & Event::Validated)?`.

## Two notes from building it

**Getting an `untyped` link took three tries.** `public_send(:label)` and `instance_variable_get(:@label)` both resolve — the analyzer follows the literal symbol — and `method(:label).call` does not. It then stayed `String?` for another cycle anyway, because the previously generated `.rbs` feeds `known_return_types`: the file had to be deleted before the run. Same fixed point example66 documents.

**`latest` is now a one-line forwarder** (`def latest; store.newest; end`), which is what fizzy's `last_event` is and what `DelegationAnalyzer` reads as a delegate. That was my first suspect and it is **not** the cause — the inline never fires on fizzy's `card.events.order(:created_at).last`, whose receiver is not an attr-shape — but the variant earns its keep: it pins that the delegation path narrows too.

## What moves

`steep_baseline.txt` and `steep_contracts.yml`: **nothing**. The three variants add no diagnostic and no contract entry.

One snapshot outside example68:

```diff
 class Account < ApplicationRecord
   def label: () -> String
   def matches?: ((Post & Post::Validated) post) -> bool
+
+  class AfterMatches
+    def display_name: () -> ::String
+  end
 end
```

`Account#matches?` is `display_name == post.title`, and `Post::Validated` makes `title` non-nil — so a truthy comparison proves `display_name` is there. Real, and it falls out of #162 with nothing written for it.

## Verified on fizzy

```
$ bundle exec steep check app/models/card/activity_spike/detector.rb
No type error detected. 🫖
```

Full suite green (1629 examples); RBS regenerated to a fixed point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGYyGCxXCG4jcG5pkxEaSf
