### PR TITLE
Read an `include` written on a constant receiver

### DIFF
--- a/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/collector.rb
@@ -86,6 +86,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
 
     def visit_call_node(node)
       collect_class_body_call(node) if @names.current_scope && @method_depth.zero?
+      collect_receiver_call(node) if @method_depth.zero?
       super
     end
 
@@ -242,9 +243,43 @@ module RbsInfer::Project::StoredBlockReplayExpander
         # Only single-argument calls used to be read at all, so the plural
         # form resolved nothing (felixefelip/rbs_infer#253).
         node.arguments.arguments.each do |argument|
-          @shapes.module_calls << ModuleCall.new(owner: nil, subject: @names.current_scope, method: node.name.to_s, argument: argument)
+          module_call(node, subject: @names.current_scope, argument: argument)
         end
       end
+    end
+
+    # The same application, written on a CONSTANT instead of in a class body.
+    #
+    # `include Mod` needs a body to be written in, so a reopening of a class
+    # this project does not declare has to spell it `Klass.include(Mod)` — which
+    # is how every `lib/rails_ext/` extension applies a concern to
+    # `ActiveRecord::Relation` and friends. The receiver names its subject
+    # outright, so no enclosing scope is needed and the call is read at top
+    # level too. `AST::TargetDiscovery` already reads this shape — it is what
+    # emits the `include` into those reopens — and reading it here is what makes
+    # the concern's `included do` land on the same hosts, instead of the two
+    # halves of one `include` disagreeing (felixefelip/rbs_infer#340).
+    #
+    # Applications only, deliberately: a block written on a constant receiver
+    # (`Klass.keep do … end`) would also need `Replay#scope` — the namespace the
+    # block is written in, which `StoredBlockReplayImplements` points Steep at —
+    # to stop being the subject, and nothing writes that shape here.
+    def collect_receiver_call(node)
+      return if NodeReading.bare_or_self?(node) || node.block || node.arguments.nil?
+
+      subject = @names.receiver_subject(node.receiver)
+      return unless subject
+
+      @names.record_reopened(subject)
+
+      node.arguments.arguments.each do |argument|
+        module_call(node, subject: subject, argument: argument)
+      end
+    end
+
+    def module_call(node, subject:, argument:)
+      @shapes.module_calls << ModuleCall.new(context: @names.current_scope, subject: subject,
+                                             method: node.name.to_s, argument: argument)
     end
 
     # Method shapes declared OUTSIDE this file.

--- a/lib/rbs_infer/project/stored_block_replay_expander/declarations.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/declarations.rb
@@ -38,6 +38,16 @@ module RbsInfer::Project::StoredBlockReplayExpander
       # name is declared: the module is not in any file's text, and the reopening
       # this pass emits for it is what declares it.
       @created_kinds = {}
+      # Subjects this file names ONLY as the receiver of an application —
+      # `ActiveRecord::Relation.include(Mod)`, which is how a reopening of a
+      # class the project does not declare has to spell it. There is no
+      # `class`/`module` keyword to read, so this records the one the pipeline
+      # already commits to for this very shape: `Analyzer#build_include_reopen`
+      # synthesizes the mixin reopen with `is_module: false`, and a replay that
+      # lands on the same subject has to agree with it or the file would emit
+      # two reopens of one name under two keywords
+      # (felixefelip/rbs_infer#340).
+      @reopened_kinds = {}
       @superclasses = []
       # Who can call whose DSL, as the files this one absorbs write it. Kept
       # apart from the table this file builds for the same reason
@@ -114,6 +124,20 @@ module RbsInfer::Project::StoredBlockReplayExpander
       @names.include?(name) ? name : nil
     end
 
+    # The subject a call written on a constant receiver is made ON, or nil when
+    # the receiver names no constant.
+    #
+    # Resolved against this file's declarations when it declares one, and taken
+    # as written when it does not — the same two-step `splice` makes of an
+    # argument, and for the same reason: a subject is matched against the
+    # shapes some other file supplied, and a name nobody supplies methods under
+    # changes no answer. It is the undeclared case that matters here, since a
+    # `Klass.include(Mod)` reopening exists precisely because the project does
+    # not declare `Klass` (felixefelip/rbs_infer#340).
+    def receiver_subject(node)
+      resolve(node, current_scope) || self.class.written_constant(node)
+    end
+
     # Whether a name is declared anywhere this file can see, and with what
     # keyword — its own text, a file it absorbed, or a namespace a DSL call
     # brought into existence.
@@ -128,8 +152,21 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # The keyword THIS file declared a name with, and nothing wider. A reopening
     # is emitted only for a class this source names, so an absorbed or created
     # kind is not an answer to that question.
+    #
+    # A subject reopened by an application is one this source names — that is
+    # what `Klass.include(Mod)` is — so it answers here, where an absorbed kind
+    # (a fact about another file) does not.
     def own_kind(name)
-      @kinds[name]
+      @kinds[name] || @reopened_kinds[name]
+    end
+
+    # A subject named as the receiver of an application, which this file may
+    # reopen even though it declares nothing by that name. A real declaration
+    # still wins wherever it is written, since `own_kind` reads it first — the
+    # `class Foo` a file writes below a `Foo.include(Bar)` has not been walked
+    # yet when this records.
+    def record_reopened(name)
+      @reopened_kinds[name] = "class"
     end
 
     # Which method table a `def` puts the method in, in the terms `providers`
@@ -189,7 +226,14 @@ module RbsInfer::Project::StoredBlockReplayExpander
       # is neither an `extend` nor an ancestor of the SUBJECT, so nothing above
       # can express it, and a DSL whose supplying module is written as a core reopening
       # had no provider at all (felixefelip/rbs_infer#256).
-      @kinds.each do |subject, kind|
+      # A subject this file REOPENS is one of those too, and it is the case that
+      # has no body to read the keyword off: `ActiveRecord::Relation.include(M)`
+      # says `Module#include` is callable on it just as plainly as writing the
+      # `include` inside a `class ActiveRecord::Relation` would, and without this
+      # nothing supplies `include` to a host the project does not declare — so
+      # the concern's `included do` landed nowhere
+      # (felixefelip/rbs_infer#340).
+      @kinds.merge(@reopened_kinds) { |_name, declared, _reopened| declared }.each do |subject, kind|
         CORE_SELF_CHAINS.fetch(kind, []).each { |ancestor| table[ancestor] << subject }
       end
 

--- a/lib/rbs_infer/project/stored_block_replay_expander/resolution.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/resolution.rb
@@ -97,7 +97,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
     end
 
     def splice(call, providers, local:)
-      argument = (local && @names.resolve(call.argument, call.subject)) ||
+      argument = (local && @names.resolve(call.argument, call.context)) ||
                  Declarations.written_constant(call.argument)
       return unless argument
 
@@ -216,7 +216,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # each call site names its own target, and the block simply runs twice, as
     # it does at runtime (felixefelip/rbs_infer#263).
     def resolve_module_call(module_call, providers)
-      source_subject = @names.resolve(module_call.argument, module_call.subject)
+      source_subject = @names.resolve(module_call.argument, module_call.context)
       return [] unless source_subject
 
       replays_landed(module_call.subject, module_call.method, source_subject, providers, Set.new)
@@ -263,7 +263,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # closes the hop.
     def register_deferrals(providers)
       (@shapes.module_calls + @shapes.foreign_module_calls).each do |module_call|
-        source_subject = @names.resolve(module_call.argument, module_call.subject)
+        source_subject = @names.resolve(module_call.argument, module_call.context)
         next unless source_subject
 
         deferral = deferral_for(module_call.subject, module_call.method, source_subject, providers)
@@ -322,7 +322,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
       (@shapes.module_calls + @shapes.foreign_module_calls).any? do |module_call|
         next false unless module_call.subject == subject
 
-        argument = @names.resolve(module_call.argument, module_call.subject)
+        argument = @names.resolve(module_call.argument, module_call.context)
         next false unless argument
 
         source_providers = providers.select { |_, subjects| subjects.include?(argument) }.keys
@@ -389,7 +389,7 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # pass cannot pick a winner for, so it says nothing. Several `extend`s from
     # one provider are not that — see `inward_extend_shapes`.
     def resolve_extensions(module_call, providers)
-      source_subject = @names.resolve(module_call.argument, module_call.subject)
+      source_subject = @names.resolve(module_call.argument, module_call.context)
       return [] unless source_subject
 
       extensions_for(module_call.subject, module_call.method, source_subject, providers, Set.new)

--- a/lib/rbs_infer/project/stored_block_replay_expander/shapes.rb
+++ b/lib/rbs_infer/project/stored_block_replay_expander/shapes.rb
@@ -75,7 +75,13 @@ module RbsInfer::Project::StoredBlockReplayExpander
     # the string they index. The rewrite slices it to move the body, and the
     # block may come from another file (see `absorb`).
     StoredCall = Data.define(:owner, :subject, :method, :block, :source)
-    ModuleCall = Data.define(:owner, :subject, :method, :argument)
+    # `subject` is what the call is written ON — the class body's own `self` for
+    # `include Mod`, and the receiver for `Klass.include(Mod)`. `context` is where
+    # it is WRITTEN, which is the lexical scope `argument` resolves against and is
+    # not the same question: `Foo.include(Bar)` at top level applies `::Bar`, not
+    # the `Foo::Bar` the receiver's namespace might also declare
+    # (felixefelip/rbs_infer#340).
+    ModuleCall = Data.define(:context, :subject, :method, :argument)
 
     # The same replay written from the other end — `base.class_eval(&@block)`,
     # where `self` is the module that KEPT the block and the target arrives as a

--- a/spec/dummy/lib/rails_ext/relation_prepend_order.rb
+++ b/spec/dummy/lib/rails_ext/relation_prepend_order.rb
@@ -1,0 +1,42 @@
+# The crossing the dummy had both halves of and never together
+# (felixefelip/rbs_infer#340): a concern whose `included do` defines a METHOD,
+# applied with `Receiver.include` rather than from a class body.
+#
+# Neither half is new. `included_hook.rb` replays a block's `def`s onto the host
+# that includes the concern, and `array_conversions.rb` reopens a class the
+# project does not declare by writing the `include` on the constant. Their
+# crossing resolved nothing: the reopen carried the `include` and the module
+# came out empty, so `prepend_order` was declared nowhere and every call site
+# was a `NoMethod`.
+#
+# `Klass.include(Mod)` is not a stylistic choice here — it is the only spelling
+# available. There is no `class ActiveRecord::Relation` in this project to write
+# `include` inside, which is exactly why a `lib/rails_ext/` extension writes it
+# this way, and why the two hosts below are one call each rather than one body.
+#
+# Copied in shape from fizzy's `lib/rails_ext/prepend_order.rb`, down to the two
+# hosts: `AssociationRelation` is the second, so a fix that reads only the first
+# call site is visible here.
+module RelationPrependOrder
+  extend ActiveSupport::Concern
+
+  included do
+    def prepend_order(*args)
+      new_orders = args.flatten.map { |arg| arg.is_a?(String) ? arg : arg.to_sql }
+
+      spawn.tap do |relation|
+        relation.order_values = new_orders + order_values
+      end
+    end
+
+    # A literal return, so the snapshot pins a TYPE and not only a method name:
+    # a replay that lands but loses the body would still declare
+    # `prepend_order` and would stop declaring this as `String`.
+    def prepend_order_marker
+      "prepend_order"
+    end
+  end
+end
+
+ActiveRecord::Relation.include(RelationPrependOrder)
+ActiveRecord::AssociationRelation.include(RelationPrependOrder)

--- a/spec/expectations/lib/rails_ext/active_storage_authorization.rbs
+++ b/spec/expectations/lib/rails_ext/active_storage_authorization.rbs
@@ -28,6 +28,34 @@ end
 module ActiveStorage
   module Blobs
     class RedirectController
+    end
+  end
+end
+
+module ActiveStorage
+  module Blobs
+    class ProxyController
+    end
+  end
+end
+
+module ActiveStorage
+  module Representations
+    class RedirectController
+    end
+  end
+end
+
+module ActiveStorage
+  module Representations
+    class ProxyController
+    end
+  end
+end
+
+module ActiveStorage
+  module Blobs
+    class RedirectController
       include ::ActiveStorage::Authorize
     end
   end

--- a/spec/expectations/lib/rails_ext/relation_prepend_order.rbs
+++ b/spec/expectations/lib/rails_ext/relation_prepend_order.rbs
@@ -1,0 +1,29 @@
+module RelationPrependOrder
+  extend ActiveSupport::Concern
+end
+
+module ActiveRecord
+  class Relation
+    def prepend_order: (*untyped args) -> untyped
+    def prepend_order_marker: () -> String
+  end
+end
+
+module ActiveRecord
+  class AssociationRelation
+    def prepend_order: (*untyped args) -> untyped
+    def prepend_order_marker: () -> String
+  end
+end
+
+module ActiveRecord
+  class Relation
+    include RelationPrependOrder
+  end
+end
+
+module ActiveRecord
+  class AssociationRelation
+    include RelationPrependOrder
+  end
+end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -1304,6 +1304,35 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     end
   end
 
+  # `Receiver.include` and an `included do` that defines a method, crossed
+  # (felixefelip/rbs_infer#340). The dummy had each half on its own — the
+  # replay reads a class-body `include`, the reopen reads a constant receiver —
+  # and their crossing resolved nothing: the two reopens carried the `include`
+  # and the concern came out empty, so `prepend_order` was declared nowhere.
+  #
+  # Both hosts, because the fizzy file this copies applies the concern twice and
+  # a fix that reads only the first call site would still pass with one.
+  it "a concern applied by `Receiver.include` carries its `included do` methods" do
+    name = "lib/rails_ext/relation_prepend_order"
+    rbs = RbsInfer::Analyzer.new(
+      target_file: "#{name}.rb",
+      source_files: source_files
+    ).generate_rbs
+
+    if ENV["UPDATE_EXPECTATIONS"]
+      path = expectations_dir.join("#{name}.rbs")
+      path.dirname.mkpath
+      path.write(rbs)
+    end
+
+    expect(rbs.chomp).to eq(expected_rbs(name).chomp)
+    # Once per host, and with the body still attached: a replay that lands the
+    # method but loses what it returns would keep the first count and drop the
+    # second.
+    expect(rbs.scan(/def prepend_order:/).size).to eq(2)
+    expect(rbs.scan(/def prepend_order_marker: \(\) -> String/).size).to eq(2)
+  end
+
   it "PostsController matches expected RBS" do
     assert_snapshot("controllers/posts_controller", target_class: "PostsController", target_file: "app/controllers/posts_controller.rb")
   end

--- a/spec/lib/rbs_infer/project/stored_block_replay_expander_spec.rb
+++ b/spec/lib/rbs_infer/project/stored_block_replay_expander_spec.rb
@@ -1110,6 +1110,127 @@ RSpec.describe RbsInfer::Project::StoredBlockReplayExpander do
     end
   end
 
+  # The same `include`, written on a CONSTANT rather than in a class body.
+  #
+  # A reopening of a class the project does not declare has no body to write
+  # `include Mod` in, so it spells it `Klass.include(Mod)` — which is what every
+  # `lib/rails_ext/` extension does to `ActiveRecord::Relation` and friends.
+  # `AST::TargetDiscovery` already reads that shape and is what emits the
+  # `include` into the reopen; the replay declined it, so the concern's RBS came
+  # out holding the `include` and none of the methods the `included do` defines
+  # (felixefelip/rbs_infer#340).
+  context "an `include` written on a constant receiver" do
+    def applied(host: "Host", declares: "class Host\nend\n")
+      <<~RUBY
+        class Module
+          def include(*modules)
+            modules.reverse_each do |mod|
+              mod.send(:append_features, self)
+              mod.send(:included, self)
+            end
+            self
+          end
+        end
+
+        module Hookable
+          def self.included(base)
+            base.class_eval do
+              def from_hook
+                "hook"
+              end
+            end
+          end
+        end
+
+        #{declares}
+        #{host}.include(Hookable)
+      RUBY
+    end
+
+    it "moves the block onto the class the call names" do
+      expanded = expand(applied)
+
+      expect(expanded).to include("class Host\n  def from_hook")
+      expect(Prism.parse(expanded).success?).to be(true)
+    end
+
+    # The case that motivates the shape at all: nothing in the project declares
+    # `ActiveRecord::Relation`, which is exactly why the `include` had to be
+    # written on the constant. A subject with no `class` keyword to read still
+    # gets one — the same one `Analyzer#build_include_reopen` already commits to
+    # for this shape, so the two halves of one `include` cannot disagree.
+    it "reopens a host the file declares nothing for" do
+      expanded = expand(applied(host: "ActiveRecord::Relation", declares: ""))
+
+      expect(expanded).to include("class ActiveRecord::Relation\n  def from_hook")
+      expect(Prism.parse(expanded).success?).to be(true)
+    end
+
+    it "reopens every host the file applies it to" do
+      source = applied(host: "ActiveRecord::Relation", declares: "") +
+               "ActiveRecord::AssociationRelation.include(Hookable)\n"
+      expanded = expand(source)
+
+      expect(expanded).to include("class ActiveRecord::Relation\n  def from_hook")
+      expect(expanded).to include("class ActiveRecord::AssociationRelation\n  def from_hook")
+    end
+
+    it "adds nothing on a second pass over its own output" do
+      expect(expand(expand(applied))).to be_nil
+    end
+
+    # The argument resolves where the call is WRITTEN, not under the receiver.
+    # `Host.include(Hookable)` at top level applies `::Hookable`, and a
+    # `Host::Hookable` that keeps a different block is a different module —
+    # reading the name under the receiver would have applied that one instead.
+    it "resolves the applied module against the call's own scope" do
+      source = applied.sub("class Host\nend", <<~SHADOW.chomp)
+        class Host
+          module Hookable
+            def self.included(base)
+              base.class_eval do
+                def from_shadow
+                  "shadow"
+                end
+              end
+            end
+          end
+        end
+      SHADOW
+      expanded = expand(source)
+
+      expect(expanded).to include("class Host\n  def from_hook")
+      expect(expanded).not_to include("class Host\n  def from_shadow")
+    end
+
+    it "declines a receiver that names no constant" do
+      expect(expand(applied(host: "host", declares: "host = Host\n"))).to be_nil
+    end
+
+    # The same guard the class-body reading has always had: a call inside a
+    # `def` runs when that method is called, if ever, and a source rewrite
+    # cannot say when. `class` is not even legal in a method body, so the
+    # reopening this would emit has nowhere to go.
+    it "declines an application written inside a method body" do
+      source = applied(declares: "class Host\nend\n")
+               .sub("Host.include(Hookable)", "def apply_it\n  Host.include(Hookable)\nend")
+
+      expect(expand(source)).to be_nil
+    end
+
+    # A block written ON a constant is a different question — `Replay#scope`,
+    # which `StoredBlockReplayImplements` points Steep at, is the namespace the
+    # block is written in and would stop being the subject. Nothing writes that
+    # shape, so it stays declined rather than guessed at.
+    it "declines a block handed to a constant receiver" do
+      source = applied(declares: "class Host\nend\n").sub(
+        "Host.include(Hookable)", "Host.class_evaled do\n  def from_block; end\nend"
+      )
+
+      expect(expand(source)).to be_nil
+    end
+  end
+
 
   # The DSL that runs the block it was just handed, with nothing stored: both
   # other outward shapes fetch their block from a slot, so an immediate


### PR DESCRIPTION
Closes #340.

A concern's `included do` landed on the host that wrote `include Mod` in its class body, and nowhere when the same `include` was written on the constant — `ActiveRecord::Relation.include(Mod)`, which is the only spelling available to a reopening of a class the project does not declare. The reopen came out carrying the `include` and the concern came out empty, so every method the block defines was declared nowhere and every call site was a `NoMethod`.

The two readings of one `include` disagreed. `AST::TargetDiscovery` reads the explicit receiver — it is what emits those reopens — while the replay pass read only a bare call in a class body. Now both read it.

## Two layers

Closing the first alone still declined, so both are here.

**The collector reads the shape.** `Collector#collect_receiver_call` reads an application written on a constant receiver, at top level as well: the receiver names its subject outright and needs no enclosing scope. `ModuleCall` grows `context` — where the call is WRITTEN — beside `subject` — what it is written ON. They coincide for a class-body call and part ways here: `Foo.include(Bar)` at top level applies `::Bar`, not the `Foo::Bar` the receiver's namespace may also declare. The `owner` field, dead since it was added, is what `context` replaces.

**An undeclared subject gets a provider.** `Declarations#providers` handed the core self-chain (`Module`/`Class`/`Object`) only to names the file DECLARES, so an undeclared host had nothing supplying `include` to it, and `replay_for` then declined for having no keyword to write the reopen with. A subject the file reopens now gets both: the same chain, and the `class` that `Analyzer#build_include_reopen` already commits to for this very shape — so the two halves of one `include` cannot emit one name under two keywords.

## The fixture

The dummy had each half and never their crossing: `included_hook.rb` replays a block's `def`s but includes from a class body, and `array_conversions.rb` writes the `include` on a constant but its module has no `included do`. `spec/dummy/lib/rails_ext/relation_prepend_order.rb` is the crossing, copied in shape from fizzy's `lib/rails_ext/prepend_order.rb` down to its two hosts — so a fix that reads only the first call site is visible.

Its snapshot pins a type and not only a method name: `prepend_order_marker` is `() -> String` on both hosts, so a replay that lands the method but loses the body fails.

## Measured

On the fizzy file the issue was found in, `prepend_order` now lands on `ActiveRecord::Relation` and `ActiveRecord::AssociationRelation` both, closing the `NoMethod` at its one call site.

A generic host stays safe: the same concern applied to `Array` emits `class Array[unchecked out Elem]` and loads under RBS with no `GenericParameterMismatchError` — the trap `array_conversions.rb` exists to guard.

`1638 examples, 0 failures`, the dummy's Steep baseline unmoved.

## Known cosmetic effect

Visible in the `active_storage_authorization` snapshot: a concern whose `included do` defines no method (callbacks only) now also produces an empty `class X; end` reopen beside its `include` reopen. Valid RBS and Steep is unmoved. It comes from `generate_multi_target_rbs` emitting declaration targets and include targets as separate blocks — merging those is a separate change, not folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiEk84Zq78HeSyJfTAei1y
