### PR TITLE
feat(literals): emit a literal type where the program fixes the value (S3 of #345)

### DIFF
--- a/lib/rbs_infer/ast/node_type_inferrer.rb
+++ b/lib/rbs_infer/ast/node_type_inferrer.rb
@@ -59,13 +59,32 @@ module RbsInfer::AST
     # caller layers its own resolution on top — replacing the literal-typing
     # case table that used to be copy-pasted across the value typers
     # (felixefelip/rbs_infer#58).
+    # The class a literal node's value belongs to, or nil for a node that is not
+    # a scalar literal. For positions where the value is not evidence about what
+    # may appear there — see `ExtractParamsSignature#optional_param_type`.
+    LITERAL_CLASSES = {
+      Prism::StringNode => "String",
+      Prism::IntegerNode => "Integer",
+      Prism::SymbolNode => "Symbol",
+      Prism::TrueNode => "bool",
+      Prism::FalseNode => "bool"
+    }.freeze
+
+    def self.widen_literal_node(node)
+      LITERAL_CLASSES[node.class]
+    end
+
     def self.infer_literal_node_type(node, constant_resolver:, known_types: {}, context_class: nil)
       case node
-      when Prism::StringNode, Prism::InterpolatedStringNode then "String"
-      when Prism::IntegerNode then "Integer"
+      when Prism::StringNode then node.unescaped.inspect
+      when Prism::InterpolatedStringNode then "String"
+      when Prism::IntegerNode then node.value.inspect
+      # RBS has no float literal type.
       when Prism::FloatNode then "Float"
-      when Prism::SymbolNode, Prism::InterpolatedSymbolNode then "Symbol"
-      when Prism::TrueNode, Prism::FalseNode then "bool"
+      when Prism::SymbolNode then node.unescaped.to_sym.inspect
+      when Prism::InterpolatedSymbolNode then "Symbol"
+      when Prism::TrueNode then "true"
+      when Prism::FalseNode then "false"
       when Prism::NilNode then "nil"
       when Prism::ArrayNode then infer_array_type(node, known_types: known_types, context_class: context_class, constant_resolver: constant_resolver)
       when Prism::HashNode then infer_hash_type(node, known_types: known_types, context_class: context_class, constant_resolver: constant_resolver)

--- a/lib/rbs_infer/inference/class_member_collector.rb
+++ b/lib/rbs_infer/inference/class_member_collector.rb
@@ -563,12 +563,55 @@ module RbsInfer::Inference
       type = infer_node_type(last_stmt)
       return nil unless type
 
+      early = early_return_types(defn)
+      return nil if early.nil?
+
+      type = RbsInfer::Inference::TypeMerger.union_types([type, *early]) unless early.empty?
+
       # Se há return nil no corpo, tornar nilable
       if has_nil_return?(defn)
         type = RbsInfer::Signatures::RbsParserUtil.nilablize(type)
       end
 
       type
+    end
+
+    # The types an early `return <value>` contributes. Only the tail used to
+    # reach the signature, so `return false if flag` above a `true` tail
+    # inferred `-> true` (felixefelip/rbs_infer#347).
+    #
+    # nil when any of them cannot be typed here: a union missing one arm is
+    # narrower than the truth, and narrower is what produces a declaration the
+    # body contradicts. Falling back leaves the Steep-backed pass to read the
+    # whole body, which is what it is for.
+    def early_return_types(defn)
+      returns_in(defn).each_with_object([]) do |node, types|
+        arguments = node.arguments&.arguments
+        # A bare `return` and `return nil` are nilability, not a type —
+        # `has_nil_return?` below reads them.
+        next if arguments.nil? || arguments.empty?
+        next if arguments.any? { |argument| argument.is_a?(Prism::NilNode) }
+        return nil unless arguments.size == 1
+
+        type = infer_node_type(arguments.first) or return nil
+        types << type
+      end
+    end
+
+    # Every `return` that returns from THIS method. A nested `def` has its own,
+    # and a lambda's `return` leaves the lambda — neither is a return path here.
+    # A block's is, which is why blocks are walked.
+    def returns_in(node, found = [])
+      return found unless node.is_a?(Prism::Node)
+
+      node.compact_child_nodes.each do |child|
+        next if child.is_a?(Prism::DefNode) || child.is_a?(Prism::LambdaNode)
+
+        found << child if child.is_a?(Prism::ReturnNode)
+        returns_in(child, found)
+      end
+
+      found
     end
 
     # Purely syntactic, unlike `ReturnTypeResolver`'s: this pass runs BEFORE any

--- a/lib/rbs_infer/inference/class_member_collector/extract_params_signature.rb
+++ b/lib/rbs_infer/inference/class_member_collector/extract_params_signature.rb
@@ -97,7 +97,11 @@ class RbsInfer::Inference::ClassMemberCollector < Prism::Visitor
         @nil_default_params << param.name.to_s
         "untyped"
       else
-        infer_node_type(value) || "untyped"
+        # The same reading as `nil` above, for every other literal. A default is
+        # what the method gets when nobody passes anything; it does not say which
+        # values a caller may pass. `def gravatar_url(size = 80)` typed `?80 size`
+        # rejects every other size.
+        RbsInfer::AST::NodeTypeInferrer.widen_literal_node(value) || infer_node_type(value) || "untyped"
       end
     end
 

--- a/lib/rbs_infer/inference/initialize_body_analyzer.rb
+++ b/lib/rbs_infer/inference/initialize_body_analyzer.rb
@@ -87,7 +87,11 @@ module RbsInfer::Inference
         if kw.value.is_a?(Prism::NilNode)
           @nil_default_params << param_name
         else
-          default_type = infer_type_from_node(kw.value)
+          # Widened for the reason the `nil` branch above exists: a default says
+          # what the method gets when nobody passes anything, not which values a
+          # caller may pass.
+          default_type = RbsInfer::AST::NodeTypeInferrer.widen_literal_node(kw.value) ||
+                         infer_type_from_node(kw.value)
           @keyword_defaults[param_name] = default_type if default_type
         end
       end

--- a/lib/rbs_infer/signatures/method_type_resolver.rb
+++ b/lib/rbs_infer/signatures/method_type_resolver.rb
@@ -88,6 +88,12 @@ module RbsInfer::Signatures
       # `goldness.present?` on a nilable `has_one` — a body that plainly returns
       # false when the association is nil, which Steep then rejects with
       # "Cannot allow method body have type `(true | false)` … declared as `true`".
+      # A literal receiver resolves on its own class: `"abc".upcase` is a
+      # `String` call, and the literal carries none of `String`'s methods.
+      if (widened = RbsInfer::Signatures::RbsParserUtil.widen_literal_type(class_name))
+        return resolve(widened, method_name, arg_types: arg_types, block_body_type: block_body_type)
+      end
+
       if class_name.end_with?("?")
         return resolve_nilable(class_name.delete_suffix("?"), method_name, block_body_type: block_body_type,
                                arg_types: arg_types)

--- a/lib/rbs_infer/signatures/rbs_definition_resolver.rb
+++ b/lib/rbs_infer/signatures/rbs_definition_resolver.rb
@@ -124,7 +124,16 @@ module RbsInfer::Signatures
       return false unless function.required_positionals.size == arg_types.size
 
       function.required_positionals.zip(arg_types).all? do |param, arg|
-        normalize_type_name(param.type.to_s) == normalize_type_name(arg)
+        expected = normalize_type_name(param.type.to_s)
+        actual = normalize_type_name(arg)
+        next true if expected == actual
+
+        # A literal argument satisfies a parameter declared as its class, and the
+        # comparison here is by name: `10` never equalled `Integer`, so no
+        # overload of `Integer#+` matched and the whole list stayed a candidate —
+        # `31 + 10` came out `BigDecimal`, off an overload the stdlib adds.
+        widened = RbsInfer::Signatures::RbsParserUtil.widen_literal_type(actual)
+        !widened.nil? && normalize_type_name(widened) == expected
       end
     end
 

--- a/lib/rbs_infer/signatures/rbs_parser_util.rb
+++ b/lib/rbs_infer/signatures/rbs_parser_util.rb
@@ -219,7 +219,22 @@ module RbsInfer::Signatures
     # one is about what the `?` BINDS to. A bare proc return type reads fine,
     # so wrapping it there would be noise for no one.
     def parenthesize_before_optional(type_str)
+      return "(#{type_str})" if bare_symbol_literal?(type_str)
+
       wrap_top_level(type_str, /[|&^]/, [RBS::Types::Union, RBS::Types::Intersection, RBS::Types::Proc])
+    end
+
+    # `?` is a legal character in a symbol, so appending the nilable marker to
+    # `:edit` yields `:edit?` — which RBS reads as the symbol `:edit?`, not as
+    # `:edit` or nil. Parens keep the two apart. Only the bare symbol is
+    # affected: `"edit"?`, `1?`, `true?` and `:edit!?` all parse as intended.
+    def bare_symbol_literal?(type_str)
+      return false unless type_str&.start_with?(":")
+
+      parsed = RBS::Parser.parse_type(type_str)
+      parsed.is_a?(RBS::Types::Literal) && parsed.literal.is_a?(Symbol)
+    rescue RBS::ParsingError, RBS::BaseError
+      false
     end
 
     # Wraps `type_str` in parens when it parses to one of `kinds`. `trigger` is

--- a/lib/rbs_infer/signatures/rbs_parser_util.rb
+++ b/lib/rbs_infer/signatures/rbs_parser_util.rb
@@ -218,6 +218,26 @@ module RbsInfer::Signatures
     # in method-type position is an overload separator, so it has to go. This
     # one is about what the `?` BINDS to. A bare proc return type reads fine,
     # so wrapping it there would be noise for no one.
+    # The class a literal TYPE belongs to, or nil for anything else. A resolver
+    # handed `"abc"` has nothing to look `upcase` up on; the call is a `String`
+    # call, and the literal is a `String`.
+    LITERAL_TYPE_CLASSES = { String => "String", Symbol => "Symbol", Integer => "Integer" }.freeze
+    LITERAL_TYPE_START = /\A(?:"|:|-?\d|true\z|false\z)/
+
+    def widen_literal_type(type_str)
+      return nil unless type_str&.match?(LITERAL_TYPE_START)
+
+      parsed = RBS::Parser.parse_type(type_str)
+      return nil unless parsed.is_a?(RBS::Types::Literal)
+
+      value = parsed.literal
+      return "bool" if value == true || value == false
+
+      LITERAL_TYPE_CLASSES[LITERAL_TYPE_CLASSES.keys.find { |k| value.is_a?(k) }]
+    rescue RBS::ParsingError, RBS::BaseError
+      nil
+    end
+
     def parenthesize_before_optional(type_str)
       return "(#{type_str})" if bare_symbol_literal?(type_str)
 

--- a/spec/bin/rbs_infer_spec.rb
+++ b/spec/bin/rbs_infer_spec.rb
@@ -298,7 +298,7 @@ RSpec.describe "bin/rbs_infer" do
       expect(status).to be_success
       # Sem o input no source_files, o call-site em pseudo/factory.rb some e o
       # param cai para `untyped`. Com a correção, resolve para String.
-      expect(stdout).to include("def initialize: (name: String) -> void")
+      expect(stdout).to include('def initialize: (name: "hi") -> void')
       expect(stdout).not_to include("name: untyped")
     end
   end
@@ -350,7 +350,7 @@ RSpec.describe "bin/rbs_infer" do
       stdout, _stderr, status = run_rbs_infer("packages/billing/widget.rb", dir: @tmpdir)
 
       expect(status).to be_success
-      expect(stdout).to include("def initialize: (name: String) -> void")
+      expect(stdout).to include('def initialize: (name: "hi") -> void')
     end
 
     # A substituição tem um preço, e ele fica pinado aqui: o que o Steepfile não
@@ -393,7 +393,7 @@ RSpec.describe "bin/rbs_infer" do
       stdout, _stderr, status = run_rbs_infer("pseudo", dir: @tmpdir)
 
       expect(status).to be_success
-      expect(stdout).to include("def initialize: (name: String) -> void")
+      expect(stdout).to include('def initialize: (name: "hi") -> void')
     end
 
     # Sem Steepfile utilizável não há segunda resposta, mais silenciosa, para
@@ -428,7 +428,7 @@ RSpec.describe "bin/rbs_infer" do
       stdout, _stderr, status = run_rbs_infer("app", dir: @tmpdir)
 
       expect(status).to be_success
-      expect(stdout).to include("def initialize: (name: String, age: Integer) -> void")
+      expect(stdout).to include('def initialize: (name: "Felix", age: 30) -> void')
     end
   end
 
@@ -493,7 +493,7 @@ RSpec.describe "bin/rbs_infer" do
 
       expect(status).to be_success
       expect(stdout).to include("module ClassMethods")
-      expect(stdout).to include("def greeting: () -> String")
+      expect(stdout).to include('def greeting: () -> "hello"')
     end
 
     # O `**` do `Dir.glob` não desce em diretório oculto, e é disso que depende

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_29_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_30_000003) do
   create_table "accounts", force: :cascade do |t|
     t.string "display_name", default: "", null: false
     t.string "email", default: "", null: false
@@ -22,6 +22,50 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_29_000001) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_accounts_on_email", unique: true
     t.index ["reset_password_token"], name: "index_accounts_on_reset_password_token", unique: true
+  end
+
+  create_table "action_text_rich_texts", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "body"
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "articles", force: :cascade do |t|
+    t.string "title", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "assignments", force: :cascade do |t|
@@ -95,6 +139,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_29_000001) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "assignments", "posts"
   add_foreign_key "assignments", "users", column: "owner_id"
   add_foreign_key "comments", "posts"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_30_000003) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_29_000001) do
   create_table "accounts", force: :cascade do |t|
     t.string "display_name", default: "", null: false
     t.string "email", default: "", null: false
@@ -22,50 +22,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_30_000003) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_accounts_on_email", unique: true
     t.index ["reset_password_token"], name: "index_accounts_on_reset_password_token", unique: true
-  end
-
-  create_table "action_text_rich_texts", force: :cascade do |t|
-    t.string "name", null: false
-    t.text "body"
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
-  end
-
-  create_table "active_storage_attachments", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
-    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
-  end
-
-  create_table "active_storage_blobs", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.string "service_name", null: false
-    t.bigint "byte_size", null: false
-    t.string "checksum"
-    t.datetime "created_at", null: false
-    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
-  end
-
-  create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
-    t.string "variation_digest", null: false
-    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
-  end
-
-  create_table "articles", force: :cascade do |t|
-    t.string "title", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "assignments", force: :cascade do |t|
@@ -139,8 +95,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_30_000003) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "assignments", "posts"
   add_foreign_key "assignments", "users", column: "owner_id"
   add_foreign_key "comments", "posts"

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -1,12 +1,6 @@
 ---
 version: 1
 postconditions:
-- class: Account
-  method: matches?
-  when_true:
-    methods:
-      display_name: "::String"
-    self: "::Account & ::Account::AfterMatches"
 - class: ActionController::Base
   method: head
   unconditional:
@@ -1998,11 +1992,11 @@ method_entry_facts:
 - class: Example12
   method: dispatch_age
   ivars:
-    "@value": "::Integer"
+    "@value": '42'
 - class: Example12
   method: dispatch_name
   ivars:
-    "@name": "::String"
+    "@name": '"John Doe"'
 - class: Example13::Guarded
   method: act_block_halt
   self_methods:
@@ -2408,13 +2402,13 @@ argument_entry_facts:
   param: which
   pattern: ":age"
   ivars:
-    "@value": "::Integer"
+    "@value": '42'
 - class: Example12
   method: show
   param: which
   pattern: ":name"
   ivars:
-    "@name": "::String"
+    "@name": '"John Doe"'
 - class: Example7::Dispatcher
   method: show
   param: which
@@ -2432,13 +2426,13 @@ argument_entry_facts:
   param: which
   pattern: ":age"
   ivars:
-    "@value": "::Integer"
+    "@value": '42'
 - class: Example8
   method: show
   param: which
   pattern: ":name"
   ivars:
-    "@name": "::String"
+    "@name": '"John Doe"'
 - class: Example9::Dispatcher
   method: show
   param: which

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -1821,6 +1821,20 @@ postconditions:
     may_write:
     - "@widget"
 method_entry_facts:
+- class: Account
+  method: label
+  consts:
+    Current.account: "(::Account & ::Account::Validated)"
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
+- class: Account
+  method: matches?
+  consts:
+    Current.account: "(::Account & ::Account::Validated)"
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: ActiveJob::Base
   method: perform_later
   consts:
@@ -2363,6 +2377,13 @@ method_entry_facts:
   method: test_hash
   ivars:
     "@xml": "::Nokogiri::XML::Document"
+- class: User
+  method: posts_titled_like
+  consts:
+    Current.account: "(::Account & ::Account::Validated)"
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
 - class: User
   method: recent_posts
   consts:

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -1,6 +1,12 @@
 ---
 version: 1
 postconditions:
+- class: Account
+  method: matches?
+  when_true:
+    methods:
+      display_name: "::String"
+    self: "::Account & ::Account::AfterMatches"
 - class: ActionController::Base
   method: head
   unconditional:

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -342,7 +342,7 @@ postconditions:
   method: run
   unconditional:
     consts:
-      Example10::Foo.name: "::String"
+      Example10::Foo.name: '"John Doe"'
       Example10::Sink.last: "::String"
 - class: Example10::Foo
   method: name
@@ -352,9 +352,9 @@ postconditions:
   method: name=
   unconditional:
     ivars:
-      "@name": "::String"
+      "@name": '"John Doe"'
     establishes_consts:
-      name: "::String"
+      name: '"John Doe"'
   effects:
     may_write:
     - "@name"
@@ -962,31 +962,31 @@ postconditions:
   method: gap_alias_read
   unconditional:
     consts:
-      Example3::Foo.name: "::String"
+      Example3::Foo.name: ("John Doe" | "x")
       Example3::Foo.user: "::Example3::User"
 - class: Example3
   method: gap_alias_write
   unconditional:
     consts:
-      Example3::Foo.name: "::String"
+      Example3::Foo.name: ("John Doe" | "x")
       Example3::Foo.user: "::Example3::User"
 - class: Example3
   method: gap_callee_mutation
   unconditional:
     consts:
-      Example3::Foo.name: "::String"
+      Example3::Foo.name: ("John Doe" | "x")
       Example3::Foo.user: "::Example3::User"
 - class: Example3
   method: gap_conditional
   unconditional:
     consts:
-      Example3::Foo.name: "::String"
+      Example3::Foo.name: ("John Doe" | "x")
       Example3::Foo.user: "::Example3::User"
 - class: Example3
   method: run
   unconditional:
     consts:
-      Example3::Foo.name: "::String"
+      Example3::Foo.name: ("John Doe" | "x")
       Example3::Foo.user: "::Example3::User"
 - class: Example31::Foo
   method: bazingado
@@ -1050,7 +1050,7 @@ postconditions:
   method: user=
   unconditional:
     establishes_consts:
-      name: "::String"
+      name: ("John Doe" | "x")
       user: "::Example3::User"
 - class: Example3::Foo
   method: foo_instance
@@ -1066,7 +1066,7 @@ postconditions:
   method: run
   unconditional:
     consts:
-      Example4::Foo.name: "::String"
+      Example4::Foo.name: '"John Doe"'
 - class: Example40::Bazinga
   method: bazingado
   effects:
@@ -1110,7 +1110,7 @@ postconditions:
   method: name=
   unconditional:
     establishes_consts:
-      name: "::String"
+      name: '"John Doe"'
   effects:
     may_write:
     - "@name"
@@ -1118,7 +1118,7 @@ postconditions:
   method: run
   unconditional:
     consts:
-      Example5::Foo.name: "::String"
+      Example5::Foo.name: '"John Doe"'
 - class: Example5::Foo
   method: name
   effects:
@@ -1127,9 +1127,9 @@ postconditions:
   method: name=
   unconditional:
     ivars:
-      "@name": "::String"
+      "@name": '"John Doe"'
     establishes_consts:
-      name: "::String"
+      name: '"John Doe"'
   effects:
     may_write:
     - "@name"
@@ -1137,7 +1137,7 @@ postconditions:
   method: run
   unconditional:
     consts:
-      Example6::Foo.name: "::String"
+      Example6::Foo.name: '"John Doe"'
 - class: Example62::Deferring
   method: keep
   effects:
@@ -1212,9 +1212,9 @@ postconditions:
   method: name=
   unconditional:
     ivars:
-      "@name": "::String"
+      "@name": '"John Doe"'
     establishes_consts:
-      name: "::String"
+      name: '"John Doe"'
   effects:
     may_write:
     - "@name"
@@ -1222,12 +1222,12 @@ postconditions:
   method: run_age
   unconditional:
     consts:
-      Example7::Age.value: "::Integer"
+      Example7::Age.value: '42'
 - class: Example7
   method: run_name
   unconditional:
     consts:
-      Example7::Foo.name: "::String"
+      Example7::Foo.name: '"John Doe"'
 - class: Example7::Age
   method: value
   effects:
@@ -1236,9 +1236,9 @@ postconditions:
   method: value=
   unconditional:
     ivars:
-      "@value": "::Integer"
+      "@value": '42'
     establishes_consts:
-      value: "::Integer"
+      value: '42'
   effects:
     may_write:
     - "@value"
@@ -1250,9 +1250,9 @@ postconditions:
   method: name=
   unconditional:
     ivars:
-      "@name": "::String"
+      "@name": '"John Doe"'
     establishes_consts:
-      name: "::String"
+      name: '"John Doe"'
   effects:
     may_write:
     - "@name"
@@ -1278,12 +1278,12 @@ postconditions:
   method: run_age
   unconditional:
     consts:
-      Example9::Age.value: "::Integer"
+      Example9::Age.value: '42'
 - class: Example9
   method: run_name
   unconditional:
     consts:
-      Example9::Foo.name: "::String"
+      Example9::Foo.name: '"John Doe"'
 - class: Example9::Age
   method: value
   effects:
@@ -1292,9 +1292,9 @@ postconditions:
   method: value=
   unconditional:
     ivars:
-      "@value": "::Integer"
+      "@value": '42'
     establishes_consts:
-      value: "::Integer"
+      value: '42'
   effects:
     may_write:
     - "@value"
@@ -1306,9 +1306,9 @@ postconditions:
   method: name=
   unconditional:
     ivars:
-      "@name": "::String"
+      "@name": '"John Doe"'
     establishes_consts:
-      name: "::String"
+      name: '"John Doe"'
   effects:
     may_write:
     - "@name"
@@ -1827,20 +1827,6 @@ postconditions:
     may_write:
     - "@widget"
 method_entry_facts:
-- class: Account
-  method: label
-  consts:
-    Current.account: "(::Account & ::Account::Validated)"
-    Current.author_name: "::String"
-    Current.user: "(::User & ::User::Validated)"
-    Current.viewer_name: "::String"
-- class: Account
-  method: matches?
-  consts:
-    Current.account: "(::Account & ::Account::Validated)"
-    Current.author_name: "::String"
-    Current.user: "(::User & ::User::Validated)"
-    Current.viewer_name: "::String"
 - class: ActiveJob::Base
   method: perform_later
   consts:
@@ -1885,31 +1871,11 @@ method_entry_facts:
     Current.user: "(::User & ::User::Validated)"
     Current.viewer_name: "::String"
 - class: Current
-  method: account
-  consts:
-    Current.account: "(::Account & ::Account::Validated)"
-    Current.author_name: "::String"
-    Current.user: "(::User & ::User::Validated)"
-    Current.viewer_name: "::String"
-- class: Current
   method: author_name
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
     Current.viewer_name: "::String"
-- class: DashboardController
-  method: render
-  self_methods:
-    current_account: "(::Account & ::Account::Validated)"
-    current_user: "(::User & ::User::Validated)"
-  consts:
-    Current.account: "(::Account & ::Account::Validated)"
-    Current.author_name: "::String"
-    Current.user: "(::User & ::User::Validated)"
-    Current.viewer_name: "::String"
-  ivars:
-    "@account": "(::Account & ::Account::Validated)"
-    "@recent_posts": "::Post::ActiveRecord_Relation"
 - class: DashboardController
   method: set_current_account
   self_methods:
@@ -1952,13 +1918,6 @@ method_entry_facts:
   self_methods:
     current_user: "(::User & ::User::Validated)"
   consts:
-    Current.author_name: "::String"
-    Current.user: "(::User & ::User::Validated)"
-    Current.viewer_name: "::String"
-- class: ERBDashboardShow
-  method: __rbs_infer__body
-  consts:
-    Current.account: "(::Account & ::Account::Validated)"
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
     Current.viewer_name: "::String"
@@ -2022,12 +1981,6 @@ method_entry_facts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
     Current.viewer_name: "::String"
-- class: ERBUsersAvatarsEdit
-  method: __rbs_infer__body
-  consts:
-    Current.author_name: "::String"
-    Current.user: "(::User & ::User::Validated)"
-    Current.viewer_name: "::String"
 - class: ERBUsersShow
   method: __rbs_infer__body
   consts:
@@ -2037,11 +1990,11 @@ method_entry_facts:
 - class: Example10::Bar
   method: greet
   consts:
-    Example10::Foo.name: "::String"
+    Example10::Foo.name: '"John Doe"'
 - class: Example10::Foo
   method: name
   consts:
-    Example10::Foo.name: "::String"
+    Example10::Foo.name: '"John Doe"'
 - class: Example12
   method: dispatch_age
   ivars:
@@ -2133,31 +2086,31 @@ method_entry_facts:
 - class: Example4
   method: run_foo_name
   consts:
-    Example4::Foo.name: "::String"
+    Example4::Foo.name: '"John Doe"'
 - class: Example4::Bar
   method: foo_name
   consts:
-    Example4::Foo.name: "::String"
+    Example4::Foo.name: '"John Doe"'
 - class: Example5::Bar
   method: deep_foo_name
   consts:
-    Example5::Foo.name: "::String"
+    Example5::Foo.name: '"John Doe"'
 - class: Example5::Bar
   method: foo_name
   consts:
-    Example5::Foo.name: "::String"
+    Example5::Foo.name: '"John Doe"'
 - class: Example5::Foo
   method: name
   consts:
-    Example5::Foo.name: "::String"
+    Example5::Foo.name: '"John Doe"'
 - class: Example6::Bar
   method: greet
   consts:
-    Example6::Foo.name: "::String"
+    Example6::Foo.name: '"John Doe"'
 - class: Example6::Foo
   method: name
   consts:
-    Example6::Foo.name: "::String"
+    Example6::Foo.name: '"John Doe"'
 - class: FilterConfiguration
   method: configure_filter
   self_methods:
@@ -2384,13 +2337,6 @@ method_entry_facts:
   ivars:
     "@xml": "::Nokogiri::XML::Document"
 - class: User
-  method: posts_titled_like
-  consts:
-    Current.account: "(::Account & ::Account::Validated)"
-    Current.author_name: "::String"
-    Current.user: "(::User & ::User::Validated)"
-    Current.viewer_name: "::String"
-- class: User
   method: recent_posts
   consts:
     Current.author_name: "::String"
@@ -2398,16 +2344,6 @@ method_entry_facts:
     Current.viewer_name: "::String"
 - class: Users::AvatarsController
   method: edit
-  self_methods:
-    current_user: "(::User & ::User::Validated)"
-  consts:
-    Current.author_name: "::String"
-    Current.user: "(::User & ::User::Validated)"
-    Current.viewer_name: "::String"
-  ivars:
-    "@user": "(::User & ::User::Validated)"
-- class: Users::AvatarsController
-  method: render
   self_methods:
     current_user: "(::User & ::User::Validated)"
   consts:
@@ -2467,13 +2403,6 @@ method_entry_facts:
     Current.user: "(::User & ::User::Validated)"
     Current.viewer_name: "::String"
 argument_entry_facts:
-- class: DashboardController
-  method: render
-  param: target
-  pattern: ":show"
-  ivars:
-    "@account": "(::Account & ::Account::Validated)"
-    "@recent_posts": "::Post::ActiveRecord_Relation"
 - class: Example12
   method: show
   param: which
@@ -2491,13 +2420,13 @@ argument_entry_facts:
   param: which
   pattern: ":age"
   consts:
-    Example7::Age.value: "::Integer"
+    Example7::Age.value: '42'
 - class: Example7::Dispatcher
   method: show
   param: which
   pattern: ":name"
   consts:
-    Example7::Foo.name: "::String"
+    Example7::Foo.name: '"John Doe"'
 - class: Example8
   method: show
   param: which
@@ -2515,13 +2444,13 @@ argument_entry_facts:
   param: which
   pattern: ":age"
   consts:
-    Example9::Age.value: "::Integer"
+    Example9::Age.value: '42'
 - class: Example9::Dispatcher
   method: show
   param: which
   pattern: ":name"
   consts:
-    Example9::Foo.name: "::String"
+    Example9::Foo.name: '"John Doe"'
 - class: PostsController
   method: render
   param: target
@@ -2548,12 +2477,6 @@ argument_entry_facts:
   ivars:
     "@comments": "::Comment::ActiveRecord_Relation"
     "@post": "(::Post & ::Post::Validated)"
-- class: Users::AvatarsController
-  method: render
-  param: target
-  pattern: ":edit"
-  ivars:
-    "@user": "(::User & ::User::Validated)"
 - class: UsersController
   method: render
   param: target

--- a/spec/dummy/sig/generated/.steep_postconditions.yml
+++ b/spec/dummy/sig/generated/.steep_postconditions.yml
@@ -1865,11 +1865,31 @@ method_entry_facts:
     Current.user: "(::User & ::User::Validated)"
     Current.viewer_name: "::String"
 - class: Current
+  method: account
+  consts:
+    Current.account: "(::Account & ::Account::Validated)"
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
+- class: Current
   method: author_name
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
     Current.viewer_name: "::String"
+- class: DashboardController
+  method: render
+  self_methods:
+    current_account: "(::Account & ::Account::Validated)"
+    current_user: "(::User & ::User::Validated)"
+  consts:
+    Current.account: "(::Account & ::Account::Validated)"
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
+  ivars:
+    "@account": "(::Account & ::Account::Validated)"
+    "@recent_posts": "::Post::ActiveRecord_Relation"
 - class: DashboardController
   method: set_current_account
   self_methods:
@@ -1912,6 +1932,13 @@ method_entry_facts:
   self_methods:
     current_user: "(::User & ::User::Validated)"
   consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
+- class: ERBDashboardShow
+  method: __rbs_infer__body
+  consts:
+    Current.account: "(::Account & ::Account::Validated)"
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
     Current.viewer_name: "::String"
@@ -1971,6 +1998,12 @@ method_entry_facts:
     Current.viewer_name: "::String"
 - class: ERBPostsShow
   method: render
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
+- class: ERBUsersAvatarsEdit
+  method: __rbs_infer__body
   consts:
     Current.author_name: "::String"
     Current.user: "(::User & ::User::Validated)"
@@ -2347,6 +2380,16 @@ method_entry_facts:
   ivars:
     "@user": "(::User & ::User::Validated)"
 - class: Users::AvatarsController
+  method: render
+  self_methods:
+    current_user: "(::User & ::User::Validated)"
+  consts:
+    Current.author_name: "::String"
+    Current.user: "(::User & ::User::Validated)"
+    Current.viewer_name: "::String"
+  ivars:
+    "@user": "(::User & ::User::Validated)"
+- class: Users::AvatarsController
   method: set_user
   self_methods:
     current_user: "(::User & ::User::Validated)"
@@ -2397,6 +2440,13 @@ method_entry_facts:
     Current.user: "(::User & ::User::Validated)"
     Current.viewer_name: "::String"
 argument_entry_facts:
+- class: DashboardController
+  method: render
+  param: target
+  pattern: ":show"
+  ivars:
+    "@account": "(::Account & ::Account::Validated)"
+    "@recent_posts": "::Post::ActiveRecord_Relation"
 - class: Example12
   method: show
   param: which
@@ -2471,6 +2521,12 @@ argument_entry_facts:
   ivars:
     "@comments": "::Comment::ActiveRecord_Relation"
     "@post": "(::Post & ::Post::Validated)"
+- class: Users::AvatarsController
+  method: render
+  param: target
+  pattern: ":edit"
+  ivars:
+    "@user": "(::User & ::User::Validated)"
 - class: UsersController
   method: render
   param: target

--- a/spec/dummy/sig/rbs_infer/app/controllers/concerns/filter_configuration.rbs
+++ b/spec/dummy/sig/rbs_infer/app/controllers/concerns/filter_configuration.rbs
@@ -1,7 +1,7 @@
 module FilterConfiguration
   extend ActiveSupport::Concern
 
-  def configure_filter: (String name) -> untyped
+  def configure_filter: ("posts" name) -> untyped
 
   private
 

--- a/spec/dummy/sig/rbs_infer/app/helpers/application_helper.rbs
+++ b/spec/dummy/sig/rbs_infer/app/helpers/application_helper.rbs
@@ -1,5 +1,5 @@
 module ApplicationHelper
-  def test_helper_method: () -> String
+  def test_helper_method: () -> "I'm a helper method"
   def user_name_created_at: () -> ActiveSupport::TimeWithZone
   def user_label_tag: () -> String
 end

--- a/spec/dummy/sig/rbs_infer/app/helpers/posts_helper.rbs
+++ b/spec/dummy/sig/rbs_infer/app/helpers/posts_helper.rbs
@@ -1,7 +1,7 @@
 module PostsHelper
   def post_status_badge: ((Post & Post::Validated) post) -> String
   def post_summary: ((Post & Post::Validated) post, ?Integer length) -> String
-  def post_weights: (?Array[Integer] weights, ?Integer length, ?singleton(::Palette) klass) -> String
+  def post_weights: (?Array[Integer] weights, ?8 length, ?singleton(::Palette) klass) -> String
   def post_index_marker: ((Post & Post::Validated) post) -> String
   def comment_author_badge: (Comment & Comment::Validated comment) -> String
 end

--- a/spec/dummy/sig/rbs_infer/app/jobs/avatar_thumbnail_job.rbs
+++ b/spec/dummy/sig/rbs_infer/app/jobs/avatar_thumbnail_job.rbs
@@ -1,3 +1,3 @@
 class AvatarThumbnailJob < ApplicationJob
-  def perform: (User & User::Validated user, sizes: Array[Integer]) -> Array[Hash[Symbol, (String | Integer)]]
+  def perform: (User & User::Validated user, sizes: Array[(64 | 128)]) -> Array[Hash[Symbol, (String | 64 | 128)]]
 end

--- a/spec/dummy/sig/rbs_infer/app/jobs/avatar_thumbnail_job.rbs
+++ b/spec/dummy/sig/rbs_infer/app/jobs/avatar_thumbnail_job.rbs
@@ -1,3 +1,3 @@
 class AvatarThumbnailJob < ApplicationJob
-  def perform: (User & User::Validated user, sizes: Array[(64 | 128)]) -> Array[Hash[Symbol, (String | 64 | 128)]]
+  def perform: (User & User::Validated user, sizes: Array[(64 | 128)]) -> Array[Hash[(:owner | :width), (String | 64 | 128)]]
 end

--- a/spec/dummy/sig/rbs_infer/app/models/account.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/account.rbs
@@ -1,4 +1,8 @@
 class Account < ApplicationRecord
   def label: () -> String
-  def matches?: (untyped post) -> bool
+  def matches?: ((Post & Post::Validated) post) -> bool
+
+  class AfterMatches
+    def display_name: () -> ::String
+  end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/account.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/account.rbs
@@ -1,8 +1,4 @@
 class Account < ApplicationRecord
   def label: () -> String
-  def matches?: ((Post & Post::Validated) post) -> bool
-
-  class AfterMatches
-    def display_name: () -> ::String
-  end
+  def matches?: (untyped post) -> bool
 end

--- a/spec/dummy/sig/rbs_infer/app/models/cbor_like.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/cbor_like.rbs
@@ -1,10 +1,10 @@
 class CborLike
-  @max_depth: Integer
-  @limit: Integer
+  @max_depth: 16
+  @limit: 16
   @depth: Integer
 
-  MAX_DEPTH: Integer
+  MAX_DEPTH: 16
 
-  def initialize: (?max_depth: Integer) -> 0
+  def initialize: (?max_depth: 16) -> 0
   def levels: () -> Array[untyped]
 end

--- a/spec/dummy/sig/rbs_infer/app/models/cbor_like.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/cbor_like.rbs
@@ -5,6 +5,6 @@ class CborLike
 
   MAX_DEPTH: Integer
 
-  def initialize: (?max_depth: Integer) -> Integer
+  def initialize: (?max_depth: Integer) -> 0
   def levels: () -> Array[untyped]
 end

--- a/spec/dummy/sig/rbs_infer/app/models/coupon.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/coupon.rbs
@@ -1,5 +1,5 @@
 class Coupon
-  CODE_LENGTH: Integer
+  CODE_LENGTH: 8
 
   def self.make: () -> String
 end

--- a/spec/dummy/sig/rbs_infer/app/models/coupon/code.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/coupon/code.rbs
@@ -1,5 +1,5 @@
 class Coupon
   module Code
-    def self.generate: (Integer length) -> String
+    def self.generate: (8 length) -> String
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/eval_reopen.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/eval_reopen.rbs
@@ -3,7 +3,7 @@ class EvalReopen
 
   def own: () -> String
   def by_class_eval: () -> Integer
-  def tagged: (Symbol value, ?Integer limit) -> String
+  def tagged: (:draft value, ?Integer limit) -> String
   def slot: () -> String
   def by_module_eval: () -> Symbol
 end

--- a/spec/dummy/sig/rbs_infer/app/models/eval_reopen.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/eval_reopen.rbs
@@ -1,11 +1,11 @@
 class EvalReopen
   include ::EvalReopen::Slots
 
-  def own: () -> String
-  def by_class_eval: () -> Integer
+  def own: () -> "own"
+  def by_class_eval: () -> 2
   def tagged: (:draft value, ?Integer limit) -> String
   def slot: () -> String
-  def by_module_eval: () -> Symbol
+  def by_module_eval: () -> :three
 end
 
 class EvalReopenCaller

--- a/spec/dummy/sig/rbs_infer/app/models/eval_reopen/slots.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/eval_reopen/slots.rbs
@@ -1,8 +1,8 @@
 class EvalReopen
   module Slots
-    @slot: String?
+    @slot: "value"?
 
     def slot: () -> String?
-    def slot=: (String? value) -> String?
+    def slot=: ("value"? value) -> "value"?
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/eventable.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/eventable.rbs
@@ -1,5 +1,5 @@
 module Eventable
   extend ActiveSupport::Concern
 
-  def track_event: ((Symbol | String) action, **untyped) -> { action: (Symbol | String), particulars: untyped }
+  def track_event: ((:published | "renamed" | :closed | :reopened) action, **untyped) -> { action: (:published | "renamed" | :closed | :reopened), particulars: untyped }
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example.rbs
@@ -1,21 +1,21 @@
 class Column
   attr_accessor board: Board?
-  attr_accessor column_name: String
-  attr_accessor user_name: String?
+  attr_accessor column_name: "To Do"
+  attr_accessor user_name: "John Doe"?
 
-  def initialize: (column_name: String) -> void
-  def set_default_user_name: () -> String
-  def save: () -> bool
+  def initialize: (column_name: "To Do") -> void
+  def set_default_user_name: () -> "John Doe"
+  def save: () -> true
 
   class AfterSetDefaultUserName
-    attr_reader user_name: String
+    attr_reader user_name: "John Doe"
   end
 end
 
 class Board
-  attr_reader user_name: String
+  attr_reader user_name: "John Doe"
 
-  def initialize: (user_name: String) -> void
+  def initialize: (user_name: "John Doe") -> void
 end
 
 class Example

--- a/spec/dummy/sig/rbs_infer/app/models/example10.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example10.rbs
@@ -4,10 +4,10 @@ end
 
 class Example10
   class Foo
-    self.@name: String?
+    self.@name: "John Doe"?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> String
+    def self.name=: ("John Doe" value) -> "John Doe"
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example11.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example11.rbs
@@ -1,6 +1,6 @@
 class Example11
   class Post
-    def title: () -> String
+    def title: () -> "Hello"
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example12.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example12.rbs
@@ -6,5 +6,5 @@ class Example12
   def run_age: () -> (String | Integer | nil)
   def dispatch_name: () -> (String | Integer | nil)
   def dispatch_age: () -> (String | Integer | nil)
-  def show: (Symbol which) -> (String | Integer | nil)
+  def show: ((:name | :age) which) -> (String | Integer | nil)
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example13.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example13.rbs
@@ -24,13 +24,13 @@ end
 
 class Example13
   class Guarded
-    @name: String
+    @name: "John Doe"
     @halted: false | true
 
-    def initialize: (name: String) -> bool
+    def initialize: (name: "John Doe") -> false
     def current_user: () -> Example13Viewer?
-    def halt: () -> bool
-    def with_format: () ?{ (Symbol) -> bool } -> bool?
+    def halt: () -> true
+    def with_format: () ?{ (Symbol) -> true } -> bool?
     def guard_supported: () -> Example13Viewer?
     def run_supported: () -> String?
     def act_supported: () -> String
@@ -61,11 +61,11 @@ class Example13Viewer
   attr_reader name: String
 
   def initialize: (name: String) -> void
-  def active?: () -> bool
+  def active?: () -> true
 end
 
 class Example13Tenant
-  attr_reader label: String
+  attr_reader label: "acme"
 
-  def initialize: (label: String) -> void
+  def initialize: (label: "acme") -> void
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example13.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example13.rbs
@@ -30,7 +30,7 @@ class Example13
     def initialize: (name: "John Doe") -> false
     def current_user: () -> Example13Viewer?
     def halt: () -> true
-    def with_format: () ?{ (Symbol) -> true } -> bool?
+    def with_format: () ?{ (:html) -> true } -> bool?
     def guard_supported: () -> Example13Viewer?
     def run_supported: () -> String?
     def act_supported: () -> String

--- a/spec/dummy/sig/rbs_infer/app/models/example14.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example14.rbs
@@ -6,15 +6,15 @@ class Example14
 
   private
 
-  def halt: () -> bool
+  def halt: () -> true
   def verify: () -> Example14::User
   def set_user: () -> Example14::User
 end
 
 class Example14
   class User
-    attr_reader name: String
+    attr_reader name: "Joe"
 
-    def initialize: (name: String) -> void
+    def initialize: (name: "Joe") -> void
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example15.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example15.rbs
@@ -5,16 +5,16 @@ class Example15
 
   private
 
-  def halt: () -> bool
+  def halt: () -> true
   def verify: () -> Example15::User
   def set_user: () -> Example15::User
 end
 
 class Example15
   class User
-    attr_reader name: String
+    attr_reader name: "Joe"
 
-    def initialize: (name: String) -> void
+    def initialize: (name: "Joe") -> void
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example16.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example16.rbs
@@ -9,17 +9,17 @@ class Example16
   def authenticate: () -> (Example16::User | bool)
   def resume: () -> Example16::User?
   def from_token: () -> (Example16::User | bool)
-  def deny: () -> bool
-  def halt: () -> bool
+  def deny: () -> true
+  def halt: () -> true
   def cookie?: () -> bool
   def token?: () -> bool
 end
 
 class Example16
   class User
-    attr_reader name: String
+    attr_reader name: ("cookie" | "token")
 
-    def initialize: (name: String) -> void
+    def initialize: (name: ("cookie" | "token")) -> void
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example17.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example17.rbs
@@ -1,14 +1,14 @@
 class Example17
-  def with_token: () { (String) -> String } -> String
-  def with_optional: () ?{ (String) -> untyped } -> untyped
-  def with_yield: () { (String) -> untyped } -> untyped
+  def with_token: () { ("token") -> String } -> String
+  def with_optional: () ?{ ("token") -> untyped } -> untyped
+  def with_yield: () { ("token") -> untyped } -> untyped
   def with_pair: () { (String, Integer) -> untyped } -> untyped
-  def with_either: (untyped flag) { (String | Integer) -> untyped } -> untyped
-  def forward_required: () { (String) -> untyped } -> String
+  def with_either: (untyped flag) { ("text" | 42) -> untyped } -> untyped
+  def forward_required: () { ("token") -> untyped } -> String
   def forward_optional: () ?{ (*untyped) -> untyped } -> untyped
   def forward_guarded: () ?{ (*untyped) -> untyped } -> String?
-  def forward_anonymous: () { (String) -> untyped } -> String
+  def forward_anonymous: () { ("token") -> untyped } -> String
   def forward_anonymous_guarded: () ?{ (*untyped) -> untyped } -> String?
-  def name: () -> String
+  def name: () -> "example"
   def run: () -> String
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example18.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example18.rbs
@@ -10,17 +10,17 @@ class Example18
   def from_token: () -> (Example18::User | bool)
   def with_token: () { (String) -> Example18::User? } -> (Example18::User | bool)
   def fetch_token: () { (String) -> Example18::User? } -> Example18::User?
-  def deny: () -> bool
-  def halt: () -> bool
+  def deny: () -> true
+  def halt: () -> true
   def lookup: (String token) -> Example18::User?
   def token_value: () -> String
 end
 
 class Example18
   class User
-    attr_reader name: String
+    attr_reader name: "token"
 
-    def initialize: (name: String) -> void
+    def initialize: (name: "token") -> void
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example19.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example19.rbs
@@ -1,15 +1,15 @@
 class Example19
   @halted: true?
-  @message: String?
+  @message: "denied"?
 
   module Responder
-    def self.deny: (Example19 host, String message) -> bool
+    def self.deny: (Example19 host, "denied" message) -> true
   end
 
   def show: () -> String
   def call: () -> String?
-  def halt: () -> bool
-  def record: (String? message) -> String?
+  def halt: () -> true
+  def record: ("denied"? message) -> String?
 
   private
 
@@ -17,16 +17,16 @@ class Example19
   def from_token: () -> (Example19::User | bool)
   def with_token: () { (String) -> Example19::User? } -> (Example19::User | bool)
   def fetch_token: () { (String) -> Example19::User? } -> Example19::User?
-  def refuse: () -> bool
+  def refuse: () -> true
   def lookup: (String token) -> Example19::User?
   def token_value: () -> String
 end
 
 class Example19
   class User
-    attr_reader name: String
+    attr_reader name: "token"
 
-    def initialize: (name: String) -> void
+    def initialize: (name: "token") -> void
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example2.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example2.rbs
@@ -4,22 +4,22 @@ end
 
 class Example2
   class User
-    attr_reader name: String
+    attr_reader name: "John Doe"
 
-    def initialize: (name: String) -> void
+    def initialize: (name: "John Doe") -> void
   end
 end
 
 class Example2
   class Foo
     attr_reader user: untyped
-    attr_reader name: String?
-    attr_writer name: String?
+    attr_reader name: "John Doe"?
+    attr_writer name: "John Doe"?
 
-    def user=: (Example2::User value) -> String
+    def user=: (Example2::User value) -> "John Doe"
 
     class AfterUser
-      attr_reader name: String
+      attr_reader name: "John Doe"
       attr_reader user: Example2::User
     end
   end

--- a/spec/dummy/sig/rbs_infer/app/models/example20.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example20.rbs
@@ -1,15 +1,15 @@
 class Example20
   @halted: true?
-  @message: String?
+  @message: "denied"?
 
   module Responder
-    def self.deny: (Example20 host, String message) -> bool
+    def self.deny: (Example20 host, "denied" message) -> true
   end
 
   def show: () -> String
   def call: () -> String?
-  def halt: () -> bool
-  def record: (String? message) -> String?
+  def halt: () -> true
+  def record: ("denied"? message) -> String?
 
   private
 
@@ -17,7 +17,7 @@ class Example20
   def from_token: () -> (Example20::User | bool | nil)
   def with_token: () { (String) -> Example20::User? } -> (Example20::User | bool)
   def fetch_token: () { (String) -> Example20::User? } -> Example20::User?
-  def refuse: () -> bool
+  def refuse: () -> true
   def lookup: (String token) -> Example20::User?
   def bearer_request?: () -> bool
   def json_request?: () -> bool
@@ -26,9 +26,9 @@ end
 
 class Example20
   class User
-    attr_reader name: String
+    attr_reader name: "token"
 
-    def initialize: (name: String) -> void
+    def initialize: (name: "token") -> void
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example21.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example21.rbs
@@ -10,9 +10,9 @@ end
 
 class Example21
   class Holder
-    attr_reader name: String
+    attr_reader name: "holder"
 
-    def initialize: (name: String) -> void
+    def initialize: (name: "holder") -> void
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example23.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example23.rbs
@@ -15,7 +15,7 @@ class Example23
   class Bar
     extend ::Example23::Foo
 
-    def self.log_something: (String message) -> String
+    def self.log_something: ("bazingado" message) -> String
   end
 end
 
@@ -23,6 +23,6 @@ class Example23
   class BarOther
     extend ::Example23::Foo
 
-    def self.log_something: (String message) -> String
+    def self.log_something: ("bazingado" message) -> String
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example26.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example26.rbs
@@ -25,6 +25,6 @@ class Example26
   class BarOther
     extend ::Example26::Foo
 
-    def self.log_something: (String message) -> String
+    def self.log_something: ("bazingado" message) -> String
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example27.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example27.rbs
@@ -1,7 +1,7 @@
 class Example27
   module Foo
     def bazinga: (singleton(::Example27::Baz) module_included) -> nil
-    def bazingado: (?singleton(Example27::Bar)? base_foo, ?message: String?) -> nil
+    def bazingado: (?singleton(Example27::Bar)? base_foo, ?message: "Hello, world!"?) -> nil
   end
 
   module Baz

--- a/spec/dummy/sig/rbs_infer/app/models/example28.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example28.rbs
@@ -19,11 +19,11 @@ class Example28
   class Bar
     extend ::Example28::Foo
 
-    def self.validade_age: () -> String
+    def self.validade_age: () -> "validating age"
 
-    def age: () -> Integer
-    def call_test: () -> String
-    def greet: () -> String
+    def age: () -> 42
+    def call_test: () -> "Hello, world!"
+    def greet: () -> "Hello, world!"
     def age_after_a_decade: () -> Integer
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example29.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example29.rbs
@@ -23,11 +23,11 @@ class Example29
   class Bar
     extend ::Example29::Foo
 
-    def self.validade_age: () -> String
+    def self.validade_age: () -> "validating age"
 
-    def age: () -> Integer
-    def call_test: () -> String
-    def greet: () -> String
+    def age: () -> 42
+    def call_test: () -> "Hello, world!"
+    def greet: () -> "Hello, world!"
     def age_after_a_decade: () -> Integer
   end
 end
@@ -36,7 +36,7 @@ class Example29
   class BarOther
     extend ::Example29::Foo
 
-    def name: () -> String
+    def name: () -> "John Doe"
     def call_name_upcase: () -> String
     def name_upcase: () -> String
   end

--- a/spec/dummy/sig/rbs_infer/app/models/example3.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example3.rbs
@@ -8,9 +8,9 @@ end
 
 class Example3
   class User
-    attr_reader name: String
+    attr_reader name: ("John Doe" | "x")
 
-    def initialize: (name: String) -> void
+    def initialize: (name: ("John Doe" | "x")) -> void
   end
 end
 
@@ -20,7 +20,7 @@ class Example3
 
     module GeneratedAttributes
       attr_accessor user: (Example3::User | nil)?
-      attr_accessor name: String?
+      attr_accessor name: ("John Doe" | "x")?
       attr_writer foo_instance: untyped
     end
 
@@ -29,10 +29,10 @@ class Example3
     def self.foo_instance: () -> Example3::Foo
     def self.user: () -> (Example3::User | nil)?
     def self.user=: ((Example3::User | nil) value) -> Example3::User?
-    def self.name: () -> String?
-    def self.name=: (String? value) -> String?
+    def self.name: () -> ("John Doe" | "x")?
+    def self.name=: (("John Doe" | "x")? value) -> ("John Doe" | "x" | nil)
     def self.clear_user: () -> nil
 
-    def user=: ((Example3::User | nil) value) -> String?
+    def user=: ((Example3::User | nil) value) -> ("John Doe" | "x" | nil)
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example30.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example30.rbs
@@ -1,6 +1,6 @@
 module Example30
   class Foo
-    def name: () -> String
+    def name: () -> "Foo"
     def build_age: () -> Symbol
     def call_age: () -> Integer
   end

--- a/spec/dummy/sig/rbs_infer/app/models/example30.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example30.rbs
@@ -9,7 +9,7 @@ end
 module Example30
   class Foo
     class AfterBuildAge
-      def age: () -> Integer
+      def age: () -> 25
     end
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example32.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example32.rbs
@@ -17,8 +17,8 @@ class Example32
 
     extend ::Example32::Foo
 
-    def test: () -> String
+    def test: () -> "test"
     def use_test: () -> String?
-    def age: () -> Integer
+    def age: () -> 31
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example33.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example33.rbs
@@ -19,7 +19,7 @@ class Example33
   class Bar
     extend ::Example33::Foo
 
-    def age: () -> Integer
+    def age: () -> 31
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example33.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example33.rbs
@@ -27,7 +27,7 @@ class Example33
   class BarOther
     extend ::Example33::Foo
 
-    def name: () -> String
+    def name: () -> "John Doe"
     def call_name_upcase: () -> String
     def name_upcase: () -> String
   end

--- a/spec/dummy/sig/rbs_infer/app/models/example34.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example34.rbs
@@ -16,6 +16,6 @@ class Example34
     extend ::Example34::Foo
     include ::Example34::Baz
 
-    def age: () -> Integer
+    def age: () -> 31
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example35.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example35.rbs
@@ -15,6 +15,6 @@ end
 class Example35
   class Bar < Baz
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example36.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example36.rbs
@@ -15,6 +15,6 @@ end
 class Example36
   class Bar < Baz
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example37.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example37.rbs
@@ -18,6 +18,6 @@ class Example37
     extend ::Example37::Foo
 
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example38.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example38.rbs
@@ -27,7 +27,7 @@ class Example38
     extend ::Example38::Foo
 
     def call_age: () -> Integer
-    def age: () -> Integer
-    def name: () -> String
+    def age: () -> 31
+    def name: () -> "John Doe"
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example39.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example39.rbs
@@ -17,6 +17,6 @@ module Example39
     extend ::Example39::Foo
 
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example4.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example4.rbs
@@ -5,10 +5,10 @@ end
 
 class Example4
   class Foo
-    self.@name: String?
+    self.@name: "John Doe"?
 
     def self.name: () -> String?
-    def self.name=: ((String | nil) value) -> String?
+    def self.name=: (("John Doe" | nil) value) -> "John Doe"?
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example40.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example40.rbs
@@ -35,7 +35,7 @@ class Example40
     extend ::Example40::Foo
 
     def call_age: () -> Integer
-    def age: () -> Integer
-    def name: () -> String
+    def age: () -> 31
+    def name: () -> "John Doe"
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example41.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example41.rbs
@@ -15,6 +15,6 @@ class Example41
     extend ::Example41::Foo
     include ::Example41::Baz
 
-    def age: () -> Integer
+    def age: () -> 31
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example42.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example42.rbs
@@ -21,7 +21,7 @@ class Example42
     extend ::Example42::Foo
 
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end
 
@@ -30,6 +30,6 @@ class Example42
     extend ::Example42::Foo
 
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example43.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example43.rbs
@@ -27,7 +27,7 @@ class Example43
     extend ::Example43::Foo
 
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end
 
@@ -36,7 +36,7 @@ class Example43
     extend ::Example43::Foo
 
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end
 
@@ -46,7 +46,7 @@ class Example43
 
     def call_age: () -> Integer
     def call_name: () -> String
-    def age: () -> Integer
-    def name: () -> String
+    def age: () -> 31
+    def name: () -> "John Doe"
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example44.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example44.rbs
@@ -16,7 +16,7 @@ class Example44
     include ::Example44::Baz
 
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end
 
@@ -26,6 +26,6 @@ class Example44
     include ::Example44::Baz
 
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example45.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example45.rbs
@@ -16,7 +16,7 @@ class Example45
     include ::Example45::Baz
 
     def self.call_age: () -> Integer
-    def self.age: () -> Integer
+    def self.age: () -> 31
   end
 end
 
@@ -25,6 +25,6 @@ class Example45
     include ::Example45::Baz
 
     def self.call_age: () -> Integer
-    def self.age: () -> Integer
+    def self.age: () -> 31
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example47.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example47.rbs
@@ -20,8 +20,8 @@ end
 class Example47
   module Baz
     module BananaMethods
-      def color: () -> String
-      def age: () -> Integer
+      def color: () -> "yellow"
+      def age: () -> 31
     end
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example48.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example48.rbs
@@ -8,7 +8,7 @@ class Example48
   end
 
   module Baz::BananaMethods
-    def age: () -> Integer
+    def age: () -> 31
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example49.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example49.rbs
@@ -9,7 +9,7 @@ end
 
 class Example49
   module Baz
-    def color: () -> String
-    def age: () -> Integer
+    def color: () -> "yellow"
+    def age: () -> 31
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example5.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example5.rbs
@@ -4,10 +4,10 @@ end
 
 class Example5
   class Foo
-    self.@name: String?
+    self.@name: "John Doe"?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> String
+    def self.name=: ("John Doe" value) -> "John Doe"
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example50.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example50.rbs
@@ -20,8 +20,8 @@ end
 class Example50
   module Baz
     module BananaMethods
-      def color: () -> String
-      def age: () -> Integer
+      def color: () -> "yellow"
+      def age: () -> 31
     end
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example51.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example51.rbs
@@ -17,7 +17,7 @@ end
 class Example51
   module Baz
     module BananaMethods
-      def age: () -> Integer
+      def age: () -> 31
     end
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example52.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example52.rbs
@@ -21,7 +21,7 @@ end
 class Example52
   module Baz
     module BananaMethods
-      def age: () -> Integer
+      def age: () -> 31
     end
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example53.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example53.rbs
@@ -14,7 +14,7 @@ class Example53
     extend ::Example53::Baz::BananaMethods
     include ::Example53::Baz
 
-    def self.origin: () -> String
+    def self.origin: () -> "farm"
     def self.call_age: () -> Integer
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example54/baz.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example54/baz.rbs
@@ -12,7 +12,7 @@ end
 class Example54
   module Baz
     module BananaMethods
-      def age: () -> Integer
+      def age: () -> 31
     end
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example55/baz.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example55/baz.rbs
@@ -7,7 +7,7 @@ end
 class Example55
   module Baz
     module BananaMethods
-      def age: () -> Integer
+      def age: () -> 31
     end
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example56.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example56.rbs
@@ -4,10 +4,10 @@ end
 
 class Example56
   class Reader
-    def name: () -> String
+    def name: () -> "farm"
     def maybe_name: () -> String?
     def label: () -> String
     def shout: () -> String
-    def maybe_label: () -> String?
+    def maybe_label: () -> "loud"?
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example57.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example57.rbs
@@ -2,7 +2,7 @@ class Example57
   include Fields
 
   def window_size: () -> Integer
-  def creation_window: () -> Integer
+  def creation_window: () -> 7
 end
 
 class Example57
@@ -10,6 +10,6 @@ class Example57
     include Example57Windowed
 
     def doubled: () -> Integer
-    def window_days: () -> Integer
+    def window_days: () -> 30
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example58/defaults.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example58/defaults.rbs
@@ -9,7 +9,7 @@ end
 class Example58
   module Defaults
     module ClassMethods
-      def default_values: () -> { indexed_by: String, sorted_by: String }
+      def default_values: () -> { indexed_by: "all", sorted_by: "latest" }
     end
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example59/naming.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example59/naming.rbs
@@ -7,7 +7,7 @@ end
 class Example59
   module Naming
     module ClassMethods
-      def human_name: (String index) -> String
+      def human_name: (("all" | "closed") index) -> String
     end
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example59_labels.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example59_labels.rbs
@@ -1,5 +1,5 @@
 class Example59Labels
-  INDEXES: Array[String]
+  INDEXES: Array[("all" | "closed")]
 
   def labels: () -> Array[String]
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example6.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example6.rbs
@@ -4,10 +4,10 @@ end
 
 class Example6
   class Foo
-    self.@name: String?
+    self.@name: "John Doe"?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> String
+    def self.name=: ("John Doe" value) -> "John Doe"
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/example60.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example60.rbs
@@ -4,5 +4,5 @@ class Example60
 
   def example60_printer: () -> Example60Printer
   def print_label: () -> String
-  def stamp: (String label, Integer times) -> String
+  def stamp: ("tag" label, 2 times) -> String
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example60/labels.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example60/labels.rbs
@@ -2,14 +2,14 @@ class Example60
   module Labels
     extend ActiveSupport::Concern
 
-    def human_name: (String index) -> String
+    def human_name: ("all" index) -> String
   end
 end
 
 class Example60
   module Labels
     module ClassMethods
-      def human_name: (String index) -> String
+      def human_name: ("all" index) -> String
     end
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example60_printer.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example60_printer.rbs
@@ -1,3 +1,3 @@
 class Example60Printer
-  def stamp: (String label, Integer times) -> String
+  def stamp: ("tag" label, 2 times) -> String
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example61.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example61.rbs
@@ -1,5 +1,5 @@
 class Example61
-  def self.normalize: ((Symbol | String) key) -> String
+  def self.normalize: ((:indexed_by | "indexed_by") key) -> String
 
   def normalized_key: () -> String
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example62.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example62.rbs
@@ -24,6 +24,6 @@ class Example62
 end
 
 class Example62Caller
-  def fill: () -> String
+  def fill: () -> "value"
   def read_hallmark: () -> String
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example62/slots.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example62/slots.rbs
@@ -1,8 +1,8 @@
 class Example62
   module Slots
-    @hallmark: String?
+    @hallmark: "value"?
 
     def hallmark: () -> String?
-    def hallmark=: (String? value) -> String?
+    def hallmark=: ("value"? value) -> "value"?
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example64/vault.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example64/vault.rbs
@@ -1,5 +1,5 @@
 class Example64
   module Vault
-    def self.label: () -> String
+    def self.label: () -> "nested"
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example65.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example65.rbs
@@ -1,6 +1,6 @@
 class Example65
   class Dispatcher
-    def self.dispatch: (*(String | { greeting: String } | Integer | { step: Integer }) args, **untyped) -> Object
+    def self.dispatch: (*("ada" | { greeting: "hello" } | 1 | { step: 2 } | "/tmp/x.csv") args, **untyped) -> Object
 
     def handle: (*untyped) -> untyped
   end
@@ -8,7 +8,7 @@ end
 
 class Example65
   class Rival
-    def self.dispatch: (*(bool | { mode: Symbol }) args, **untyped) -> Object
+    def self.dispatch: (*(true | { mode: :fast }) args, **untyped) -> Object
 
     def handle: (*untyped) -> untyped
   end

--- a/spec/dummy/sig/rbs_infer/app/models/example65_adder.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example65_adder.rbs
@@ -1,3 +1,3 @@
 class Example65Adder < Example65::Dispatcher
-  def handle: (Integer count, step: Integer) -> Integer
+  def handle: (1 count, step: 2) -> Integer
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example65_greeter.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example65_greeter.rbs
@@ -1,3 +1,3 @@
 class Example65Greeter < Example65::Dispatcher
-  def handle: (String name, greeting: String) -> String
+  def handle: ("ada" name, greeting: "hello") -> String
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example65_impostor.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example65_impostor.rbs
@@ -1,3 +1,3 @@
 class Example65Impostor < Example65::Rival
-  def handle: (bool flag, mode: Symbol) -> Symbol?
+  def handle: (true flag, mode: :fast) -> Symbol?
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example65_reporter.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example65_reporter.rbs
@@ -1,3 +1,3 @@
 class Example65Reporter < Example65::Dispatcher
-  def handle: (String path) -> String
+  def handle: ("/tmp/x.csv" path) -> String
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example66_trackable.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example66_trackable.rbs
@@ -1,10 +1,10 @@
 module Example66Trackable
   alias flagged? flag
 
-  attr_accessor flag: bool?
+  attr_accessor flag: true?
 
-  def mark!: () -> bool
-  def relevant?: () -> bool
+  def mark!: () -> true
+  def relevant?: () -> false
 
   class AfterMark
     attr_reader flag: true

--- a/spec/dummy/sig/rbs_infer/app/models/example67_source.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example67_source.rbs
@@ -1,6 +1,6 @@
 class Example67Source
   def enabled?: () -> bool
-  def window_size: () -> Integer
+  def window_size: () -> 30
   def window: () -> Example67Window?
   def windowed?: () -> bool
   def detect_spikes: () -> bool

--- a/spec/dummy/sig/rbs_infer/app/models/example67_window.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example67_window.rbs
@@ -1,7 +1,7 @@
 class Example67Window
   def self.for: (Example67Source source) -> Example67Window?
 
-  attr_reader size: Integer
+  attr_reader size: 30
 
-  def initialize: (Integer size) -> void
+  def initialize: (30 size) -> void
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example68_entry.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example68_entry.rbs
@@ -1,7 +1,7 @@
 class Example68Entry
-  attr_reader label: (String | nil)
-  attr_reader stamp: Integer
+  attr_reader label: ("opened" | nil)
+  attr_reader stamp: (1 | 0)
 
-  def initialize: ((String | nil) label, Integer stamp) -> void
+  def initialize: (("opened" | nil) label, (1 | 0) stamp) -> void
   def marker: () -> untyped
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example69.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example69.rbs
@@ -1,7 +1,7 @@
 module Example69
   class Foo
-    def name: () -> String
-    def action: () -> String
+    def name: () -> "name"
+    def action: () -> "delete"
     def call_name_action: () -> String
     def call_action: () -> String
     def call_dynamic: () -> String

--- a/spec/dummy/sig/rbs_infer/app/models/example7.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example7.rbs
@@ -5,24 +5,24 @@ end
 
 class Example7
   class Foo
-    self.@name: String?
+    self.@name: "John Doe"?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> String
+    def self.name=: ("John Doe" value) -> "John Doe"
   end
 end
 
 class Example7
   class Age
-    self.@value: Integer?
+    self.@value: 42?
 
     def self.value: () -> Integer?
-    def self.value=: (Integer value) -> Integer
+    def self.value=: (42 value) -> 42
   end
 end
 
 class Example7
   class Dispatcher
-    def show: (Symbol which) -> (String | Integer | nil)
+    def show: ((:name | :age) which) -> (String | Integer | nil)
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example8.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example8.rbs
@@ -4,5 +4,5 @@ class Example8
 
   def run_name: () -> (String | Integer | nil)
   def run_age: () -> (String | Integer | nil)
-  def show: (Symbol which) -> (String | Integer | nil)
+  def show: ((:name | :age) which) -> (String | Integer | nil)
 end

--- a/spec/dummy/sig/rbs_infer/app/models/example9.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example9.rbs
@@ -5,24 +5,24 @@ end
 
 class Example9
   class Foo
-    self.@name: String?
+    self.@name: "John Doe"?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> String
+    def self.name=: ("John Doe" value) -> "John Doe"
   end
 end
 
 class Example9
   class Age
-    self.@value: Integer?
+    self.@value: 42?
 
     def self.value: () -> Integer?
-    def self.value=: (Integer value) -> Integer
+    def self.value=: (42 value) -> 42
   end
 end
 
 class Example9
   class Dispatcher
-    def show: (Symbol which) -> (String | Integer | nil)
+    def show: ((:name | :age) which) -> (String | Integer | nil)
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/included_hook.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/included_hook.rbs
@@ -33,5 +33,5 @@ class IncludedHookCaller
   def read_slot: () -> String
   def read_badge: () -> String
   def read_stamp: () -> String
-  def read_shared: () -> Integer
+  def read_shared: () -> 1
 end

--- a/spec/dummy/sig/rbs_infer/app/models/included_hook.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/included_hook.rbs
@@ -20,11 +20,11 @@ class IncludedHook
   include Sugared
   include Homespun
 
-  def from_hook: () -> String
+  def from_hook: () -> "hook"
   def slot: () -> String
-  def from_sugar: () -> String
+  def from_sugar: () -> "sugar"
   def badge: () -> String
-  def from_homespun: () -> String
+  def from_homespun: () -> "homespun"
   def stamp: () -> String
 end
 

--- a/spec/dummy/sig/rbs_infer/app/models/included_hook/slots.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/included_hook/slots.rbs
@@ -1,14 +1,14 @@
 class IncludedHook
   module Slots
-    @slot: String?
-    @badge: String?
-    @stamp: String?
+    @slot: "value"?
+    @badge: "value"?
+    @stamp: "value"?
 
     def slot: () -> String?
-    def slot=: (String? value) -> String?
+    def slot=: ("value"? value) -> "value"?
     def badge: () -> String?
-    def badge=: (String? value) -> String?
+    def badge=: ("value"? value) -> "value"?
     def stamp: () -> String?
-    def stamp=: (String? value) -> String?
+    def stamp=: ("value"? value) -> "value"?
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/included_hook_first.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/included_hook_first.rbs
@@ -1,5 +1,5 @@
 class IncludedHookFirst
   include IncludedHook::Shared
 
-  def from_shared: () -> Integer
+  def from_shared: () -> 1
 end

--- a/spec/dummy/sig/rbs_infer/app/models/included_hook_second.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/included_hook_second.rbs
@@ -1,5 +1,5 @@
 class IncludedHookSecond
   include IncludedHook::Shared
 
-  def from_shared: () -> Integer
+  def from_shared: () -> 1
 end

--- a/spec/dummy/sig/rbs_infer/app/models/notification.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/notification.rbs
@@ -1,6 +1,6 @@
 class Notification < ApplicationRecord
   def channel: () -> String
-  def mute!: () -> String
+  def mute!: () -> "none"
   def read?: () -> bool
   def headline: () -> String
 

--- a/spec/dummy/sig/rbs_infer/app/models/palette.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/palette.rbs
@@ -1,6 +1,6 @@
 class Palette
-  MAX: Integer
-  DEFAULT_NAME: String
+  MAX: 8
+  DEFAULT_NAME: "Blue"
   WEIGHTS: Array[Integer]
   COLORS: Array[Palette]
 

--- a/spec/dummy/sig/rbs_infer/app/models/post.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/post.rbs
@@ -19,9 +19,9 @@ class Post < ApplicationRecord
   def was_priority_high: () -> bool?
   def publish_in_transaction: () -> self
   def popular_tags: (?Integer limit) -> untyped
-  def tag_limit: () -> Integer
+  def tag_limit: () -> 10
   def tag_named: () -> (Tag & Tag::Validated)?
-  def sibling_tag_names: () -> Array[String]
+  def sibling_tag_names: () -> Array[("news" | "featured")]
   def iterate_tags: () -> Post_Tag::ActiveRecord_Associations_CollectionProxy
   def archive: () -> Post_Comment::ActiveRecord_Associations_CollectionProxy
   def archive_via_singleton: () -> Post_Comment::ActiveRecord_Associations_CollectionProxy

--- a/spec/dummy/sig/rbs_infer/app/models/post/taggable.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/post/taggable.rbs
@@ -14,7 +14,7 @@ end
 class Post
   module Taggable
     module ClassMethods
-      def default_tag_names: () -> Array[String]
+      def default_tag_names: () -> Array[("news" | "featured")]
       def known_tag?: (untyped name) -> bool
       def tags_ordered_by_tag_name: () -> Post::ActiveRecord_Relation
       def touch_recently_tagged: () -> nil

--- a/spec/dummy/sig/rbs_infer/app/models/send_dispatch.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/send_dispatch.rbs
@@ -1,5 +1,5 @@
 class SendDispatch
-  def call: () -> String
+  def call: () -> "called"
 
   private
 

--- a/spec/dummy/sig/rbs_infer/app/models/send_dispatch.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/send_dispatch.rbs
@@ -3,8 +3,8 @@ class SendDispatch
 
   private
 
-  def stamp: (String value) -> String
-  def stamped?: (String value) -> bool
+  def stamp: (("post" | "a") value) -> String
+  def stamped?: ("stamped: post" value) -> bool
 end
 
 class SendDispatchCaller

--- a/spec/dummy/sig/rbs_infer/app/models/singleton_ivar_probe.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/singleton_ivar_probe.rbs
@@ -5,9 +5,9 @@ class SingletonIvarProbe
 
   @instance_ivar: String
 
-  def self.configure: () -> String
-  def self.build: () -> String
-  def self.label: () -> String
+  def self.configure: () -> "custom"
+  def self.build: () -> "classe"
+  def self.label: () -> "singleton"
 
-  def initialize: () -> String
+  def initialize: () -> "instancia"
 end

--- a/spec/dummy/sig/rbs_infer/app/models/tag.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/tag.rbs
@@ -1,5 +1,5 @@
 class Tag < ApplicationRecord
   def self.popular: (?Integer limit) -> untyped
-  def self.default_limit: () -> Integer
+  def self.default_limit: () -> 10
   def self.named: (String value) -> (Tag & Tag::Validated)?
 end

--- a/spec/dummy/sig/rbs_infer/app/models/user.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/user.rbs
@@ -10,6 +10,6 @@ class User < ApplicationRecord
   def known_post_tag?: (untyped name) -> bool
   def posts_count: () -> Integer
   def recent_posts: (?Integer limit) -> User_Post::ActiveRecord_Associations_CollectionProxy
-  def posts_titled_like: ((Post & Post::Validated) post) -> Integer
+  def posts_titled_like: (untyped post) -> Integer
   def unread_notifications_count: () -> Integer
 end

--- a/spec/dummy/sig/rbs_infer/app/models/user.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/user.rbs
@@ -10,6 +10,6 @@ class User < ApplicationRecord
   def known_post_tag?: (untyped name) -> bool
   def posts_count: () -> Integer
   def recent_posts: (?Integer limit) -> User_Post::ActiveRecord_Associations_CollectionProxy
-  def posts_titled_like: (untyped post) -> Integer
+  def posts_titled_like: ((Post & Post::Validated) post) -> Integer
   def unread_notifications_count: () -> Integer
 end

--- a/spec/dummy/sig/rbs_infer/app/models/user/notifiable.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/user/notifiable.rbs
@@ -4,9 +4,9 @@ class User
 
     def unread_notifications: () -> Notification::ActiveRecord_Relation
     def notifications_count: () -> Integer
-    def notify!: (String title) -> Notification
+    def notify!: ("Welcome" title) -> Notification
     def notify_welcome!: () -> Notification
-    def mute_latest_notification!: () -> String?
+    def mute_latest_notification!: () -> "none"?
     def latest_notification_headline: () -> String?
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/vault/totaled.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/vault/totaled.rbs
@@ -7,7 +7,7 @@ end
 module Vault
   module Totaled
     module ClassMethods
-      def vault_key: () -> String
+      def vault_key: () -> "vault"
     end
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/widget.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/widget.rbs
@@ -3,5 +3,5 @@ class Widget
   include ::Widget::Publishable
   include ::Widget::Closeable
 
-  def rename: () -> { action: Symbol | String, particulars: untyped }
+  def rename: () -> { action: :published | "renamed" | :closed | :reopened, particulars: untyped }
 end

--- a/spec/dummy/sig/rbs_infer/app/models/widget/closeable.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/widget/closeable.rbs
@@ -2,8 +2,8 @@ class Widget
   module Closeable
     extend ActiveSupport::Concern
 
-    def close: () -> { action: (Symbol | String), particulars: untyped }
+    def close: () -> { action: (:published | "renamed" | :closed | :reopened), particulars: untyped }
     def reopen: () -> ({ action: Symbol | String, particulars: untyped } | nil)
-    def audit: () -> bool
+    def audit: () -> true
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/models/widget/publishable.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/widget/publishable.rbs
@@ -5,7 +5,7 @@ class Widget
     alias was_just_published? published?
     alias just_published? published?
 
-    def publish: () -> { action: Symbol | String, particulars: untyped }
-    def published?: () -> bool
+    def publish: () -> { action: :published | "renamed" | :closed | :reopened, particulars: untyped }
+    def published?: () -> true
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/services/comment/create.rbs
+++ b/spec/dummy/sig/rbs_infer/app/services/comment/create.rbs
@@ -5,7 +5,7 @@ class Comment
     private
 
     def process_creation_response: (Comment & Comment::Validated comment, Symbol status) -> void
-    def dummy_hash: () -> { baz: Integer, comment: Comment, foo: String, nested: { a: Integer, b: Integer } }
+    def dummy_hash: () -> { foo: "bar", baz: 42, nested: { a: 1, b: 2 }, comment: Comment }
     def test_dummy_hash: () -> Comment
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/services/comment/create.rbs
+++ b/spec/dummy/sig/rbs_infer/app/services/comment/create.rbs
@@ -5,7 +5,7 @@ class Comment
     private
 
     def process_creation_response: (Comment & Comment::Validated comment, Symbol status) -> void
-    def dummy_hash: () -> { foo: String, baz: Integer, nested: { a: Integer, b: Integer }, comment: Comment }
+    def dummy_hash: () -> { baz: Integer, comment: Comment, foo: String, nested: { a: Integer, b: Integer } }
     def test_dummy_hash: () -> Comment
   end
 end

--- a/spec/dummy/sig/rbs_infer/app/services/event_reporter.rbs
+++ b/spec/dummy/sig/rbs_infer/app/services/event_reporter.rbs
@@ -1,3 +1,3 @@
 class EventReporter
-  def report: () -> { action: String | Symbol }
+  def report: () -> { action: "created" | :reported }
 end

--- a/spec/dummy/sig/rbs_infer/app/services/event_tracker.rbs
+++ b/spec/dummy/sig/rbs_infer/app/services/event_tracker.rbs
@@ -1,4 +1,4 @@
 class EventTracker
-  def track_event: (action: (String | Symbol)) -> { action: (String | Symbol) }
+  def track_event: (action: ("created" | :reported)) -> { action: ("created" | :reported) }
   def track_created: () -> { action: untyped }
 end

--- a/spec/dummy/sig/rbs_infer/app/services/post_filtering.rbs
+++ b/spec/dummy/sig/rbs_infer/app/services/post_filtering.rbs
@@ -1,9 +1,9 @@
 class PostFiltering
   attr_reader user: (User & User::Validated | User)
   attr_reader post: Post
-  attr_reader expanded: bool
+  attr_reader expanded: false
 
-  def initialize: ((User & User::Validated | User) user, Post post, ?expanded: bool) -> void
+  def initialize: ((User & User::Validated | User) user, Post post, ?expanded: false) -> void
   def expanded?: () -> bool
   def title: () -> String?
   def author_name: () -> String?

--- a/spec/dummy/sig/rbs_infer/app/services/post_publisher.rbs
+++ b/spec/dummy/sig/rbs_infer/app/services/post_publisher.rbs
@@ -1,9 +1,9 @@
 class PostPublisher
-  def self.publish: (untyped post) -> bool
+  def self.publish: (untyped post) -> true
 
   attr_reader post: Post
   attr_reader notifier: EmailNotifier
 
   def initialize: (Post post, ?notifier: EmailNotifier) -> void
-  def call: () -> bool
+  def call: () -> true
 end

--- a/spec/dummy/sig/rbs_infer/app/services/post_publisher.rbs
+++ b/spec/dummy/sig/rbs_infer/app/services/post_publisher.rbs
@@ -1,9 +1,9 @@
 class PostPublisher
-  def self.publish: (untyped post) -> true
+  def self.publish: (untyped post) -> bool
 
   attr_reader post: Post
   attr_reader notifier: EmailNotifier
 
   def initialize: (Post post, ?notifier: EmailNotifier) -> void
-  def call: () -> true
+  def call: () -> bool
 end

--- a/spec/dummy/sig/rbs_infer/app/services/profile_formatter.rbs
+++ b/spec/dummy/sig/rbs_infer/app/services/profile_formatter.rbs
@@ -1,7 +1,7 @@
 class ProfileFormatter
-  attr_reader nickname: (String | nil)
+  attr_reader nickname: ("ada" | nil)
 
-  def initialize: (nickname: (String | nil)) -> void
+  def initialize: (nickname: ("ada" | nil)) -> void
   def call: () -> untyped
   def call_without_check: () -> untyped
 

--- a/spec/dummy/sig/rbs_infer/app/services/widget_auditor.rbs
+++ b/spec/dummy/sig/rbs_infer/app/services/widget_auditor.rbs
@@ -2,5 +2,5 @@ class WidgetAuditor
   attr_reader widget: (Widget & Widget::Closeable)
 
   def initialize: ((Widget & Widget::Closeable) widget) -> void
-  def audit: () -> bool
+  def audit: () -> true
 end

--- a/spec/dummy/sig/rbs_infer/app/uploaders/avatar_uploader.rbs
+++ b/spec/dummy/sig/rbs_infer/app/uploaders/avatar_uploader.rbs
@@ -1,4 +1,4 @@
 class AvatarUploader < CarrierWave::Uploader::Base
   def store_dir: () -> String
-  def extension_allowlist: () -> Array[String]
+  def extension_allowlist: () -> Array[("jpg" | "jpeg" | "gif" | "png" | "webp")]
 end

--- a/spec/dummy/sig/rbs_infer/lib/rails_ext/active_storage_authorization.rbs
+++ b/spec/dummy/sig/rbs_infer/lib/rails_ext/active_storage_authorization.rbs
@@ -18,7 +18,7 @@ module ActiveStorage
 
     private
 
-    def bearer_token_authenticatable_request?: () -> bool
+    def bearer_token_authenticatable_request?: () -> true
     def publicly_accessible_blob?: () -> untyped
     def ensure_accessible: () -> untyped
     def http_cache_forever: (?public: untyped) ?{ (*untyped) -> untyped } -> untyped

--- a/spec/dummy/sig/rbs_infer/lib/rails_ext/relation_prepend_order.rbs
+++ b/spec/dummy/sig/rbs_infer/lib/rails_ext/relation_prepend_order.rbs
@@ -5,14 +5,14 @@ end
 module ActiveRecord
   class Relation
     def prepend_order: (*untyped args) -> untyped
-    def prepend_order_marker: () -> String
+    def prepend_order_marker: () -> "prepend_order"
   end
 end
 
 module ActiveRecord
   class AssociationRelation
     def prepend_order: (*untyped args) -> untyped
-    def prepend_order_marker: () -> String
+    def prepend_order_marker: () -> "prepend_order"
   end
 end
 

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/dashboard/show.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/dashboard/show.rbs
@@ -1,10 +1,10 @@
 class ERBDashboardShow
-  @account: (Account & Account::Validated)?
-  @recent_posts: Post::ActiveRecord_Relation?
+  @account: (Account & Account::Validated)
+  @recent_posts: Post::ActiveRecord_Relation
 
   include ActionViewContext
 
-  def initialize: (account: (Account & Account::Validated)?, recent_posts: Post::ActiveRecord_Relation?) -> void
+  def initialize: (account: Account & ::Account::Validated, recent_posts: Post::ActiveRecord_Relation) -> void
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/dashboard/show.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/dashboard/show.rbs
@@ -1,10 +1,10 @@
 class ERBDashboardShow
-  @account: (Account & Account::Validated)
-  @recent_posts: Post::ActiveRecord_Relation
+  @account: (Account & Account::Validated)?
+  @recent_posts: Post::ActiveRecord_Relation?
 
   include ActionViewContext
 
-  def initialize: (account: Account & ::Account::Validated, recent_posts: Post::ActiveRecord_Relation) -> void
+  def initialize: (account: (Account & Account::Validated)?, recent_posts: Post::ActiveRecord_Relation?) -> void
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/edit.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/edit.rbs
@@ -5,7 +5,7 @@ class ERBPostsEdit
   include PostsHelper
 
   def initialize: (post: Post & ::Post::Validated) -> void
-  def render: (?{ partial: String, locals: { post: Post & Post::Validated } }? target, *untyped rest) -> nil
+  def render: (?({ partial: "posts/form", locals: { post: Post & Post::Validated } } | { partial: "posts/summary", locals: { post: Post & Post::Validated } })? target, *untyped rest) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/new.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/new.rbs
@@ -5,7 +5,7 @@ class ERBPostsNew
   include PostsHelper
 
   def initialize: (post: Post) -> void
-  def render: (?{ partial: String, locals: { post: Post } }? target, *untyped rest) -> nil
+  def render: (?{ partial: "posts/form", locals: { post: Post } }? target, *untyped rest) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/show.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/posts/show.rbs
@@ -6,7 +6,7 @@ class ERBPostsShow
   include PostsHelper
 
   def initialize: (comments: Comment::ActiveRecord_Relation, post: Post & ::Post::Validated) -> void
-  def render: (?({ partial: String, locals: { comment: (Comment & Comment::Validated) } } | String)? target, *{ post: Post & Post::Validated } rest) -> nil
+  def render: (?({ partial: "comment", locals: { comment: (Comment & Comment::Validated) } } | "posts/summary")? target, *{ post: Post & Post::Validated } rest) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/users/avatars/edit.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/users/avatars/edit.rbs
@@ -1,9 +1,9 @@
 class ERBUsersAvatarsEdit
-  @user: (User & User::Validated)
+  @user: (User & User::Validated)?
 
   include ActionViewContext
 
-  def initialize: (user: User & ::User::Validated) -> void
+  def initialize: (user: (User & User::Validated)?) -> void
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/users/avatars/edit.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_actionview_runtime/users/avatars/edit.rbs
@@ -1,9 +1,9 @@
 class ERBUsersAvatarsEdit
-  @user: (User & User::Validated)?
+  @user: (User & User::Validated)
 
   include ActionViewContext
 
-  def initialize: (user: (User & User::Validated)?) -> void
+  def initialize: (user: User & ::User::Validated) -> void
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_activejob_runtime/active_job_base.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_activejob_runtime/active_job_base.rbs
@@ -1,5 +1,5 @@
 module ActiveJob
   class Base
-    def self.perform_later: (*(Post | { recipient: String? } | User & User::Validated | { sizes: Array[Integer] }) args, **untyped) -> ActiveJob::Base
+    def self.perform_later: (*(Post | { recipient: String? } | User & User::Validated | { sizes: Array[64 | 128] }) args, **untyped) -> ActiveJob::Base
   end
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_ar_runtime/assignment.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_ar_runtime/assignment.rbs
@@ -1,5 +1,5 @@
 class Assignment
-  def save: (**untyped) -> bool
+  def save: (**untyped) -> true
   def run_before_validation_callbacks: () -> User?
   def run_belongs_to_default_callbacks: () -> User?
   def run_belongs_to_default_owner: () -> User?

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_ar_runtime/notification/generated_store_accessors.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_ar_runtime/notification/generated_store_accessors.rbs
@@ -1,9 +1,9 @@
 class Notification
   module GeneratedStoreAccessors
-    @__store_settings_channel: String?
+    @__store_settings_channel: "none"?
 
     def channel: () -> String?
-    def channel=: (String? value) -> String?
+    def channel=: ("none"? value) -> "none"?
     def theme: () -> untyped
     def theme=: (untyped value) -> untyped
     def settings_digest: () -> untyped

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_ar_runtime/tag/generated_relation_methods.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_ar_runtime/tag/generated_relation_methods.rbs
@@ -1,7 +1,7 @@
 class Tag
   module GeneratedRelationMethods
     def popular: (?Integer limit) -> untyped
-    def default_limit: () -> Integer
+    def default_limit: () -> 10
     def named: (String value) -> (Tag & Tag::Validated)?
   end
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/action_controller/metal/http_authentication.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/action_controller/metal/http_authentication.rbs
@@ -2,13 +2,13 @@ module ActionController
   module HttpAuthentication
     module Token
       def authenticate: ((ActionController::Base & ActionController::HttpAuthentication::Token::ControllerMethods) controller) { (String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?) -> untyped } -> untyped
-      def authentication_request: ((ActionController::Base & ActionController::HttpAuthentication::Token::ControllerMethods) controller, String realm, ?untyped message) -> bool
+      def authentication_request: ((ActionController::Base & ActionController::HttpAuthentication::Token::ControllerMethods) controller, String realm, ?untyped message) -> true
     end
 
     module Token::ControllerMethods
       def authenticate_or_request_with_http_token: (?String realm, ?untyped message) { (String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?) -> untyped } -> untyped
       def authenticate_with_http_token: () { (String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?) -> untyped } -> untyped
-      def request_http_token_authentication: (?String realm, ?untyped message) -> bool
+      def request_http_token_authentication: (?String realm, ?untyped message) -> true
     end
   end
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/action_controller_base.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/action_controller_base.rbs
@@ -2,9 +2,9 @@ module ActionController
   class Base
     @__rbs_infer__performed: true?
 
-    def redirect_to: (*untyped args) -> bool
-    def render: (*{ plain: String, status: Symbol } args) -> bool
-    def head: (*untyped args) -> bool
+    def redirect_to: (*untyped args) -> true
+    def render: (*{ plain: String, status: :unauthorized } args) -> true
+    def head: (*untyped args) -> true
     def performed?: () -> true?
     def __rbs_infer__unknown_condition?: () -> untyped
   end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/dashboard_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/dashboard_controller.rbs
@@ -1,7 +1,7 @@
 class DashboardController
   @__rbs_infer__performed: true?
 
-  def render: (?:show? target, *untyped rest) -> true
+  def render: (?(:show)? target, *untyped rest) -> true
 
   private
 

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/dashboard_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/dashboard_controller.rbs
@@ -1,9 +1,9 @@
 class DashboardController
   @__rbs_infer__performed: true?
 
-  def render: (?Symbol? target, *untyped rest) -> bool
+  def render: (?:show? target, *untyped rest) -> true
 
   private
 
-  def __rbs_infer__run_show: () -> bool?
+  def __rbs_infer__run_show: () -> true?
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/posts_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/posts_controller.rbs
@@ -1,13 +1,13 @@
 class PostsController
   @__rbs_infer__performed: true?
 
-  def render: (?Symbol? target, *{ status: Symbol } rest) -> bool
+  def render: (?(:index | :show | :new | :edit)? target, *{ status: :unprocessable_entity } rest) -> true
 
   private
 
-  def __rbs_infer__run_index: () -> bool?
-  def __rbs_infer__run_show: () -> bool?
-  def __rbs_infer__run_new: () -> bool?
+  def __rbs_infer__run_index: () -> true?
+  def __rbs_infer__run_show: () -> true?
+  def __rbs_infer__run_new: () -> true?
   def __rbs_infer__run_create: () -> void
   def __rbs_infer__run_update: () -> void
   def __rbs_infer__run_destroy: () -> void

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/users_avatars_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/users_avatars_controller.rbs
@@ -2,7 +2,7 @@ module Users
   class AvatarsController
     @__rbs_infer__performed: true?
 
-    def render: (?:edit? target, *{ status: :unprocessable_entity } rest) -> true
+    def render: (?(:edit)? target, *{ status: :unprocessable_entity } rest) -> true
 
     private
 

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/users_avatars_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/users_avatars_controller.rbs
@@ -2,11 +2,11 @@ module Users
   class AvatarsController
     @__rbs_infer__performed: true?
 
-    def render: (?Symbol? target, *{ status: Symbol } rest) -> bool
+    def render: (?:edit? target, *{ status: :unprocessable_entity } rest) -> true
 
     private
 
-    def __rbs_infer__run_edit: () -> bool?
+    def __rbs_infer__run_edit: () -> true?
     def __rbs_infer__run_update: () -> void
   end
 end

--- a/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/users_controller.rbs
+++ b/spec/dummy/sig/rbs_infer/sig/generated/steep_controller_runtime/users_controller.rbs
@@ -1,11 +1,11 @@
 class UsersController
   @__rbs_infer__performed: true?
 
-  def render: (?(Symbol | String)? target, *untyped rest) -> bool
+  def render: (?(:show | "posts/show")? target, *untyped rest) -> true
 
   private
 
   def __rbs_infer__run_index: () -> void
-  def __rbs_infer__run_show: () -> bool?
+  def __rbs_infer__run_show: () -> true?
   def __rbs_infer__run_featured_post: () -> void
 end

--- a/spec/dummy/sig/rbs_rails/app/models/user.rbs
+++ b/spec/dummy/sig/rbs_rails/app/models/user.rbs
@@ -324,11 +324,8 @@ class ::User < ::ApplicationRecord
 
     def updated_at_for_database: () -> ::Time?
 
-    def avatar: () -> ::String?
 
-    def avatar=: (::String?) -> ::String?
 
-    def avatar?: () -> bool
 
     def avatar_changed?: (?from: ::String?, ?to: ::String?) -> bool
 

--- a/spec/dummy/sig/rbs_rails/app/models/user.rbs
+++ b/spec/dummy/sig/rbs_rails/app/models/user.rbs
@@ -324,8 +324,11 @@ class ::User < ::ApplicationRecord
 
     def updated_at_for_database: () -> ::Time?
 
+    def avatar: () -> ::String?
 
+    def avatar=: (::String?) -> ::String?
 
+    def avatar?: () -> bool
 
     def avatar_changed?: (?from: ::String?, ?to: ::String?) -> bool
 

--- a/spec/expectations/controllers/concerns/filter_configuration.rbs
+++ b/spec/expectations/controllers/concerns/filter_configuration.rbs
@@ -1,7 +1,7 @@
 module FilterConfiguration
   extend ActiveSupport::Concern
 
-  def configure_filter: (String name) -> untyped
+  def configure_filter: ("posts" name) -> untyped
 
   private
 

--- a/spec/expectations/helpers/application_helper.rbs
+++ b/spec/expectations/helpers/application_helper.rbs
@@ -1,5 +1,5 @@
 module ApplicationHelper
-  def test_helper_method: () -> String
+  def test_helper_method: () -> "I'm a helper method"
   def user_name_created_at: () -> ActiveSupport::TimeWithZone
   def user_label_tag: () -> String
 end

--- a/spec/expectations/helpers/posts_helper.rbs
+++ b/spec/expectations/helpers/posts_helper.rbs
@@ -1,7 +1,7 @@
 module PostsHelper
   def post_status_badge: ((Post & Post::Validated) post) -> String
   def post_summary: ((Post & Post::Validated) post, ?Integer length) -> String
-  def post_weights: (?Array[Integer] weights, ?Integer length, ?singleton(::Palette) klass) -> String
+  def post_weights: (?Array[Integer] weights, ?8 length, ?singleton(::Palette) klass) -> String
   def post_index_marker: ((Post & Post::Validated) post) -> String
   def comment_author_badge: (Comment & Comment::Validated comment) -> String
 end

--- a/spec/expectations/jobs/avatar_thumbnail_job.rbs
+++ b/spec/expectations/jobs/avatar_thumbnail_job.rbs
@@ -1,3 +1,3 @@
 class AvatarThumbnailJob < ApplicationJob
-  def perform: (User & User::Validated user, sizes: Array[(64 | 128)]) -> Array[Hash[Symbol, (String | Integer)]]
+  def perform: (User & User::Validated user, sizes: Array[(64 | 128)]) -> Array[Hash[(:owner | :width), (String | 64 | 128)]]
 end

--- a/spec/expectations/jobs/avatar_thumbnail_job.rbs
+++ b/spec/expectations/jobs/avatar_thumbnail_job.rbs
@@ -1,3 +1,3 @@
 class AvatarThumbnailJob < ApplicationJob
-  def perform: (User & User::Validated user, sizes: Array[Integer]) -> Array[Hash[Symbol, (String | Integer)]]
+  def perform: (User & User::Validated user, sizes: Array[(64 | 128)]) -> Array[Hash[Symbol, (String | Integer)]]
 end

--- a/spec/expectations/lib/rails_ext/active_storage_authorization.rbs
+++ b/spec/expectations/lib/rails_ext/active_storage_authorization.rbs
@@ -18,7 +18,7 @@ module ActiveStorage
 
     private
 
-    def bearer_token_authenticatable_request?: () -> bool
+    def bearer_token_authenticatable_request?: () -> true
     def publicly_accessible_blob?: () -> untyped
     def ensure_accessible: () -> untyped
     def http_cache_forever: (?public: untyped) ?{ (*untyped) -> untyped } -> untyped

--- a/spec/expectations/lib/rails_ext/relation_prepend_order.rbs
+++ b/spec/expectations/lib/rails_ext/relation_prepend_order.rbs
@@ -5,14 +5,14 @@ end
 module ActiveRecord
   class Relation
     def prepend_order: (*untyped args) -> untyped
-    def prepend_order_marker: () -> String
+    def prepend_order_marker: () -> "prepend_order"
   end
 end
 
 module ActiveRecord
   class AssociationRelation
     def prepend_order: (*untyped args) -> untyped
-    def prepend_order_marker: () -> String
+    def prepend_order_marker: () -> "prepend_order"
   end
 end
 

--- a/spec/expectations/models/cbor_like.rbs
+++ b/spec/expectations/models/cbor_like.rbs
@@ -1,10 +1,10 @@
 class CborLike
-  @max_depth: Integer
-  @limit: Integer
+  @max_depth: 16
+  @limit: 16
   @depth: Integer
 
-  MAX_DEPTH: Integer
+  MAX_DEPTH: 16
 
-  def initialize: (?max_depth: Integer) -> 0
+  def initialize: (?max_depth: 16) -> 0
   def levels: () -> Array[untyped]
 end

--- a/spec/expectations/models/cbor_like.rbs
+++ b/spec/expectations/models/cbor_like.rbs
@@ -5,6 +5,6 @@ class CborLike
 
   MAX_DEPTH: Integer
 
-  def initialize: (?max_depth: Integer) -> Integer
+  def initialize: (?max_depth: Integer) -> 0
   def levels: () -> Array[untyped]
 end

--- a/spec/expectations/models/coupon/code.rbs
+++ b/spec/expectations/models/coupon/code.rbs
@@ -1,5 +1,5 @@
 class Coupon
   module Code
-    def self.generate: (Integer length) -> String
+    def self.generate: (8 length) -> String
   end
 end

--- a/spec/expectations/models/eval_reopen.rbs
+++ b/spec/expectations/models/eval_reopen.rbs
@@ -1,9 +1,9 @@
 class EvalReopen
   include ::EvalReopen::Slots
 
-  def own: () -> String
-  def by_class_eval: () -> Integer
+  def own: () -> "own"
+  def by_class_eval: () -> 2
   def tagged: (:draft value, ?Integer limit) -> String
   def slot: () -> String
-  def by_module_eval: () -> Symbol
+  def by_module_eval: () -> :three
 end

--- a/spec/expectations/models/eval_reopen.rbs
+++ b/spec/expectations/models/eval_reopen.rbs
@@ -3,7 +3,7 @@ class EvalReopen
 
   def own: () -> String
   def by_class_eval: () -> Integer
-  def tagged: (Symbol value, ?Integer limit) -> String
+  def tagged: (:draft value, ?Integer limit) -> String
   def slot: () -> String
   def by_module_eval: () -> Symbol
 end

--- a/spec/expectations/models/eval_reopen/slots.rbs
+++ b/spec/expectations/models/eval_reopen/slots.rbs
@@ -1,8 +1,8 @@
 class EvalReopen
   module Slots
-    @slot: String?
+    @slot: "value"?
 
     def slot: () -> String?
-    def slot=: ("value" value) -> String?
+    def slot=: ("value"? value) -> "value"?
   end
 end

--- a/spec/expectations/models/eval_reopen/slots.rbs
+++ b/spec/expectations/models/eval_reopen/slots.rbs
@@ -3,6 +3,6 @@ class EvalReopen
     @slot: String?
 
     def slot: () -> String?
-    def slot=: (String? value) -> String?
+    def slot=: ("value" value) -> String?
   end
 end

--- a/spec/expectations/models/eventable.rbs
+++ b/spec/expectations/models/eventable.rbs
@@ -1,5 +1,5 @@
 module Eventable
   extend ActiveSupport::Concern
 
-  def track_event: ((Symbol | String) action, **untyped) -> { action: (Symbol | String), particulars: untyped }
+  def track_event: ((:published | "renamed" | :closed | :reopened) action, **untyped) -> { action: (:published | "renamed" | :closed | :reopened), particulars: untyped }
 end

--- a/spec/expectations/models/example.rbs
+++ b/spec/expectations/models/example.rbs
@@ -1,18 +1,14 @@
 class Column
   attr_accessor board: Board?
   attr_accessor column_name: "To Do"
-  attr_accessor user_name: String?
+  attr_accessor user_name: "John Doe"?
 
   def initialize: (column_name: "To Do") -> void
-  def set_default_user_name: () -> String
+  def set_default_user_name: () -> "John Doe"
   def save: () -> true
 
-  class AfterInitialize
-    attr_reader column_name: String
-  end
-
   class AfterSetDefaultUserName
-    attr_reader user_name: String
+    attr_reader user_name: "John Doe"
   end
 end
 
@@ -20,10 +16,6 @@ class Board
   attr_reader user_name: "John Doe"
 
   def initialize: (user_name: "John Doe") -> void
-
-  class AfterInitialize
-    attr_reader user_name: String
-  end
 end
 
 class Example

--- a/spec/expectations/models/example.rbs
+++ b/spec/expectations/models/example.rbs
@@ -1,11 +1,15 @@
 class Column
   attr_accessor board: Board?
-  attr_accessor column_name: String
+  attr_accessor column_name: "To Do"
   attr_accessor user_name: String?
 
-  def initialize: (column_name: String) -> void
+  def initialize: (column_name: "To Do") -> void
   def set_default_user_name: () -> String
-  def save: () -> bool
+  def save: () -> true
+
+  class AfterInitialize
+    attr_reader column_name: String
+  end
 
   class AfterSetDefaultUserName
     attr_reader user_name: String
@@ -13,9 +17,13 @@ class Column
 end
 
 class Board
-  attr_reader user_name: String
+  attr_reader user_name: "John Doe"
 
-  def initialize: (user_name: String) -> void
+  def initialize: (user_name: "John Doe") -> void
+
+  class AfterInitialize
+    attr_reader user_name: String
+  end
 end
 
 class Example

--- a/spec/expectations/models/example10.rbs
+++ b/spec/expectations/models/example10.rbs
@@ -7,7 +7,7 @@ class Example10
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> String
+    def self.name=: ("John Doe" value) -> String
   end
 end
 

--- a/spec/expectations/models/example10.rbs
+++ b/spec/expectations/models/example10.rbs
@@ -4,10 +4,10 @@ end
 
 class Example10
   class Foo
-    self.@name: String?
+    self.@name: "John Doe"?
 
     def self.name: () -> String?
-    def self.name=: ("John Doe" value) -> String
+    def self.name=: ("John Doe" value) -> "John Doe"
   end
 end
 

--- a/spec/expectations/models/example11.rbs
+++ b/spec/expectations/models/example11.rbs
@@ -1,6 +1,6 @@
 class Example11
   class Post
-    def title: () -> String
+    def title: () -> "Hello"
   end
 end
 

--- a/spec/expectations/models/example12.rbs
+++ b/spec/expectations/models/example12.rbs
@@ -6,5 +6,5 @@ class Example12
   def run_age: () -> (String | Integer | nil)
   def dispatch_name: () -> (String | Integer | nil)
   def dispatch_age: () -> (String | Integer | nil)
-  def show: (Symbol which) -> (String | Integer | nil)
+  def show: ((:name | :age) which) -> (String | Integer | nil)
 end

--- a/spec/expectations/models/example13.rbs
+++ b/spec/expectations/models/example13.rbs
@@ -27,9 +27,9 @@ class Example13
     @name: String
     @halted: false | true
 
-    def initialize: (name: String) -> bool
+    def initialize: (name: "John Doe") -> false
     def current_user: () -> Example13Viewer?
-    def halt: () -> bool
+    def halt: () -> true
     def with_format: () ?{ (Symbol) -> bool } -> bool?
     def guard_supported: () -> Example13Viewer?
     def run_supported: () -> String?
@@ -61,11 +61,15 @@ class Example13Viewer
   attr_reader name: String
 
   def initialize: (name: String) -> void
-  def active?: () -> bool
+  def active?: () -> true
 end
 
 class Example13Tenant
-  attr_reader label: String
+  attr_reader label: "acme"
 
-  def initialize: (label: String) -> void
+  def initialize: (label: "acme") -> void
+
+  class AfterInitialize
+    attr_reader label: String
+  end
 end

--- a/spec/expectations/models/example13.rbs
+++ b/spec/expectations/models/example13.rbs
@@ -24,13 +24,13 @@ end
 
 class Example13
   class Guarded
-    @name: String
+    @name: "John Doe"
     @halted: false | true
 
     def initialize: (name: "John Doe") -> false
     def current_user: () -> Example13Viewer?
     def halt: () -> true
-    def with_format: () ?{ (Symbol) -> bool } -> bool?
+    def with_format: () ?{ (:html) -> true } -> bool?
     def guard_supported: () -> Example13Viewer?
     def run_supported: () -> String?
     def act_supported: () -> String
@@ -68,8 +68,4 @@ class Example13Tenant
   attr_reader label: "acme"
 
   def initialize: (label: "acme") -> void
-
-  class AfterInitialize
-    attr_reader label: String
-  end
 end

--- a/spec/expectations/models/example14.rbs
+++ b/spec/expectations/models/example14.rbs
@@ -16,9 +16,5 @@ class Example14
     attr_reader name: "Joe"
 
     def initialize: (name: "Joe") -> void
-
-    class AfterInitialize
-      attr_reader name: String
-    end
   end
 end

--- a/spec/expectations/models/example14.rbs
+++ b/spec/expectations/models/example14.rbs
@@ -6,15 +6,19 @@ class Example14
 
   private
 
-  def halt: () -> bool
+  def halt: () -> true
   def verify: () -> Example14::User
   def set_user: () -> Example14::User
 end
 
 class Example14
   class User
-    attr_reader name: String
+    attr_reader name: "Joe"
 
-    def initialize: (name: String) -> void
+    def initialize: (name: "Joe") -> void
+
+    class AfterInitialize
+      attr_reader name: String
+    end
   end
 end

--- a/spec/expectations/models/example15.rbs
+++ b/spec/expectations/models/example15.rbs
@@ -15,10 +15,6 @@ class Example15
     attr_reader name: "Joe"
 
     def initialize: (name: "Joe") -> void
-
-    class AfterInitialize
-      attr_reader name: String
-    end
   end
 end
 

--- a/spec/expectations/models/example15.rbs
+++ b/spec/expectations/models/example15.rbs
@@ -5,16 +5,20 @@ class Example15
 
   private
 
-  def halt: () -> bool
+  def halt: () -> true
   def verify: () -> Example15::User
   def set_user: () -> Example15::User
 end
 
 class Example15
   class User
-    attr_reader name: String
+    attr_reader name: "Joe"
 
-    def initialize: (name: String) -> void
+    def initialize: (name: "Joe") -> void
+
+    class AfterInitialize
+      attr_reader name: String
+    end
   end
 end
 

--- a/spec/expectations/models/example16.rbs
+++ b/spec/expectations/models/example16.rbs
@@ -10,16 +10,20 @@ class Example16
   def resume: () -> Example16::User?
   def from_token: () -> (Example16::User | bool)
   def deny: () -> bool
-  def halt: () -> bool
+  def halt: () -> true
   def cookie?: () -> bool
   def token?: () -> bool
 end
 
 class Example16
   class User
-    attr_reader name: String
+    attr_reader name: ("cookie" | "token")
 
-    def initialize: (name: String) -> void
+    def initialize: (name: ("cookie" | "token")) -> void
+
+    class AfterInitialize
+      attr_reader name: String
+    end
   end
 end
 

--- a/spec/expectations/models/example16.rbs
+++ b/spec/expectations/models/example16.rbs
@@ -9,7 +9,7 @@ class Example16
   def authenticate: () -> (Example16::User | bool)
   def resume: () -> Example16::User?
   def from_token: () -> (Example16::User | bool)
-  def deny: () -> bool
+  def deny: () -> true
   def halt: () -> true
   def cookie?: () -> bool
   def token?: () -> bool
@@ -20,10 +20,6 @@ class Example16
     attr_reader name: ("cookie" | "token")
 
     def initialize: (name: ("cookie" | "token")) -> void
-
-    class AfterInitialize
-      attr_reader name: String
-    end
   end
 end
 

--- a/spec/expectations/models/example17.rbs
+++ b/spec/expectations/models/example17.rbs
@@ -1,14 +1,14 @@
 class Example17
-  def with_token: () { (String) -> String } -> String
-  def with_optional: () ?{ (String) -> untyped } -> untyped
-  def with_yield: () { (String) -> untyped } -> untyped
+  def with_token: () { ("token") -> String } -> String
+  def with_optional: () ?{ ("token") -> untyped } -> untyped
+  def with_yield: () { ("token") -> untyped } -> untyped
   def with_pair: () { (String, Integer) -> untyped } -> untyped
-  def with_either: (untyped flag) { (String | Integer) -> untyped } -> untyped
-  def forward_required: () { (String) -> untyped } -> String
+  def with_either: (untyped flag) { ("text" | 42) -> untyped } -> untyped
+  def forward_required: () { ("token") -> untyped } -> String
   def forward_optional: () ?{ (*untyped) -> untyped } -> untyped
   def forward_guarded: () ?{ (*untyped) -> untyped } -> String?
-  def forward_anonymous: () { (String) -> untyped } -> String
+  def forward_anonymous: () { ("token") -> untyped } -> String
   def forward_anonymous_guarded: () ?{ (*untyped) -> untyped } -> String?
-  def name: () -> String
+  def name: () -> "example"
   def run: () -> String
 end

--- a/spec/expectations/models/example18.rbs
+++ b/spec/expectations/models/example18.rbs
@@ -11,16 +11,20 @@ class Example18
   def with_token: () { (String) -> Example18::User? } -> (Example18::User | bool)
   def fetch_token: () { (String) -> Example18::User? } -> Example18::User?
   def deny: () -> bool
-  def halt: () -> bool
+  def halt: () -> true
   def lookup: (String token) -> Example18::User?
   def token_value: () -> String
 end
 
 class Example18
   class User
-    attr_reader name: String
+    attr_reader name: "token"
 
-    def initialize: (name: String) -> void
+    def initialize: (name: "token") -> void
+
+    class AfterInitialize
+      attr_reader name: String
+    end
   end
 end
 

--- a/spec/expectations/models/example18.rbs
+++ b/spec/expectations/models/example18.rbs
@@ -10,7 +10,7 @@ class Example18
   def from_token: () -> (Example18::User | bool)
   def with_token: () { (String) -> Example18::User? } -> (Example18::User | bool)
   def fetch_token: () { (String) -> Example18::User? } -> Example18::User?
-  def deny: () -> bool
+  def deny: () -> true
   def halt: () -> true
   def lookup: (String token) -> Example18::User?
   def token_value: () -> String
@@ -21,10 +21,6 @@ class Example18
     attr_reader name: "token"
 
     def initialize: (name: "token") -> void
-
-    class AfterInitialize
-      attr_reader name: String
-    end
   end
 end
 

--- a/spec/expectations/models/example19.rbs
+++ b/spec/expectations/models/example19.rbs
@@ -1,15 +1,15 @@
 class Example19
   @halted: true?
-  @message: String?
+  @message: "denied"?
 
   module Responder
-    def self.deny: (Example19 host, "denied" message) -> bool
+    def self.deny: (Example19 host, "denied" message) -> true
   end
 
   def show: () -> String
   def call: () -> String?
   def halt: () -> true
-  def record: (String? message) -> String?
+  def record: ("denied"? message) -> String?
 
   private
 
@@ -17,7 +17,7 @@ class Example19
   def from_token: () -> (Example19::User | bool)
   def with_token: () { (String) -> Example19::User? } -> (Example19::User | bool)
   def fetch_token: () { (String) -> Example19::User? } -> Example19::User?
-  def refuse: () -> bool
+  def refuse: () -> true
   def lookup: (String token) -> Example19::User?
   def token_value: () -> String
 end
@@ -27,10 +27,6 @@ class Example19
     attr_reader name: "token"
 
     def initialize: (name: "token") -> void
-
-    class AfterInitialize
-      attr_reader name: String
-    end
   end
 end
 

--- a/spec/expectations/models/example19.rbs
+++ b/spec/expectations/models/example19.rbs
@@ -3,12 +3,12 @@ class Example19
   @message: String?
 
   module Responder
-    def self.deny: (Example19 host, String message) -> bool
+    def self.deny: (Example19 host, "denied" message) -> bool
   end
 
   def show: () -> String
   def call: () -> String?
-  def halt: () -> bool
+  def halt: () -> true
   def record: (String? message) -> String?
 
   private
@@ -24,9 +24,13 @@ end
 
 class Example19
   class User
-    attr_reader name: String
+    attr_reader name: "token"
 
-    def initialize: (name: String) -> void
+    def initialize: (name: "token") -> void
+
+    class AfterInitialize
+      attr_reader name: String
+    end
   end
 end
 

--- a/spec/expectations/models/example2.rbs
+++ b/spec/expectations/models/example2.rbs
@@ -4,9 +4,13 @@ end
 
 class Example2
   class User
-    attr_reader name: String
+    attr_reader name: "John Doe"
 
-    def initialize: (name: String) -> void
+    def initialize: (name: "John Doe") -> void
+
+    class AfterInitialize
+      attr_reader name: String
+    end
   end
 end
 

--- a/spec/expectations/models/example2.rbs
+++ b/spec/expectations/models/example2.rbs
@@ -7,23 +7,19 @@ class Example2
     attr_reader name: "John Doe"
 
     def initialize: (name: "John Doe") -> void
-
-    class AfterInitialize
-      attr_reader name: String
-    end
   end
 end
 
 class Example2
   class Foo
     attr_reader user: untyped
-    attr_reader name: String?
-    attr_writer name: String?
+    attr_reader name: "John Doe"?
+    attr_writer name: "John Doe"?
 
-    def user=: (Example2::User value) -> String
+    def user=: (Example2::User value) -> "John Doe"
 
     class AfterUser
-      attr_reader name: String
+      attr_reader name: "John Doe"
       attr_reader user: Example2::User
     end
   end

--- a/spec/expectations/models/example20.rbs
+++ b/spec/expectations/models/example20.rbs
@@ -3,12 +3,12 @@ class Example20
   @message: String?
 
   module Responder
-    def self.deny: (Example20 host, String message) -> bool
+    def self.deny: (Example20 host, "denied" message) -> bool
   end
 
   def show: () -> String
   def call: () -> String?
-  def halt: () -> bool
+  def halt: () -> true
   def record: (String? message) -> String?
 
   private
@@ -26,9 +26,13 @@ end
 
 class Example20
   class User
-    attr_reader name: String
+    attr_reader name: "token"
 
-    def initialize: (name: String) -> void
+    def initialize: (name: "token") -> void
+
+    class AfterInitialize
+      attr_reader name: String
+    end
   end
 end
 

--- a/spec/expectations/models/example20.rbs
+++ b/spec/expectations/models/example20.rbs
@@ -1,15 +1,15 @@
 class Example20
   @halted: true?
-  @message: String?
+  @message: "denied"?
 
   module Responder
-    def self.deny: (Example20 host, "denied" message) -> bool
+    def self.deny: (Example20 host, "denied" message) -> true
   end
 
   def show: () -> String
   def call: () -> String?
   def halt: () -> true
-  def record: (String? message) -> String?
+  def record: ("denied"? message) -> String?
 
   private
 
@@ -17,7 +17,7 @@ class Example20
   def from_token: () -> (Example20::User | bool | nil)
   def with_token: () { (String) -> Example20::User? } -> (Example20::User | bool)
   def fetch_token: () { (String) -> Example20::User? } -> Example20::User?
-  def refuse: () -> bool
+  def refuse: () -> true
   def lookup: (String token) -> Example20::User?
   def bearer_request?: () -> bool
   def json_request?: () -> bool
@@ -29,10 +29,6 @@ class Example20
     attr_reader name: "token"
 
     def initialize: (name: "token") -> void
-
-    class AfterInitialize
-      attr_reader name: String
-    end
   end
 end
 

--- a/spec/expectations/models/example21.rbs
+++ b/spec/expectations/models/example21.rbs
@@ -13,10 +13,6 @@ class Example21
     attr_reader name: "holder"
 
     def initialize: (name: "holder") -> void
-
-    class AfterInitialize
-      attr_reader name: String
-    end
   end
 end
 

--- a/spec/expectations/models/example21.rbs
+++ b/spec/expectations/models/example21.rbs
@@ -10,9 +10,13 @@ end
 
 class Example21
   class Holder
-    attr_reader name: String
+    attr_reader name: "holder"
 
-    def initialize: (name: String) -> void
+    def initialize: (name: "holder") -> void
+
+    class AfterInitialize
+      attr_reader name: String
+    end
   end
 end
 

--- a/spec/expectations/models/example23.rbs
+++ b/spec/expectations/models/example23.rbs
@@ -15,7 +15,7 @@ class Example23
   class Bar
     extend ::Example23::Foo
 
-    def self.log_something: (String message) -> String
+    def self.log_something: ("bazingado" message) -> String
   end
 end
 
@@ -23,6 +23,6 @@ class Example23
   class BarOther
     extend ::Example23::Foo
 
-    def self.log_something: (String message) -> String
+    def self.log_something: ("bazingado" message) -> String
   end
 end

--- a/spec/expectations/models/example26.rbs
+++ b/spec/expectations/models/example26.rbs
@@ -25,6 +25,6 @@ class Example26
   class BarOther
     extend ::Example26::Foo
 
-    def self.log_something: (String message) -> String
+    def self.log_something: ("bazingado" message) -> String
   end
 end

--- a/spec/expectations/models/example27.rbs
+++ b/spec/expectations/models/example27.rbs
@@ -1,7 +1,7 @@
 class Example27
   module Foo
     def bazinga: (singleton(::Example27::Baz) module_included) -> nil
-    def bazingado: (?singleton(Example27::Bar)? base_foo, ?message: String?) -> nil
+    def bazingado: (?singleton(Example27::Bar)? base_foo, ?message: "Hello, world!"?) -> nil
   end
 
   module Baz

--- a/spec/expectations/models/example28.rbs
+++ b/spec/expectations/models/example28.rbs
@@ -19,11 +19,11 @@ class Example28
   class Bar
     extend ::Example28::Foo
 
-    def self.validade_age: () -> String
+    def self.validade_age: () -> "validating age"
 
-    def age: () -> Integer
-    def call_test: () -> String
-    def greet: () -> String
+    def age: () -> 42
+    def call_test: () -> "Hello, world!"
+    def greet: () -> "Hello, world!"
     def age_after_a_decade: () -> Integer
   end
 end

--- a/spec/expectations/models/example29.rbs
+++ b/spec/expectations/models/example29.rbs
@@ -23,11 +23,11 @@ class Example29
   class Bar
     extend ::Example29::Foo
 
-    def self.validade_age: () -> String
+    def self.validade_age: () -> "validating age"
 
-    def age: () -> Integer
-    def call_test: () -> String
-    def greet: () -> String
+    def age: () -> 42
+    def call_test: () -> "Hello, world!"
+    def greet: () -> "Hello, world!"
     def age_after_a_decade: () -> Integer
   end
 end
@@ -36,7 +36,7 @@ class Example29
   class BarOther
     extend ::Example29::Foo
 
-    def name: () -> String
+    def name: () -> "John Doe"
     def call_name_upcase: () -> String
     def name_upcase: () -> String
   end

--- a/spec/expectations/models/example3.rbs
+++ b/spec/expectations/models/example3.rbs
@@ -11,10 +11,6 @@ class Example3
     attr_reader name: ("John Doe" | "x")
 
     def initialize: (name: ("John Doe" | "x")) -> void
-
-    class AfterInitialize
-      attr_reader name: String
-    end
   end
 end
 
@@ -24,7 +20,7 @@ class Example3
 
     module GeneratedAttributes
       attr_accessor user: (Example3::User | nil)?
-      attr_accessor name: String?
+      attr_accessor name: ("John Doe" | "x")?
       attr_writer foo_instance: untyped
     end
 
@@ -33,10 +29,10 @@ class Example3
     def self.foo_instance: () -> Example3::Foo
     def self.user: () -> (Example3::User | nil)?
     def self.user=: ((Example3::User | nil) value) -> Example3::User?
-    def self.name: () -> String?
-    def self.name=: (String? value) -> String?
+    def self.name: () -> ("John Doe" | "x")?
+    def self.name=: (("John Doe" | "x")? value) -> ("John Doe" | "x" | nil)
     def self.clear_user: () -> nil
 
-    def user=: ((Example3::User | nil) value) -> String?
+    def user=: ((Example3::User | nil) value) -> ("John Doe" | "x" | nil)
   end
 end

--- a/spec/expectations/models/example3.rbs
+++ b/spec/expectations/models/example3.rbs
@@ -8,9 +8,13 @@ end
 
 class Example3
   class User
-    attr_reader name: String
+    attr_reader name: ("John Doe" | "x")
 
-    def initialize: (name: String) -> void
+    def initialize: (name: ("John Doe" | "x")) -> void
+
+    class AfterInitialize
+      attr_reader name: String
+    end
   end
 end
 

--- a/spec/expectations/models/example30.rbs
+++ b/spec/expectations/models/example30.rbs
@@ -1,6 +1,6 @@
 module Example30
   class Foo
-    def name: () -> String
+    def name: () -> "Foo"
     def build_age: () -> Symbol
     def call_age: () -> Integer
   end

--- a/spec/expectations/models/example30.rbs
+++ b/spec/expectations/models/example30.rbs
@@ -9,7 +9,7 @@ end
 module Example30
   class Foo
     class AfterBuildAge
-      def age: () -> Integer
+      def age: () -> 25
     end
   end
 end

--- a/spec/expectations/models/example32.rbs
+++ b/spec/expectations/models/example32.rbs
@@ -17,8 +17,8 @@ class Example32
 
     extend ::Example32::Foo
 
-    def test: () -> String
+    def test: () -> "test"
     def use_test: () -> String?
-    def age: () -> Integer
+    def age: () -> 31
   end
 end

--- a/spec/expectations/models/example33.rbs
+++ b/spec/expectations/models/example33.rbs
@@ -19,7 +19,7 @@ class Example33
   class Bar
     extend ::Example33::Foo
 
-    def age: () -> Integer
+    def age: () -> 31
   end
 end
 

--- a/spec/expectations/models/example33.rbs
+++ b/spec/expectations/models/example33.rbs
@@ -27,7 +27,7 @@ class Example33
   class BarOther
     extend ::Example33::Foo
 
-    def name: () -> String
+    def name: () -> "John Doe"
     def call_name_upcase: () -> String
     def name_upcase: () -> String
   end

--- a/spec/expectations/models/example34.rbs
+++ b/spec/expectations/models/example34.rbs
@@ -16,6 +16,6 @@ class Example34
     extend ::Example34::Foo
     include ::Example34::Baz
 
-    def age: () -> Integer
+    def age: () -> 31
   end
 end

--- a/spec/expectations/models/example35.rbs
+++ b/spec/expectations/models/example35.rbs
@@ -15,6 +15,6 @@ end
 class Example35
   class Bar < Baz
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end

--- a/spec/expectations/models/example36.rbs
+++ b/spec/expectations/models/example36.rbs
@@ -15,6 +15,6 @@ end
 class Example36
   class Bar < Baz
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end

--- a/spec/expectations/models/example37.rbs
+++ b/spec/expectations/models/example37.rbs
@@ -18,6 +18,6 @@ class Example37
     extend ::Example37::Foo
 
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end

--- a/spec/expectations/models/example38.rbs
+++ b/spec/expectations/models/example38.rbs
@@ -27,7 +27,7 @@ class Example38
     extend ::Example38::Foo
 
     def call_age: () -> Integer
-    def age: () -> Integer
-    def name: () -> String
+    def age: () -> 31
+    def name: () -> "John Doe"
   end
 end

--- a/spec/expectations/models/example39.rbs
+++ b/spec/expectations/models/example39.rbs
@@ -16,6 +16,6 @@ module Example39
   class Bar
     extend ::Example39::Foo
 
-    def call_age: () -> Integer
+    def call_age: () -> BigDecimal
   end
 end

--- a/spec/expectations/models/example39.rbs
+++ b/spec/expectations/models/example39.rbs
@@ -16,6 +16,6 @@ module Example39
   class Bar
     extend ::Example39::Foo
 
-    def call_age: () -> BigDecimal
+    def call_age: () -> Integer
   end
 end

--- a/spec/expectations/models/example4.rbs
+++ b/spec/expectations/models/example4.rbs
@@ -5,10 +5,10 @@ end
 
 class Example4
   class Foo
-    self.@name: String?
+    self.@name: "John Doe"?
 
     def self.name: () -> String?
-    def self.name=: (("John Doe" | nil) value) -> String?
+    def self.name=: (("John Doe" | nil) value) -> "John Doe"?
   end
 end
 

--- a/spec/expectations/models/example4.rbs
+++ b/spec/expectations/models/example4.rbs
@@ -8,7 +8,7 @@ class Example4
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: ((String | nil) value) -> String?
+    def self.name=: (("John Doe" | nil) value) -> String?
   end
 end
 

--- a/spec/expectations/models/example40.rbs
+++ b/spec/expectations/models/example40.rbs
@@ -35,7 +35,7 @@ class Example40
     extend ::Example40::Foo
 
     def call_age: () -> Integer
-    def age: () -> Integer
-    def name: () -> String
+    def age: () -> 31
+    def name: () -> "John Doe"
   end
 end

--- a/spec/expectations/models/example41.rbs
+++ b/spec/expectations/models/example41.rbs
@@ -15,6 +15,6 @@ class Example41
     extend ::Example41::Foo
     include ::Example41::Baz
 
-    def age: () -> Integer
+    def age: () -> 31
   end
 end

--- a/spec/expectations/models/example42.rbs
+++ b/spec/expectations/models/example42.rbs
@@ -21,7 +21,7 @@ class Example42
     extend ::Example42::Foo
 
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end
 
@@ -30,6 +30,6 @@ class Example42
     extend ::Example42::Foo
 
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end

--- a/spec/expectations/models/example43.rbs
+++ b/spec/expectations/models/example43.rbs
@@ -27,7 +27,7 @@ class Example43
     extend ::Example43::Foo
 
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end
 
@@ -36,7 +36,7 @@ class Example43
     extend ::Example43::Foo
 
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end
 
@@ -46,7 +46,7 @@ class Example43
 
     def call_age: () -> Integer
     def call_name: () -> String
-    def age: () -> Integer
-    def name: () -> String
+    def age: () -> 31
+    def name: () -> "John Doe"
   end
 end

--- a/spec/expectations/models/example44.rbs
+++ b/spec/expectations/models/example44.rbs
@@ -16,7 +16,7 @@ class Example44
     include ::Example44::Baz
 
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end
 
@@ -26,6 +26,6 @@ class Example44
     include ::Example44::Baz
 
     def call_age: () -> Integer
-    def age: () -> Integer
+    def age: () -> 31
   end
 end

--- a/spec/expectations/models/example45.rbs
+++ b/spec/expectations/models/example45.rbs
@@ -16,7 +16,7 @@ class Example45
     include ::Example45::Baz
 
     def self.call_age: () -> Integer
-    def self.age: () -> Integer
+    def self.age: () -> 31
   end
 end
 
@@ -25,6 +25,6 @@ class Example45
     include ::Example45::Baz
 
     def self.call_age: () -> Integer
-    def self.age: () -> Integer
+    def self.age: () -> 31
   end
 end

--- a/spec/expectations/models/example47.rbs
+++ b/spec/expectations/models/example47.rbs
@@ -20,8 +20,8 @@ end
 class Example47
   module Baz
     module BananaMethods
-      def color: () -> String
-      def age: () -> Integer
+      def color: () -> "yellow"
+      def age: () -> 31
     end
   end
 end

--- a/spec/expectations/models/example48.rbs
+++ b/spec/expectations/models/example48.rbs
@@ -8,7 +8,7 @@ class Example48
   end
 
   module Baz::BananaMethods
-    def age: () -> Integer
+    def age: () -> 31
   end
 end
 

--- a/spec/expectations/models/example49.rbs
+++ b/spec/expectations/models/example49.rbs
@@ -9,7 +9,7 @@ end
 
 class Example49
   module Baz
-    def color: () -> String
-    def age: () -> Integer
+    def color: () -> "yellow"
+    def age: () -> 31
   end
 end

--- a/spec/expectations/models/example5.rbs
+++ b/spec/expectations/models/example5.rbs
@@ -7,7 +7,7 @@ class Example5
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> String
+    def self.name=: ("John Doe" value) -> String
   end
 end
 

--- a/spec/expectations/models/example5.rbs
+++ b/spec/expectations/models/example5.rbs
@@ -4,10 +4,10 @@ end
 
 class Example5
   class Foo
-    self.@name: String?
+    self.@name: "John Doe"?
 
     def self.name: () -> String?
-    def self.name=: ("John Doe" value) -> String
+    def self.name=: ("John Doe" value) -> "John Doe"
   end
 end
 

--- a/spec/expectations/models/example50.rbs
+++ b/spec/expectations/models/example50.rbs
@@ -20,8 +20,8 @@ end
 class Example50
   module Baz
     module BananaMethods
-      def color: () -> String
-      def age: () -> Integer
+      def color: () -> "yellow"
+      def age: () -> 31
     end
   end
 end

--- a/spec/expectations/models/example51.rbs
+++ b/spec/expectations/models/example51.rbs
@@ -17,7 +17,7 @@ end
 class Example51
   module Baz
     module BananaMethods
-      def age: () -> Integer
+      def age: () -> 31
     end
   end
 end

--- a/spec/expectations/models/example52.rbs
+++ b/spec/expectations/models/example52.rbs
@@ -21,7 +21,7 @@ end
 class Example52
   module Baz
     module BananaMethods
-      def age: () -> Integer
+      def age: () -> 31
     end
   end
 end

--- a/spec/expectations/models/example53.rbs
+++ b/spec/expectations/models/example53.rbs
@@ -14,7 +14,7 @@ class Example53
     extend ::Example53::Baz::BananaMethods
     include ::Example53::Baz
 
-    def self.origin: () -> String
+    def self.origin: () -> "farm"
     def self.call_age: () -> Integer
   end
 end

--- a/spec/expectations/models/example54/baz.rbs
+++ b/spec/expectations/models/example54/baz.rbs
@@ -12,7 +12,7 @@ end
 class Example54
   module Baz
     module BananaMethods
-      def age: () -> Integer
+      def age: () -> 31
     end
   end
 end

--- a/spec/expectations/models/example55/baz.rbs
+++ b/spec/expectations/models/example55/baz.rbs
@@ -7,7 +7,7 @@ end
 class Example55
   module Baz
     module BananaMethods
-      def age: () -> Integer
+      def age: () -> 31
     end
   end
 end

--- a/spec/expectations/models/example56.rbs
+++ b/spec/expectations/models/example56.rbs
@@ -4,10 +4,10 @@ end
 
 class Example56
   class Reader
-    def name: () -> String
+    def name: () -> "farm"
     def maybe_name: () -> String?
     def label: () -> String
     def shout: () -> String
-    def maybe_label: () -> String?
+    def maybe_label: () -> "loud"?
   end
 end

--- a/spec/expectations/models/example57.rbs
+++ b/spec/expectations/models/example57.rbs
@@ -2,7 +2,7 @@ class Example57
   include Fields
 
   def window_size: () -> Integer
-  def creation_window: () -> Integer
+  def creation_window: () -> 7
 end
 
 class Example57
@@ -10,6 +10,6 @@ class Example57
     include Example57Windowed
 
     def doubled: () -> Integer
-    def window_days: () -> Integer
+    def window_days: () -> 30
   end
 end

--- a/spec/expectations/models/example6.rbs
+++ b/spec/expectations/models/example6.rbs
@@ -7,7 +7,7 @@ class Example6
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> String
+    def self.name=: ("John Doe" value) -> String
   end
 end
 

--- a/spec/expectations/models/example6.rbs
+++ b/spec/expectations/models/example6.rbs
@@ -4,10 +4,10 @@ end
 
 class Example6
   class Foo
-    self.@name: String?
+    self.@name: "John Doe"?
 
     def self.name: () -> String?
-    def self.name=: ("John Doe" value) -> String
+    def self.name=: ("John Doe" value) -> "John Doe"
   end
 end
 

--- a/spec/expectations/models/example61.rbs
+++ b/spec/expectations/models/example61.rbs
@@ -1,5 +1,5 @@
 class Example61
-  def self.normalize: ((Symbol | String) key) -> String
+  def self.normalize: ((:indexed_by | "indexed_by") key) -> String
 
   def normalized_key: () -> String
 end

--- a/spec/expectations/models/example62.rbs
+++ b/spec/expectations/models/example62.rbs
@@ -24,6 +24,6 @@ class Example62
 end
 
 class Example62Caller
-  def fill: () -> String
+  def fill: () -> "value"
   def read_hallmark: () -> String
 end

--- a/spec/expectations/models/example62/slots.rbs
+++ b/spec/expectations/models/example62/slots.rbs
@@ -3,6 +3,6 @@ class Example62
     @hallmark: String?
 
     def hallmark: () -> String?
-    def hallmark=: (String? value) -> String?
+    def hallmark=: ("value" value) -> String?
   end
 end

--- a/spec/expectations/models/example62/slots.rbs
+++ b/spec/expectations/models/example62/slots.rbs
@@ -1,8 +1,8 @@
 class Example62
   module Slots
-    @hallmark: String?
+    @hallmark: "value"?
 
     def hallmark: () -> String?
-    def hallmark=: ("value" value) -> String?
+    def hallmark=: ("value"? value) -> "value"?
   end
 end

--- a/spec/expectations/models/example65.rbs
+++ b/spec/expectations/models/example65.rbs
@@ -1,6 +1,6 @@
 class Example65
   class Dispatcher
-    def self.dispatch: (*(String | { greeting: String } | Integer | { step: Integer }) args, **untyped) -> Object
+    def self.dispatch: (*("ada" | { greeting: "hello" } | 1 | { step: 2 } | "/tmp/x.csv") args, **untyped) -> Object
 
     def handle: (*untyped) -> untyped
   end
@@ -8,7 +8,7 @@ end
 
 class Example65
   class Rival
-    def self.dispatch: (*(bool | { mode: Symbol }) args, **untyped) -> Object
+    def self.dispatch: (*(true | { mode: :fast }) args, **untyped) -> Object
 
     def handle: (*untyped) -> untyped
   end

--- a/spec/expectations/models/example65_adder.rbs
+++ b/spec/expectations/models/example65_adder.rbs
@@ -1,3 +1,3 @@
 class Example65Adder < Example65::Dispatcher
-  def handle: (Integer count, step: Integer) -> Integer
+  def handle: (1 count, step: 2) -> Integer
 end

--- a/spec/expectations/models/example65_greeter.rbs
+++ b/spec/expectations/models/example65_greeter.rbs
@@ -1,3 +1,3 @@
 class Example65Greeter < Example65::Dispatcher
-  def handle: (String name, greeting: String) -> String
+  def handle: ("ada" name, greeting: "hello") -> String
 end

--- a/spec/expectations/models/example65_impostor.rbs
+++ b/spec/expectations/models/example65_impostor.rbs
@@ -1,3 +1,3 @@
 class Example65Impostor < Example65::Rival
-  def handle: (bool flag, mode: Symbol) -> Symbol?
+  def handle: (true flag, mode: :fast) -> Symbol?
 end

--- a/spec/expectations/models/example65_reporter.rbs
+++ b/spec/expectations/models/example65_reporter.rbs
@@ -1,3 +1,3 @@
 class Example65Reporter < Example65::Dispatcher
-  def handle: (String path) -> String
+  def handle: ("/tmp/x.csv" path) -> String
 end

--- a/spec/expectations/models/example66_trackable.rbs
+++ b/spec/expectations/models/example66_trackable.rbs
@@ -1,10 +1,10 @@
 module Example66Trackable
   alias flagged? flag
 
-  attr_accessor flag: bool?
+  attr_accessor flag: true?
 
-  def mark!: () -> bool
-  def relevant?: () -> bool
+  def mark!: () -> true
+  def relevant?: () -> false
 
   class AfterMark
     attr_reader flag: true

--- a/spec/expectations/models/example67_source.rbs
+++ b/spec/expectations/models/example67_source.rbs
@@ -1,6 +1,6 @@
 class Example67Source
   def enabled?: () -> bool
-  def window_size: () -> Integer
+  def window_size: () -> 30
   def window: () -> Example67Window?
   def windowed?: () -> bool
   def detect_spikes: () -> bool

--- a/spec/expectations/models/example69.rbs
+++ b/spec/expectations/models/example69.rbs
@@ -1,0 +1,17 @@
+module Example69
+  class Foo
+    def name: () -> String
+    def action: () -> String
+    def call_name_action: () -> String
+    def call_action: () -> String
+    def call_dynamic: () -> String
+    def call_dynamic_with_name: () -> String
+    def call_both: () -> Array[String]
+    def name_action_dynamic: (flag_name: bool) -> String
+    def call_unknown: (flag_name: untyped) -> String
+
+    private
+
+    def call: (?flag_name: bool) -> String
+  end
+end

--- a/spec/expectations/models/example69.rbs
+++ b/spec/expectations/models/example69.rbs
@@ -1,7 +1,7 @@
 module Example69
   class Foo
-    def name: () -> String
-    def action: () -> String
+    def name: () -> "name"
+    def action: () -> "delete"
     def call_name_action: () -> String
     def call_action: () -> String
     def call_dynamic: () -> String

--- a/spec/expectations/models/example7.rbs
+++ b/spec/expectations/models/example7.rbs
@@ -8,7 +8,7 @@ class Example7
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> String
+    def self.name=: ("John Doe" value) -> String
   end
 end
 
@@ -17,12 +17,12 @@ class Example7
     self.@value: Integer?
 
     def self.value: () -> Integer?
-    def self.value=: (Integer value) -> Integer
+    def self.value=: (42 value) -> Integer
   end
 end
 
 class Example7
   class Dispatcher
-    def show: (Symbol which) -> (String | Integer | nil)
+    def show: ((:name | :age) which) -> (String | Integer | nil)
   end
 end

--- a/spec/expectations/models/example7.rbs
+++ b/spec/expectations/models/example7.rbs
@@ -5,19 +5,19 @@ end
 
 class Example7
   class Foo
-    self.@name: String?
+    self.@name: "John Doe"?
 
     def self.name: () -> String?
-    def self.name=: ("John Doe" value) -> String
+    def self.name=: ("John Doe" value) -> "John Doe"
   end
 end
 
 class Example7
   class Age
-    self.@value: Integer?
+    self.@value: 42?
 
     def self.value: () -> Integer?
-    def self.value=: (42 value) -> Integer
+    def self.value=: (42 value) -> 42
   end
 end
 

--- a/spec/expectations/models/example8.rbs
+++ b/spec/expectations/models/example8.rbs
@@ -4,5 +4,5 @@ class Example8
 
   def run_name: () -> (String | Integer | nil)
   def run_age: () -> (String | Integer | nil)
-  def show: (Symbol which) -> (String | Integer | nil)
+  def show: ((:name | :age) which) -> (String | Integer | nil)
 end

--- a/spec/expectations/models/example9.rbs
+++ b/spec/expectations/models/example9.rbs
@@ -5,19 +5,19 @@ end
 
 class Example9
   class Foo
-    self.@name: String?
+    self.@name: "John Doe"?
 
     def self.name: () -> String?
-    def self.name=: ("John Doe" value) -> String
+    def self.name=: ("John Doe" value) -> "John Doe"
   end
 end
 
 class Example9
   class Age
-    self.@value: Integer?
+    self.@value: 42?
 
     def self.value: () -> Integer?
-    def self.value=: (42 value) -> Integer
+    def self.value=: (42 value) -> 42
   end
 end
 

--- a/spec/expectations/models/example9.rbs
+++ b/spec/expectations/models/example9.rbs
@@ -8,7 +8,7 @@ class Example9
     self.@name: String?
 
     def self.name: () -> String?
-    def self.name=: (String value) -> String
+    def self.name=: ("John Doe" value) -> String
   end
 end
 
@@ -17,12 +17,12 @@ class Example9
     self.@value: Integer?
 
     def self.value: () -> Integer?
-    def self.value=: (Integer value) -> Integer
+    def self.value=: (42 value) -> Integer
   end
 end
 
 class Example9
   class Dispatcher
-    def show: (Symbol which) -> (String | Integer | nil)
+    def show: ((:name | :age) which) -> (String | Integer | nil)
   end
 end

--- a/spec/expectations/models/included_hook.rbs
+++ b/spec/expectations/models/included_hook.rbs
@@ -20,11 +20,11 @@ class IncludedHook
   include Sugared
   include Homespun
 
-  def from_hook: () -> String
+  def from_hook: () -> "hook"
   def slot: () -> String
-  def from_sugar: () -> String
+  def from_sugar: () -> "sugar"
   def badge: () -> String
-  def from_homespun: () -> String
+  def from_homespun: () -> "homespun"
   def stamp: () -> String
 end
 
@@ -33,5 +33,5 @@ class IncludedHookCaller
   def read_slot: () -> String
   def read_badge: () -> String
   def read_stamp: () -> String
-  def read_shared: () -> Integer
+  def read_shared: () -> 1
 end

--- a/spec/expectations/models/included_hook/slots.rbs
+++ b/spec/expectations/models/included_hook/slots.rbs
@@ -1,14 +1,14 @@
 class IncludedHook
   module Slots
-    @slot: String?
-    @badge: String?
-    @stamp: String?
+    @slot: "value"?
+    @badge: "value"?
+    @stamp: "value"?
 
     def slot: () -> String?
-    def slot=: ("value" value) -> String?
+    def slot=: ("value"? value) -> "value"?
     def badge: () -> String?
-    def badge=: ("value" value) -> String?
+    def badge=: ("value"? value) -> "value"?
     def stamp: () -> String?
-    def stamp=: ("value" value) -> String?
+    def stamp=: ("value"? value) -> "value"?
   end
 end

--- a/spec/expectations/models/included_hook/slots.rbs
+++ b/spec/expectations/models/included_hook/slots.rbs
@@ -5,10 +5,10 @@ class IncludedHook
     @stamp: String?
 
     def slot: () -> String?
-    def slot=: (String? value) -> String?
+    def slot=: ("value" value) -> String?
     def badge: () -> String?
-    def badge=: (String? value) -> String?
+    def badge=: ("value" value) -> String?
     def stamp: () -> String?
-    def stamp=: (String? value) -> String?
+    def stamp=: ("value" value) -> String?
   end
 end

--- a/spec/expectations/models/notification.rbs
+++ b/spec/expectations/models/notification.rbs
@@ -1,6 +1,6 @@
 class Notification < ApplicationRecord
   def channel: () -> String
-  def mute!: () -> String
+  def mute!: () -> "none"
   def read?: () -> bool
   def headline: () -> String
 

--- a/spec/expectations/models/palette.rbs
+++ b/spec/expectations/models/palette.rbs
@@ -1,6 +1,6 @@
 class Palette
-  MAX: Integer
-  DEFAULT_NAME: String
+  MAX: 8
+  DEFAULT_NAME: "Blue"
   WEIGHTS: Array[Integer]
   COLORS: Array[Palette]
 

--- a/spec/expectations/models/post.rbs
+++ b/spec/expectations/models/post.rbs
@@ -19,9 +19,9 @@ class Post < ApplicationRecord
   def was_priority_high: () -> bool?
   def publish_in_transaction: () -> self
   def popular_tags: (?Integer limit) -> untyped
-  def tag_limit: () -> Integer
+  def tag_limit: () -> 10
   def tag_named: () -> (Tag & Tag::Validated)?
-  def sibling_tag_names: () -> Array[String]
+  def sibling_tag_names: () -> Array[("news" | "featured")]
   def iterate_tags: () -> Post_Tag::ActiveRecord_Associations_CollectionProxy
   def archive: () -> Post_Comment::ActiveRecord_Associations_CollectionProxy
   def archive_via_singleton: () -> Post_Comment::ActiveRecord_Associations_CollectionProxy

--- a/spec/expectations/models/send_dispatch.rbs
+++ b/spec/expectations/models/send_dispatch.rbs
@@ -3,6 +3,6 @@ class SendDispatch
 
   private
 
-  def stamp: (String value) -> String
-  def stamped?: (String value) -> bool
+  def stamp: (("post" | "a") value) -> String
+  def stamped?: ("stamped: post" value) -> bool
 end

--- a/spec/expectations/models/send_dispatch.rbs
+++ b/spec/expectations/models/send_dispatch.rbs
@@ -1,5 +1,5 @@
 class SendDispatch
-  def call: () -> String
+  def call: () -> "called"
 
   private
 

--- a/spec/expectations/models/singleton_ivar_probe.rbs
+++ b/spec/expectations/models/singleton_ivar_probe.rbs
@@ -5,9 +5,9 @@ class SingletonIvarProbe
 
   @instance_ivar: String
 
-  def self.configure: () -> String
-  def self.build: () -> String
-  def self.label: () -> String
+  def self.configure: () -> "custom"
+  def self.build: () -> "classe"
+  def self.label: () -> "singleton"
 
-  def initialize: () -> String
+  def initialize: () -> "instancia"
 end

--- a/spec/expectations/models/tag.rbs
+++ b/spec/expectations/models/tag.rbs
@@ -1,5 +1,5 @@
 class Tag < ApplicationRecord
   def self.popular: (?Integer limit) -> untyped
-  def self.default_limit: () -> Integer
+  def self.default_limit: () -> 10
   def self.named: (String value) -> (Tag & Tag::Validated)?
 end

--- a/spec/expectations/models/user/notifiable.rbs
+++ b/spec/expectations/models/user/notifiable.rbs
@@ -6,7 +6,7 @@ class User
     def notifications_count: () -> Integer
     def notify!: ("Welcome" title) -> Notification
     def notify_welcome!: () -> Notification
-    def mute_latest_notification!: () -> String?
+    def mute_latest_notification!: () -> "none"?
     def latest_notification_headline: () -> String?
   end
 end

--- a/spec/expectations/models/user/notifiable.rbs
+++ b/spec/expectations/models/user/notifiable.rbs
@@ -4,7 +4,7 @@ class User
 
     def unread_notifications: () -> Notification::ActiveRecord_Relation
     def notifications_count: () -> Integer
-    def notify!: (String title) -> Notification
+    def notify!: ("Welcome" title) -> Notification
     def notify_welcome!: () -> Notification
     def mute_latest_notification!: () -> String?
     def latest_notification_headline: () -> String?

--- a/spec/expectations/services/event_tracker.rbs
+++ b/spec/expectations/services/event_tracker.rbs
@@ -1,4 +1,4 @@
 class EventTracker
-  def track_event: (action: (String | Symbol)) -> { action: (String | Symbol) }
+  def track_event: (action: ("created" | :reported)) -> { action: ("created" | :reported) }
   def track_created: () -> { action: untyped }
 end

--- a/spec/expectations/services/post_filtering.rbs
+++ b/spec/expectations/services/post_filtering.rbs
@@ -1,14 +1,15 @@
 class PostFiltering
   attr_reader user: (User & User::Validated | User)
   attr_reader post: Post
-  attr_reader expanded: bool
+  attr_reader expanded: false
 
-  def initialize: ((User & User::Validated | User) user, Post post, ?expanded: bool) -> void
+  def initialize: ((User & User::Validated | User) user, Post post, ?expanded: false) -> void
   def expanded?: () -> bool
   def title: () -> String?
   def author_name: () -> String?
 
   class AfterInitialize
+    attr_reader expanded: bool
     attr_reader user: (User & User::Validated) | User
   end
 end

--- a/spec/expectations/services/post_filtering.rbs
+++ b/spec/expectations/services/post_filtering.rbs
@@ -9,7 +9,6 @@ class PostFiltering
   def author_name: () -> String?
 
   class AfterInitialize
-    attr_reader expanded: bool
     attr_reader user: (User & User::Validated) | User
   end
 end

--- a/spec/expectations/services/post_publisher.rbs
+++ b/spec/expectations/services/post_publisher.rbs
@@ -5,5 +5,5 @@ class PostPublisher
   attr_reader notifier: EmailNotifier
 
   def initialize: (Post post, ?notifier: EmailNotifier) -> void
-  def call: () -> bool
+  def call: () -> true
 end

--- a/spec/expectations/services/post_publisher.rbs
+++ b/spec/expectations/services/post_publisher.rbs
@@ -5,5 +5,5 @@ class PostPublisher
   attr_reader notifier: EmailNotifier
 
   def initialize: (Post post, ?notifier: EmailNotifier) -> void
-  def call: () -> true
+  def call: () -> bool
 end

--- a/spec/expectations/services/profile_formatter.rbs
+++ b/spec/expectations/services/profile_formatter.rbs
@@ -1,11 +1,15 @@
 class ProfileFormatter
-  attr_reader nickname: (String | nil)
+  attr_reader nickname: ("ada" | nil)
 
-  def initialize: (nickname: (String | nil)) -> void
+  def initialize: (nickname: ("ada" | nil)) -> void
   def call: () -> untyped
   def call_without_check: () -> untyped
 
   private
 
   def format_nickname: () -> untyped
+
+  class AfterInitialize
+    attr_reader nickname: String?
+  end
 end

--- a/spec/expectations/services/profile_formatter.rbs
+++ b/spec/expectations/services/profile_formatter.rbs
@@ -8,8 +8,4 @@ class ProfileFormatter
   private
 
   def format_nickname: () -> untyped
-
-  class AfterInitialize
-    attr_reader nickname: String?
-  end
 end

--- a/spec/expectations/services/widget_auditor.rbs
+++ b/spec/expectations/services/widget_auditor.rbs
@@ -2,5 +2,5 @@ class WidgetAuditor
   attr_reader widget: (Widget & Widget::Closeable)
 
   def initialize: ((Widget & Widget::Closeable) widget) -> void
-  def audit: () -> bool
+  def audit: () -> true
 end

--- a/spec/expectations/steep_actionview_runtime/posts/edit.rbs
+++ b/spec/expectations/steep_actionview_runtime/posts/edit.rbs
@@ -5,7 +5,7 @@ class ERBPostsEdit
   include PostsHelper
 
   def initialize: (post: Post & ::Post::Validated) -> void
-  def render: (?{ partial: String, locals: { post: Post & Post::Validated } }? target, *untyped rest) -> nil
+  def render: (?({ partial: "posts/form", locals: { post: Post & Post::Validated } } | { partial: "posts/summary", locals: { post: Post & Post::Validated } })? target, *untyped rest) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/expectations/steep_actionview_runtime/posts/new.rbs
+++ b/spec/expectations/steep_actionview_runtime/posts/new.rbs
@@ -5,7 +5,7 @@ class ERBPostsNew
   include PostsHelper
 
   def initialize: (post: Post) -> void
-  def render: (?{ partial: String, locals: { post: Post } }? target, *untyped rest) -> nil
+  def render: (?{ partial: "posts/form", locals: { post: Post } }? target, *untyped rest) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/expectations/steep_actionview_runtime/posts/show.rbs
+++ b/spec/expectations/steep_actionview_runtime/posts/show.rbs
@@ -6,7 +6,7 @@ class ERBPostsShow
   include PostsHelper
 
   def initialize: (comments: Comment::ActiveRecord_Relation, post: Post & ::Post::Validated) -> void
-  def render: (?({ partial: String, locals: { comment: (Comment & Comment::Validated) } } | String)? target, *{ post: Post & Post::Validated } rest) -> nil
+  def render: (?({ partial: "comment", locals: { comment: (Comment & Comment::Validated) } } | "posts/summary")? target, *{ post: Post & Post::Validated } rest) -> nil
   def params: () -> ActionController::Parameters
   def __rbs_infer__body: () -> nil
 end

--- a/spec/expectations/steep_ar_runtime/assignment.rbs
+++ b/spec/expectations/steep_ar_runtime/assignment.rbs
@@ -1,5 +1,5 @@
 class Assignment
-  def save: (**untyped) -> bool
+  def save: (**untyped) -> true
   def run_before_validation_callbacks: () -> User?
   def run_belongs_to_default_callbacks: () -> User?
   def run_belongs_to_default_owner: () -> User?

--- a/spec/expectations/steep_ar_runtime/notification/generated_store_accessors.rbs
+++ b/spec/expectations/steep_ar_runtime/notification/generated_store_accessors.rbs
@@ -3,7 +3,7 @@ class Notification
     @__store_settings_channel: String?
 
     def channel: () -> String?
-    def channel=: (String? value) -> String?
+    def channel=: ("none" value) -> String?
     def theme: () -> untyped
     def theme=: (untyped value) -> untyped
     def settings_digest: () -> untyped

--- a/spec/expectations/steep_ar_runtime/notification/generated_store_accessors.rbs
+++ b/spec/expectations/steep_ar_runtime/notification/generated_store_accessors.rbs
@@ -1,9 +1,9 @@
 class Notification
   module GeneratedStoreAccessors
-    @__store_settings_channel: String?
+    @__store_settings_channel: "none"?
 
     def channel: () -> String?
-    def channel=: ("none" value) -> String?
+    def channel=: ("none"? value) -> "none"?
     def theme: () -> untyped
     def theme=: (untyped value) -> untyped
     def settings_digest: () -> untyped

--- a/spec/expectations/steep_ar_runtime/tag/generated_relation_methods.rbs
+++ b/spec/expectations/steep_ar_runtime/tag/generated_relation_methods.rbs
@@ -1,7 +1,7 @@
 class Tag
   module GeneratedRelationMethods
     def popular: (?Integer limit) -> untyped
-    def default_limit: () -> Integer
+    def default_limit: () -> 10
     def named: (String value) -> (Tag & Tag::Validated)?
   end
 end

--- a/spec/expectations/steep_baseline.txt
+++ b/spec/expectations/steep_baseline.txt
@@ -8,8 +8,8 @@ app/models/example21.rb:96:29: [error] Type `(::Example21::Ticket | nil)` does n
 app/models/example3.rb:123:11: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:64:13: [error] Type `(::Example3::User | nil)` does not have method `name`
 app/models/example3.rb:65:26: [error] Type `(::Example3::User | nil)` does not have method `name`
-app/models/example3.rb:66:26: [error] Type `(::String | nil)` does not have method `upcase`
-app/models/example3.rb:67:13: [error] Type `(::String | nil)` does not have method `upcase`
+app/models/example3.rb:66:26: [error] Type `("John Doe" | "x" | nil)` does not have method `upcase`
+app/models/example3.rb:67:13: [error] Type `("John Doe" | "x" | nil)` does not have method `upcase`
 app/models/example30.rb:16:6: [error] Type `::Example30::Foo` does not have method `age`
 app/models/example30.rb:9:12: [warning] Method `::Example30::Foo#age` is not declared in RBS
 app/models/example31.rb:26:8: [error] Cannot allow method body have type `::Integer` because declared as type `::Float`
@@ -41,8 +41,8 @@ app/models/send_dispatch.rb:140:16: [error] `send` names `no_such_method_anywher
 app/services/comment/create.rb:3:12: [error] Cannot find compatible overloading of method `find` of type `singleton(::Comment)`
 app/services/email_notifier.rb:13:15: [error] Type `(::User | nil)` does not have method `email`
 app/services/profile_formatter.rb:31:4: [error] `format_nickname` requires `self.nickname` to be non-nil here
-app/services/profile_formatter.rb:37:13: [error] Type `(::String | nil)` does not have method `upcase`
-app/services/tag_destroy.rb:110:6: [error] Cannot allow method body have type `(void | ::String)` because declared as type `(::String | nil)`
+app/services/profile_formatter.rb:37:13: [error] Type `("ada" | nil)` does not have method `upcase`
+app/services/tag_destroy.rb:110:6: [error] Cannot allow method body have type `(void | "error")` because declared as type `(::String | nil)`
 app/services/tag_destroy.rb:98:7: [error] Type `::TagDestroy` does not have method `untyped`
 sig/generated/steep_activejob_runtime/active_job_base.rb:15:16: [error] Unexpected positional argument
 sig/generated/steep_ar_runtime/active_support/concern.rb:53:22: [warning] Cannot pass a value of type `^(?(::Module | nil)) -> untyped` as a block-pass-argument of type `^(::Module) [self: ::Module] -> U(_)`

--- a/spec/expectations/steep_controller_runtime/action_controller/metal/http_authentication.rbs
+++ b/spec/expectations/steep_controller_runtime/action_controller/metal/http_authentication.rbs
@@ -2,13 +2,13 @@ module ActionController
   module HttpAuthentication
     module Token
       def authenticate: ((ActionController::Base & ActionController::HttpAuthentication::Token::ControllerMethods) controller) { (String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?) -> untyped } -> untyped
-      def authentication_request: ((ActionController::Base & ActionController::HttpAuthentication::Token::ControllerMethods) controller, String realm, ?untyped message) -> bool
+      def authentication_request: ((ActionController::Base & ActionController::HttpAuthentication::Token::ControllerMethods) controller, String realm, ?untyped message) -> true
     end
 
     module Token::ControllerMethods
       def authenticate_or_request_with_http_token: (?String realm, ?untyped message) { (String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?) -> untyped } -> untyped
       def authenticate_with_http_token: () { (String, ActiveSupport::HashWithIndifferentAccess[untyped, untyped]?) -> untyped } -> untyped
-      def request_http_token_authentication: (?String realm, ?untyped message) -> bool
+      def request_http_token_authentication: (?String realm, ?untyped message) -> true
     end
   end
 end

--- a/spec/expectations/steep_controller_runtime/action_controller_base.rbs
+++ b/spec/expectations/steep_controller_runtime/action_controller_base.rbs
@@ -2,9 +2,9 @@ module ActionController
   class Base
     @__rbs_infer__performed: true?
 
-    def redirect_to: (*untyped args) -> bool
-    def render: (*{ plain: String, status: Symbol } args) -> bool
-    def head: (*untyped args) -> bool
+    def redirect_to: (*untyped args) -> true
+    def render: (*{ plain: String, status: :unauthorized } args) -> true
+    def head: (*untyped args) -> true
     def performed?: () -> true?
     def __rbs_infer__unknown_condition?: () -> untyped
   end

--- a/spec/expectations/steep_controller_runtime/dashboard_controller.rbs
+++ b/spec/expectations/steep_controller_runtime/dashboard_controller.rbs
@@ -1,7 +1,7 @@
 class DashboardController
   @__rbs_infer__performed: true?
 
-  def render: (?:show? target, *untyped rest) -> true
+  def render: (?(:show)? target, *untyped rest) -> true
 
   private
 

--- a/spec/expectations/steep_controller_runtime/dashboard_controller.rbs
+++ b/spec/expectations/steep_controller_runtime/dashboard_controller.rbs
@@ -1,9 +1,9 @@
 class DashboardController
   @__rbs_infer__performed: true?
 
-  def render: (?Symbol? target, *untyped rest) -> bool
+  def render: (?:show? target, *untyped rest) -> true
 
   private
 
-  def __rbs_infer__run_show: () -> bool?
+  def __rbs_infer__run_show: () -> true?
 end

--- a/spec/expectations/steep_controller_runtime/posts_controller.rbs
+++ b/spec/expectations/steep_controller_runtime/posts_controller.rbs
@@ -1,13 +1,13 @@
 class PostsController
   @__rbs_infer__performed: true?
 
-  def render: (?Symbol? target, *{ status: Symbol } rest) -> bool
+  def render: (?(:index | :show | :new | :edit)? target, *{ status: :unprocessable_entity } rest) -> true
 
   private
 
-  def __rbs_infer__run_index: () -> bool?
-  def __rbs_infer__run_show: () -> bool?
-  def __rbs_infer__run_new: () -> bool?
+  def __rbs_infer__run_index: () -> true?
+  def __rbs_infer__run_show: () -> true?
+  def __rbs_infer__run_new: () -> true?
   def __rbs_infer__run_create: () -> void
   def __rbs_infer__run_update: () -> void
   def __rbs_infer__run_destroy: () -> void

--- a/spec/expectations/steep_controller_runtime/users_avatars_controller.rbs
+++ b/spec/expectations/steep_controller_runtime/users_avatars_controller.rbs
@@ -2,7 +2,7 @@ module Users
   class AvatarsController
     @__rbs_infer__performed: true?
 
-    def render: (?:edit? target, *{ status: :unprocessable_entity } rest) -> true
+    def render: (?(:edit)? target, *{ status: :unprocessable_entity } rest) -> true
 
     private
 

--- a/spec/expectations/steep_controller_runtime/users_avatars_controller.rbs
+++ b/spec/expectations/steep_controller_runtime/users_avatars_controller.rbs
@@ -2,11 +2,11 @@ module Users
   class AvatarsController
     @__rbs_infer__performed: true?
 
-    def render: (?Symbol? target, *{ status: Symbol } rest) -> bool
+    def render: (?:edit? target, *{ status: :unprocessable_entity } rest) -> true
 
     private
 
-    def __rbs_infer__run_edit: () -> bool?
+    def __rbs_infer__run_edit: () -> true?
     def __rbs_infer__run_update: () -> void
   end
 end

--- a/spec/expectations/steep_controller_runtime/users_controller.rbs
+++ b/spec/expectations/steep_controller_runtime/users_controller.rbs
@@ -1,11 +1,11 @@
 class UsersController
   @__rbs_infer__performed: true?
 
-  def render: (?(Symbol | String)? target, *untyped rest) -> bool
+  def render: (?(:show | "posts/show")? target, *untyped rest) -> true
 
   private
 
   def __rbs_infer__run_index: () -> void
-  def __rbs_infer__run_show: () -> bool?
+  def __rbs_infer__run_show: () -> true?
   def __rbs_infer__run_featured_post: () -> void
 end

--- a/spec/expectations/uploaders/avatar_uploader.rbs
+++ b/spec/expectations/uploaders/avatar_uploader.rbs
@@ -1,4 +1,4 @@
 class AvatarUploader < CarrierWave::Uploader::Base
   def store_dir: () -> String
-  def extension_allowlist: () -> Array[String]
+  def extension_allowlist: () -> Array[("jpg" | "jpeg" | "gif" | "png" | "webp")]
 end

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -441,6 +441,24 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     assert_snapshot("models/example68", target_file: "app/models/example68.rb")
   end
 
+  # The literal-type target, and the reason it is plain Ruby with no macro in it:
+  # `has_rich_text` is the APPLICATION of this, not the mechanism. Every expected
+  # answer is written beside the method it belongs to, and the snapshot below is
+  # today's — every `String` in it is a place a literal is known and dropped.
+  #
+  # Five distinct failure modes, one file: `call_name_action` catches an
+  # implementation that specializes nothing, `call_dynamic` one that specializes a
+  # single hop, `name_action_dynamic` one that over-specializes the DECLARATION
+  # from one call site, `call_unknown` one that picks a branch it cannot decide,
+  # and `call_both` one that loses the literal on the way into a collection.
+  #
+  # `name_action_dynamic` and `call_unknown` have the same body and differ only in
+  # having callers — which is the whole question, and which the parameter types
+  # already state (`bool` against `untyped`) without any of the new machinery.
+  it "example69 (literals that should survive a call site) matches expected RBS" do
+    assert_snapshot("models/example69", target_file: "app/models/example69.rb")
+  end
+
   # `send` with a literal symbol reaching a PRIVATE method — how MRI itself invokes the
   # mixin hooks (`rb_funcall` ignores visibility, and `included`/`append_features` are
   # private on `Module`), which is why the `Module#include` pseudo-code spells them that

--- a/spec/integration/rails_dummy_spec.rb
+++ b/spec/integration/rails_dummy_spec.rb
@@ -1348,7 +1348,7 @@ RSpec.describe "Rails dummy app integration", :dummy_app do
     # method but loses what it returns would keep the first count and drop the
     # second.
     expect(rbs.scan(/def prepend_order:/).size).to eq(2)
-    expect(rbs.scan(/def prepend_order_marker: \(\) -> String/).size).to eq(2)
+    expect(rbs.scan(/def prepend_order_marker: \(\) -> "prepend_order"/).size).to eq(2)
   end
 
   it "PostsController matches expected RBS" do

--- a/spec/integration/steep_scenarios_spec.rb
+++ b/spec/integration/steep_scenarios_spec.rb
@@ -86,23 +86,23 @@ RSpec.describe "rbs_infer -> Steep precondition scenarios" do
 
     expected_rbs = <<~RBS
       class Column
-        @name: String
+        @name: "To Do"
 
         attr_accessor board: Board?
-        attr_accessor user_name: String?
+        attr_accessor user_name: "Jo"?
 
-        def initialize: (name: String) -> void
-        def set_default_user_name: () -> String
+        def initialize: (name: "To Do") -> void
+        def set_default_user_name: () -> "Jo"
       end
 
       class Board
-        attr_reader user_name: String
+        attr_reader user_name: "Jo"
 
-        def initialize: (user_name: String) -> void
+        def initialize: (user_name: "Jo") -> void
       end
 
       class Runner
-        def self.run: () -> String
+        def self.run: () -> "Jo"
       end
     RBS
 
@@ -123,20 +123,20 @@ RSpec.describe "rbs_infer -> Steep precondition scenarios" do
 
     expected_rbs = <<~RBS
       class Column
-        @name: String
+        @name: "To Do"
 
         attr_accessor board: Board?
-        attr_accessor user_name: String?
+        attr_accessor user_name: "Jo"?
 
-        def initialize: (name: String) -> void
-        def set_default_user_name: () -> String
-        def save: () -> bool
+        def initialize: (name: "To Do") -> void
+        def set_default_user_name: () -> "Jo"
+        def save: () -> true
       end
 
       class Board
-        attr_reader user_name: String
+        attr_reader user_name: "Jo"
 
-        def initialize: (user_name: String) -> void
+        def initialize: (user_name: "Jo") -> void
       end
 
       class Runner
@@ -166,20 +166,20 @@ RSpec.describe "rbs_infer -> Steep precondition scenarios" do
 
     expected_rbs = <<~RBS
       class Column
-        @name: String
+        @name: "To Do"
 
         attr_accessor board: Board?
-        attr_accessor user_name: String?
+        attr_accessor user_name: "Jo"?
 
-        def initialize: (name: String) -> void
-        def set_default_user_name: () -> String
-        def save: () -> bool
+        def initialize: (name: "To Do") -> void
+        def set_default_user_name: () -> "Jo"
+        def save: () -> true
       end
 
       class Board
-        attr_reader user_name: String
+        attr_reader user_name: "Jo"
 
-        def initialize: (user_name: String) -> void
+        def initialize: (user_name: "Jo") -> void
       end
 
       class Runner
@@ -213,25 +213,25 @@ RSpec.describe "rbs_infer -> Steep precondition scenarios" do
 
     expected_rbs = <<~RBS
       class Column
-        @name: String
+        @name: "To Do"
 
         attr_accessor board: Board?
-        attr_accessor user_name: String?
+        attr_accessor user_name: "Jo"?
 
-        def initialize: (name: String) -> void
-        def set_default_user_name: () -> String
-        def save: () -> bool
+        def initialize: (name: "To Do") -> void
+        def set_default_user_name: () -> "Jo"
+        def save: () -> true
       end
 
       class Board
-        attr_reader user_name: String
+        attr_reader user_name: "Jo"
 
-        def initialize: (user_name: String) -> void
+        def initialize: (user_name: "Jo") -> void
       end
 
       class Factory
         def self.build: () -> Column
-        def self.run: () -> bool
+        def self.run: () -> true
       end
     RBS
 
@@ -280,9 +280,9 @@ RSpec.describe "rbs_infer -> Steep precondition scenarios" do
     # `T?`; the inline snapshot pins that faithfully.
     expected_rbs = <<~RBS
       class Board
-        attr_reader user_name: String
+        attr_reader user_name: "Jo"
 
-        def initialize: (user_name: String) -> void
+        def initialize: (user_name: "Jo") -> void
       end
 
       class Column
@@ -292,7 +292,7 @@ RSpec.describe "rbs_infer -> Steep precondition scenarios" do
       end
 
       class Runner
-        def self.run: () -> String
+        def self.run: () -> "Jo"
         def self.setup: () -> Board
       end
     RBS
@@ -335,9 +335,9 @@ RSpec.describe "rbs_infer -> Steep precondition scenarios" do
 
       class Holder
         class User
-          attr_reader name: String
+          attr_reader name: "Jo"
 
-          def initialize: (name: String) -> void
+          def initialize: (name: "Jo") -> void
         end
       end
     RBS
@@ -412,7 +412,7 @@ RSpec.describe "rbs_infer -> Steep precondition scenarios" do
       end
     RBS
 
-    expect(result.generated_rbs).to include("def pick: (untyped flag) -> (String | Array[Integer])")
+    expect(result.generated_rbs).to include('def pick: (untyped flag) -> ("one" | Array[2])')
     expect(result.diagnostics).to be_empty
   end
 
@@ -456,9 +456,11 @@ RSpec.describe "rbs_infer -> Steep precondition scenarios" do
       end
     RUBY
 
-    # `String?` — the `unless` yields the assigned label or nil — and NOT
-    # `Person`, which is what the parameter says.
-    expect(result.generated_rbs).to include("def user=: (Person? value) -> String?")
+    # `"jo"?` — the `unless` yields the assigned label or nil — and NOT `Person`,
+    # which is what the parameter says. The label is `value.name`, and this
+    # fixture's `Person#name` returns a literal, so the literal is what comes
+    # through; the point is the BODY deciding, not the width of what it decides.
+    expect(result.generated_rbs).to include('def user=: (Person? value) -> "jo"?')
     expect(result.diagnostics).to be_empty
   end
 end

--- a/spec/lib/rbs_infer/analyzer_spec.rb
+++ b/spec/lib/rbs_infer/analyzer_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe RbsInfer::Analyzer do
         analyzer = described_class.new(target_file: entity, source_files: paths)
         rbs = analyzer.generate_rbs
 
-        expect(rbs).to include("nome: String")
-        expect(rbs).to include("def initialize: (nome: String) -> void")
+        expect(rbs).to include('nome: "Felipe"')
+        expect(rbs).to include('def initialize: (nome: "Felipe") -> void')
       end
     end
 
@@ -120,8 +120,8 @@ RSpec.describe RbsInfer::Analyzer do
         analyzer = described_class.new(target_file: entity, source_files: paths)
         rbs = analyzer.generate_rbs
 
-        expect(rbs).to include("nome: String")
-        expect(rbs).to include("?senha: String")
+        expect(rbs).to include('nome: "Felipe"')
+        expect(rbs).to include('?senha: "secret"?')
         expect(rbs).not_to include("?nome:")
       end
     end
@@ -181,7 +181,7 @@ RSpec.describe RbsInfer::Analyzer do
         expect(rbs).to include("module Academico")
         expect(rbs).to include("  module Aluno")
         expect(rbs).to include("    class Email")
-        expect(rbs).to include("      attr_accessor endereco: String")
+        expect(rbs).to include('      attr_accessor endereco: "test@email.com"')
       end
     end
 
@@ -344,9 +344,9 @@ RSpec.describe RbsInfer::Analyzer do
         # `self.run` resolves against the class method `build` (Integer) it
         # calls — NOT the homonymous instance `run` (String). Return types no
         # longer cross the instance/singleton boundary (felixefelip#33).
-        expect(rbs).to include("def self.run: () -> Integer")
-        expect(rbs).to include("def self.build: () -> Integer")
-        expect(rbs).to include("def run: () -> String")
+        expect(rbs).to include("def self.run: () -> 42")
+        expect(rbs).to include("def self.build: () -> 42")
+        expect(rbs).to include('def run: () -> "abc"')
       end
     end
 
@@ -408,7 +408,7 @@ RSpec.describe RbsInfer::Analyzer do
         rbs = analyzer.generate_rbs
 
         expect(rbs).to include("def self.run: () -> String")
-        expect(rbs).to include("def run: () -> String")
+        expect(rbs).to include('def run: () -> "abc"')
       end
     end
 
@@ -443,7 +443,7 @@ RSpec.describe RbsInfer::Analyzer do
         rbs = analyzer.generate_rbs
 
         expect(rbs).to include("def self.from_const: () -> String")
-        expect(rbs).to include("def self.from_self: () -> Integer")
+        expect(rbs).to include("def self.from_self: () -> 42")
       end
     end
 
@@ -479,8 +479,8 @@ RSpec.describe RbsInfer::Analyzer do
         expect(rbs.scan(/^\s*def consume:/).size).to eq(1)
         # Distinct scopes keep distinct signatures — the return types do not
         # bleed between the singleton and the instance method.
-        expect(rbs).to include("def self.consume: (untyped code) -> Integer")
-        expect(rbs).to include("def consume: () -> String")
+        expect(rbs).to include("def self.consume: (untyped code) -> 42")
+        expect(rbs).to include('def consume: () -> "done"')
       end
     end
 
@@ -552,12 +552,13 @@ RSpec.describe RbsInfer::Analyzer do
       with_temp_files(files) do |_dir, paths|
         rbs = described_class.new(target_file: paths.first, source_files: paths).generate_rbs
 
-        expect(rbs).to include("def tail_is_literal: () -> bool?")
-        expect(rbs).to include("def tail_is_call: () -> bool?")
+        expect(rbs).to include("def tail_is_literal: () -> true?")
+        expect(rbs).to include("def tail_is_call: () -> true?")
         # No early return → no widening.
-        expect(rbs).to include("def no_early_return: () -> bool")
-        # `return 1` is not a nil return.
-        expect(rbs).to include("def value_return_only: () -> Integer")
+        expect(rbs).to include("def no_early_return: () -> true")
+        # `return 1` is not a nil return — and it is a return PATH, so its type
+        # is in the union rather than only the tail's (felixefelip/rbs_infer#347).
+        expect(rbs).to include("def value_return_only: () -> (2 | 1)")
       end
     end
 
@@ -673,7 +674,7 @@ RSpec.describe RbsInfer::Analyzer do
         analyzer = described_class.new(target_file: email, source_files: paths)
         rbs = analyzer.generate_rbs
 
-        expect(rbs).to include("endereco: String")
+        expect(rbs).to include('endereco: "test@email.com"')
       end
     end
 
@@ -706,7 +707,7 @@ RSpec.describe RbsInfer::Analyzer do
         analyzer = described_class.new(target_file: email, source_files: paths)
         rbs = analyzer.generate_rbs
 
-        expect(rbs).to include("def to_s: () -> String")
+        expect(rbs).to include('def to_s: () -> "test@email.com"')
         expect(rbs).not_to include("def to_s: () -> untyped")
       end
     end
@@ -744,10 +745,10 @@ RSpec.describe RbsInfer::Analyzer do
 
         aggregate_failures do
           expect(rbs).to include("def to_s: () -> String")
-          expect(rbs).to include("def count: () -> Integer")
+          expect(rbs).to include("def count: () -> 42")
           expect(rbs).to include("def ratio: () -> Float")
-          expect(rbs).to include("def label: () -> Symbol")
-          expect(rbs).to include("def active?: () -> bool")
+          expect(rbs).to include("def label: () -> :foo")
+          expect(rbs).to include("def active?: () -> true")
         end
       end
     end
@@ -1033,8 +1034,8 @@ RSpec.describe RbsInfer::Analyzer do
         aggregate_failures do
           # Return types should be resolved correctly. Neither body ever calls
           # its block, so there is no arity to read — `*untyped`.
-          expect(rbs).to include("def wrapper: () ?{ (*untyped) -> untyped } -> String")
-          expect(rbs).to include("def count_items: (untyped items) ?{ (*untyped) -> untyped } -> Integer")
+          expect(rbs).to include('def wrapper: () ?{ (*untyped) -> untyped } -> "hello"')
+          expect(rbs).to include("def count_items: (untyped items) ?{ (*untyped) -> untyped } -> 42")
 
           # The -> untyped inside the block must not be replaced
           expect(rbs).not_to include("-> String }")
@@ -1340,7 +1341,7 @@ RSpec.describe RbsInfer::Analyzer do
         with_temp_files(files) do |_dir, paths|
           rbs = described_class.new(target_class: "Palette", target_file: paths.first, source_files: paths).generate_rbs
 
-          expect(rbs).to include("WEIGHTS: Array[Integer]")
+          expect(rbs).to include("WEIGHTS: Array[(1 | 2 | 3)]")
         end
       end
     end
@@ -1620,7 +1621,7 @@ RSpec.describe RbsInfer::Analyzer do
 
       rbs = described_class.new(target_class: "Reopened", target_file: target, source_files: Dir["app/*.rb"]).generate_rbs
 
-      expect(rbs).to include("def handle: (?Symbol? target")
+      expect(rbs).to include("def handle: (?(:edit)? target")
     end
 
     # The target's OWN file is already covered by IntraClassCallAnalyzer. Counting it

--- a/spec/lib/rbs_infer/ast/node_type_inferrer_spec.rb
+++ b/spec/lib/rbs_infer/ast/node_type_inferrer_spec.rb
@@ -24,22 +24,22 @@ RSpec.describe RbsInfer::AST::NodeTypeInferrer do
     end
 
     it "reads the element type off the elements" do
-      expect(infer_array("[64, 128]")).to eq("Array[Integer]")
-      expect(infer_array('["a", "b"]')).to eq("Array[String]")
-      expect(infer_array("[:a, :b]")).to eq("Array[Symbol]")
+      expect(infer_array("[64, 128]")).to eq("Array[(64 | 128)]")
+      expect(infer_array('["a", "b"]')).to eq('Array[("a" | "b")]')
+      expect(infer_array("[:a, :b]")).to eq("Array[(:a | :b)]")
     end
 
     # De-duplication and subsumption come from the merger, so `bool` stays one
     # type rather than becoming `(bool | bool)`.
     it "unions genuinely mixed elements, collapsing what repeats" do
-      expect(infer_array('[1, "a"]')).to eq("Array[(Integer | String)]")
+      expect(infer_array('[1, "a"]')).to eq('Array[(1 | "a")]')
       expect(infer_array("[true, false]")).to eq("Array[bool]")
-      expect(infer_array("[1, 2.0, 3]")).to eq("Array[(Integer | Float)]")
+      expect(infer_array("[1, 2.0, 3]")).to eq("Array[(1 | Float | 3)]")
     end
 
     it "types elements that are not literals" do
       expect(infer_array("[User.new]")).to eq("Array[User]")
-      expect(infer_array("[[1, 2], [3]]")).to eq("Array[Array[Integer]]")
+      expect(infer_array("[[1, 2], [3]]")).to eq("Array[(Array[(1 | 2)] | Array[3])]")
       expect(infer_array("[size]", known_types: { "size" => "Integer" })).to eq("Array[Integer]")
     end
 
@@ -70,17 +70,17 @@ RSpec.describe RbsInfer::AST::NodeTypeInferrer do
     # kind must map identically regardless of caller — this is what the per-class
     # copies used to drift on (e.g. some missed Array/Hash/InterpolatedSymbol).
     it "maps every unambiguous literal node to its RBS type" do
-      expect(infer_literal('"x"')).to eq("String")
+      expect(infer_literal('"x"')).to eq('"x"')
       expect(infer_literal('"a#{b}c"')).to eq("String")          # InterpolatedString
-      expect(infer_literal("1")).to eq("Integer")
-      expect(infer_literal("1.5")).to eq("Float")
-      expect(infer_literal(":a")).to eq("Symbol")
+      expect(infer_literal("1")).to eq("1")
+      expect(infer_literal("1.5")).to eq("Float")                # RBS has no float literal
+      expect(infer_literal(":a")).to eq(":a")
       expect(infer_literal(':"a#{b}"')).to eq("Symbol")          # InterpolatedSymbol
-      expect(infer_literal("true")).to eq("bool")
-      expect(infer_literal("false")).to eq("bool")
+      expect(infer_literal("true")).to eq("true")
+      expect(infer_literal("false")).to eq("false")
       expect(infer_literal("nil")).to eq("nil")
-      expect(infer_literal("[1, 2]")).to eq("Array[Integer]")
-      expect(infer_literal("{ a: 1 }")).to eq("{ a: Integer }")
+      expect(infer_literal("[1, 2]")).to eq("Array[(1 | 2)]")
+      expect(infer_literal("{ a: 1 }")).to eq("{ a: 1 }")
       expect(infer_literal("/abc/")).to eq("Regexp")
       expect(infer_literal('/a#{b}/')).to eq("Regexp")           # InterpolatedRegexp
     end
@@ -95,18 +95,18 @@ RSpec.describe RbsInfer::AST::NodeTypeInferrer do
 
   describe ".infer_hash_type" do
     it "returns record type for all-Symbol keys" do
-      expect(infer_hash("{ foo: 'bar', baz: 42 }")).to eq("{ foo: String, baz: Integer }")
+      expect(infer_hash("{ foo: 'bar', baz: 42 }")).to eq('{ foo: "bar", baz: 42 }')
     end
 
     it "returns record type with various literal value types" do
       expect(infer_hash("{ s: 'x', i: 1, f: 1.5, sym: :a, b: true, n: nil }")).to eq(
-        "{ s: String, i: Integer, f: Float, sym: Symbol, b: bool, n: nil }"
+        '{ s: "x", i: 1, f: Float, sym: :a, b: true, n: nil }'
       )
     end
 
     it "returns nested record type for nested hashes" do
       expect(infer_hash("{ a: 1, nested: { b: 2, c: 3 } }")).to eq(
-        "{ a: Integer, nested: { b: Integer, c: Integer } }"
+        "{ a: 1, nested: { b: 2, c: 3 } }"
       )
     end
 
@@ -148,7 +148,7 @@ RSpec.describe RbsInfer::AST::NodeTypeInferrer do
     end
 
     it "handles array values" do
-      expect(infer_hash("{ items: [1, 2, 3] }")).to eq("{ items: Array[Integer] }")
+      expect(infer_hash("{ items: [1, 2, 3] }")).to eq("{ items: Array[(1 | 2 | 3)] }")
     end
 
     context "with known_types context" do
@@ -173,7 +173,7 @@ RSpec.describe RbsInfer::AST::NodeTypeInferrer do
       it "mixes literal and context-resolved types" do
         known = { "from_address" => "String" }
         expect(infer_hash("{ from: from_address, count: 42 }", known_types: known)).to eq(
-          "{ from: String, count: Integer }"
+          "{ from: String, count: 42 }"
         )
       end
     end

--- a/spec/lib/rbs_infer/inference/class_member_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/class_member_collector_spec.rb
@@ -123,8 +123,8 @@ RSpec.describe RbsInfer::Inference::ClassMemberCollector do
     RUBY
 
     collector = collect(source)
-    expect(collector.members.find { |m| m.name == "build_name" }.signature).to include("-> String")
-    expect(collector.members.find { |m| m.name == "build_count" }.signature).to include("-> Integer")
+    expect(collector.members.find { |m| m.name == "build_name" }.signature).to include('-> "hello"')
+    expect(collector.members.find { |m| m.name == "build_count" }.signature).to include("-> 42")
   end
 
   it "não atribui definições dentro de blocos à classe léxica" do

--- a/spec/lib/rbs_infer/inference/constant_type_resolver_spec.rb
+++ b/spec/lib/rbs_infer/inference/constant_type_resolver_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe RbsInfer::Inference::ConstantTypeResolver do
 
   describe "#resolve" do
     it "infere literais via NodeTypeInferrer (sem Steep)" do
-      expect(resolve(rhs("MAX = 8"))).to eq("Integer")
-      expect(resolve(rhs('NAME = "Blue"'))).to eq("String")
+      expect(resolve(rhs("MAX = 8"))).to eq("8")
+      expect(resolve(rhs('NAME = "Blue"'))).to eq('"Blue"')
       expect(resolve(rhs("PI = 3.14"))).to eq("Float")
-      expect(resolve(rhs("FLAG = true"))).to eq("bool")
-      expect(resolve(rhs("SYM = :blue"))).to eq("Symbol")
+      expect(resolve(rhs("FLAG = true"))).to eq("true")
+      expect(resolve(rhs("SYM = :blue"))).to eq(":blue")
     end
 
     it "resolve Klass.new para a classe (single-pass, sem RBS de Klass)" do
@@ -66,7 +66,7 @@ RSpec.describe RbsInfer::Inference::ConstantTypeResolver do
     end
 
     it "ignora um tipo do Steep não-utilizável (bot/void/nil) e cai para o leaf" do
-      expect(resolve(rhs("MAX = 8"), steep_type: "bot")).to eq("Integer")
+      expect(resolve(rhs("MAX = 8"), steep_type: "bot")).to eq("8")
     end
   end
 end

--- a/spec/lib/rbs_infer/inference/extend_call_site_spec.rb
+++ b/spec/lib/rbs_infer/inference/extend_call_site_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "a call site reaching the target through extend" do
 
     rbs = RbsInfer::Analyzer.new(target_class: "Mixin", target_file: target, source_files: Dir["app/*.rb"]).generate_rbs
 
-    expect(rbs).to include("def notify: (String target) ->")
+    expect(rbs).to include('def notify: ("hi" target) ->')
   end
 
   # The same reach, one level in: the module is NESTED under the target, so it is not a
@@ -100,7 +100,7 @@ RSpec.describe "a call site reaching the target through extend" do
 
     rbs = RbsInfer::Analyzer.new(target_class: "Wrap", target_file: target, source_files: Dir["app/*.rb"]).generate_rbs
 
-    expect(rbs).to include("def notify: (String value) ->")
+    expect(rbs).to include('def notify: ("hi" value) ->')
   end
 
   # And a `def self.` of the same name on the extender SHADOWS it, so the call site
@@ -147,7 +147,7 @@ RSpec.describe "a call site reaching the target through extend" do
 
     rbs = RbsInfer::Analyzer.new(target_class: "Wrap", target_file: target, source_files: Dir["app/*.rb"]).generate_rbs
 
-    expect(rbs).to include("def self.notify: (String value) ->")
+    expect(rbs).to include('def self.notify: ("hi" value) ->')
     expect(rbs).to include("def notify: (untyped value) ->")
   end
 
@@ -181,7 +181,7 @@ RSpec.describe "a call site reaching the target through extend" do
 
     rbs = RbsInfer::Analyzer.new(target_class: "Mixin", target_file: target, source_files: Dir["app/*.rb"]).generate_rbs
 
-    expect(rbs).to include("def notify: (String target) ->")
+    expect(rbs).to include('def notify: ("hi" target) ->')
   end
 
   # And the constant spelling earns no more than the typed one does: the singleton side is

--- a/spec/lib/rbs_infer/inference/initialize_body_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/inference/initialize_body_analyzer_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe RbsInfer::Inference::InitializeBodyAnalyzer do
 
     visitor = analyze(source)
     expect(visitor.self_assignments["items"][:kind]).to eq(:literal)
-    expect(visitor.self_assignments["items"][:type]).to eq("Array[Integer]")
+    expect(visitor.self_assignments["items"][:type]).to eq("Array[1 | 2 | 3]")
   end
 
   it "detecta self.attr = { foo: 'bar', baz: 42 } como record type" do
@@ -183,7 +183,7 @@ RSpec.describe RbsInfer::Inference::InitializeBodyAnalyzer do
 
     visitor = analyze(source)
     expect(visitor.self_assignments["options"][:kind]).to eq(:literal)
-    expect(visitor.self_assignments["options"][:type]).to eq("{ foo: String, baz: Integer }")
+    expect(visitor.self_assignments["options"][:type]).to eq('{ foo: "bar", baz: 42 }')
   end
 
   it "detecta self.attr = ['a', 'b'] como Array[String]" do
@@ -197,7 +197,7 @@ RSpec.describe RbsInfer::Inference::InitializeBodyAnalyzer do
 
     visitor = analyze(source)
     expect(visitor.self_assignments["tags"][:kind]).to eq(:literal)
-    expect(visitor.self_assignments["tags"][:type]).to eq("Array[String]")
+    expect(visitor.self_assignments["tags"][:type]).to eq('Array["ruby" | "rails"]')
   end
 
   it "detecta self.attr = [1, 'a'] como Array[Integer | String]" do
@@ -211,7 +211,7 @@ RSpec.describe RbsInfer::Inference::InitializeBodyAnalyzer do
 
     visitor = analyze(source)
     expect(visitor.self_assignments["items"][:kind]).to eq(:literal)
-    expect(visitor.self_assignments["items"][:type]).to eq("Array[Integer | String]")
+    expect(visitor.self_assignments["items"][:type]).to eq('Array[1 | "a"]')
   end
 
   context "com atribuição múltipla (`@a, @b = a, b`)" do
@@ -241,7 +241,7 @@ RSpec.describe RbsInfer::Inference::InitializeBodyAnalyzer do
 
       visitor = analyze(source)
       expect(visitor.self_assignments["email"]).to eq({ kind: :constant, type: "Email" })
-      expect(visitor.self_assignments["tags"]).to eq({ kind: :literal, type: "Array[String]" })
+      expect(visitor.self_assignments["tags"]).to eq({ kind: :literal, type: 'Array["a"]' })
     end
 
     it "não adivinha quando o valor único é desestruturado em runtime" do

--- a/spec/lib/rbs_infer/inference/intra_class_call_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/inference/intra_class_call_analyzer_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe RbsInfer::Inference::IntraClassCallAnalyzer do
     RUBY
 
     visitor = analyze(source)
-    expect(visitor.inferred_param_types["track_event"]["action"]).to eq("(String | Symbol)")
+    expect(visitor.inferred_param_types["track_event"]["action"]).to eq('("created" | :updated)')
   end
 
   it "infers a type through an ImplicitNode (shorthand keyword: enroll(student:))" do

--- a/spec/lib/rbs_infer/inference/nested_module_homonym_spec.rb
+++ b/spec/lib/rbs_infer/inference/nested_module_homonym_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "two nested modules declaring the same method name" do
 
     # `singleton(Wrap::Beta)` reaches `Beta.stamp` — the receiver names the owner and
     # the `singleton()` says which side of it.
-    expect(rbs).to include("def self.stamp: (String value)")
+    expect(rbs).to include('def self.stamp: ("hi" value)')
     # And says nothing about `Alpha#stamp`, which no call site mentions. Under the
     # name-keyed table this line read `(String value)` too.
     expect(rbs).to include("def stamp: (untyped value)")
@@ -97,6 +97,6 @@ RSpec.describe "two nested modules declaring the same method name" do
 
     rbs = RbsInfer::Analyzer.new(target_class: "Wrap", target_file: target, source_files: Dir["app/*.rb"]).generate_rbs
 
-    expect(rbs).to include("def self.stamp: (String value)")
+    expect(rbs).to include('def self.stamp: ("hi" value)')
   end
 end

--- a/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
+++ b/spec/lib/rbs_infer/inference/new_call_collector_spec.rb
@@ -128,8 +128,8 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
 
     usages = collect_usages(source, target_class: "Foo")
     expect(usages.size).to eq(1)
-    expect(usages.first["nome"]).to eq("String")
-    expect(usages.first["idade"]).to eq("Integer")
+    expect(usages.first["nome"]).to eq('"teste"')
+    expect(usages.first["idade"]).to eq("42")
   end
 
   it "resolve variáveis locais atribuídas via method call" do
@@ -199,7 +199,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
 
     usages = collect_usages(source, target_class: "Academico::Aluno::Email")
     expect(usages.size).to eq(1)
-    expect(usages.first["endereco"]).to eq("String")
+    expect(usages.first["endereco"]).to eq('"test@email.com"')
   end
 
   it "não faz match parcial incorreto" do
@@ -955,7 +955,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
         target_class: "View", target_methods: { "render" => ["target"] }
       )
 
-      expect(usages["render"].first["target"]).to eq("{ partial: String }")
+      expect(usages["render"].first["target"]).to eq('{ partial: "posts/form" }')
     end
 
     # A record keeps each key bound to its own value type. `Hash[Symbol, String | Post]`
@@ -966,7 +966,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
         target_class: "View", target_methods: { "render" => ["target"] }
       )
 
-      expect(usages["render"].first["target"]).to eq("{ partial: String, count: Integer }")
+      expect(usages["render"].first["target"]).to eq('{ partial: "posts/form", count: 2 }')
     end
 
     it "builds a record for a nested hash too, so `locals:` keeps its own keys" do
@@ -976,7 +976,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
       )
 
       expect(usages["render"].first["target"])
-        .to eq("{ partial: String, locals: { count: Integer } }")
+        .to eq('{ partial: "posts/form", locals: { count: 2 } }')
     end
 
     # A record type can only describe all-symbol keys; anything else keeps `Hash[K, V]`.
@@ -987,7 +987,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
       )
 
       expect(usages["render"].first["target"])
-        .to eq("{ partial: String, locals: Hash[String, untyped] }")
+        .to eq('{ partial: "posts/form", locals: Hash[String, untyped] }')
     end
 
     it "keeps a real keyword argument as a keyword" do
@@ -997,7 +997,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
         target_class: "View", target_methods: { "render" => ["partial"] }
       )
 
-      expect(usages["render"].first["partial"]).to eq("String")
+      expect(usages["render"].first["partial"]).to eq('"posts/form"')
       expect(usages["render"].first).not_to have_key("target")
     end
 
@@ -1007,7 +1007,7 @@ RSpec.describe RbsInfer::Inference::NewCallCollector do
         target_class: "View", target_methods: { "render" => ["target"] }
       )
 
-      expect(usages["render"].first["target"]).to eq("String")
+      expect(usages["render"].first["target"]).to eq('"posts/summary"')
     end
   end
 

--- a/spec/lib/rbs_infer/inference/nil_default_param_spec.rb
+++ b/spec/lib/rbs_infer/inference/nil_default_param_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "a parameter defaulting to nil" do
       "    Notifier.new.notify(\"hi\")"
     )
 
-    expect(rbs).to include("def notify: (?String? message) ->")
+    expect(rbs).to include('def notify: (?"hi"? message) ->')
   end
 
   it "applies to a keyword default too" do
@@ -42,7 +42,7 @@ RSpec.describe "a parameter defaulting to nil" do
       "    Notifier.new.notify(message: \"hi\")"
     )
 
-    expect(rbs).to include("def notify: (?message: String?) ->")
+    expect(rbs).to include('def notify: (?message: "hi"?) ->')
   end
 
   # A default that is not nil says nothing about nil, and the parameter keeps exactly
@@ -130,7 +130,7 @@ RSpec.describe "a parameter defaulting to nil" do
 
       rbs = RbsInfer::Analyzer.new(target_class: "Wrap", target_file: target, source_files: Dir["app/*.rb"]).generate_rbs
 
-      expect(rbs).to include("def stamp: (?String? value, ?message: String?) ->")
+      expect(rbs).to include('def stamp: (?"hi"? value, ?message: "hi"?) ->')
     end
   end
 end

--- a/spec/lib/rbs_infer/inference/send_call_site_spec.rb
+++ b/spec/lib/rbs_infer/inference/send_call_site_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "send as a call site" do
       "    Stamper.new.send(:stamp, \"post\")"
     )
 
-    expect(rbs).to include("def stamp: (String value) ->")
+    expect(rbs).to include('def stamp: ("post" value) ->')
   end
 
   # The reason a real app writes `send` at all, and the reason this was worth doing: reaching
@@ -50,7 +50,7 @@ RSpec.describe "send as a call site" do
       "    Stamper.new.send(:stamp, \"post\")"
     )
 
-    expect(rbs).to include("def stamp: (String value) ->")
+    expect(rbs).to include('def stamp: ("post" value) ->')
   end
 
   # One dispatch, three spellings. `__send__` is the one a defensive library uses precisely
@@ -68,7 +68,7 @@ RSpec.describe "send as a call site" do
         "    Stamper.new.#{spelling}"
       )
 
-      expect(rbs).to include("def stamp: (String value) ->")
+      expect(rbs).to include('def stamp: ("post" value) ->')
     end
   end
 
@@ -99,7 +99,7 @@ RSpec.describe "send as a call site" do
       "    Stamper.new.send(:stamp, \"post\")\n    Stamper.new.send(:stamp, 42)"
     )
 
-    expect(rbs).to match(/def stamp: \(\((String \| Integer|Integer \| String)\) value\) ->/)
+    expect(rbs).to match(/def stamp: \(\(("post" \| 42|42 \| "post")\) value\) ->/)
   end
 
   it "carries keyword arguments through" do
@@ -108,7 +108,7 @@ RSpec.describe "send as a call site" do
       "    Stamper.new.send(:stamp, value: \"post\")"
     )
 
-    expect(rbs).to include("def stamp: (value: String) ->")
+    expect(rbs).to include('def stamp: (value: "post") ->')
   end
 
   # The desugared node is an ordinary call, so the rest-param folding from #201 applies to it
@@ -119,7 +119,7 @@ RSpec.describe "send as a call site" do
       "    Stamper.new.send(:stamp, \"a\", \"b\")"
     )
 
-    expect(rbs).to include("def stamp: (*String values) ->")
+    expect(rbs).to include('def stamp: (*("a" | "b") values) ->')
   end
 
   # The boundary, and the reason it needs no send-specific handling: a splat argument does
@@ -145,7 +145,7 @@ RSpec.describe "send as a call site" do
       "caller.rb" => "class Caller\n  def run\n    Bus.new.send(:notify, \"payload\")\n  end\nend\n"
     )
 
-    expect(rbs).to include("def send: (Symbol channel, String payload) ->")
+    expect(rbs).to include('def send: (:notify channel, "payload" payload) ->')
     expect(rbs).to include("def notify: (untyped text) ->")
   end
 
@@ -170,6 +170,6 @@ RSpec.describe "send as a call site" do
       RUBY
     )
 
-    expect(rbs).to include("def stamp: (String value) ->")
+    expect(rbs).to include('def stamp: ("post" value) ->')
   end
 end

--- a/spec/lib/rbs_infer/inference/splat_param_inference_spec.rb
+++ b/spec/lib/rbs_infer/inference/splat_param_inference_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "rest parameter inference" do
       "    Notifier.new.mixed(User.new, \"text\")\n    Notifier.new.mixed(42)"
     )
 
-    expect(rbs).to include("def mixed: (*(User | String | Integer) things) ->")
+    expect(rbs).to include('def mixed: (*(User | "text" | 42) things) ->')
   end
 
   it "types the parameters before the splat by position, as before" do
@@ -57,7 +57,7 @@ RSpec.describe "rest parameter inference" do
       "    Notifier.new.deliver(\"hi\", \"a\", \"b\")"
     )
 
-    expect(rbs).to include("def deliver: (String subject, *String bodies) ->")
+    expect(rbs).to include('def deliver: ("hi" subject, *("a" | "b") bodies) ->')
   end
 
   # `?String?`, not `?String`: the `= nil` default is a call site nobody writes, and it
@@ -68,7 +68,7 @@ RSpec.describe "rest parameter inference" do
       "    Notifier.new.only_optional(\"a\", 1, 2)"
     )
 
-    expect(rbs).to include("def only_optional: (?String? first, *Integer rest) ->")
+    expect(rbs).to include('def only_optional: (?"a"? first, *(1 | 2) rest) ->')
   end
 
   # Keywords are matched by name, and the splat does not eat them: `mode:` still lands on
@@ -79,7 +79,7 @@ RSpec.describe "rest parameter inference" do
       "    Notifier.new.with_keyword(User.new, User.new, mode: \"fast\")"
     )
 
-    expect(rbs).to include("def with_keyword: (*User items, mode: String) ->")
+    expect(rbs).to include('def with_keyword: (*User items, mode: "fast") ->')
   end
 
   # An anonymous `*` has no name for the substitution to key on, so it keeps the bare form
@@ -113,7 +113,7 @@ RSpec.describe "rest parameter inference" do
       "caller.rb" => "class Caller\n  def go\n    Notifier.new(\"hi\", 1, 2)\n  end\nend\n"
     )
 
-    expect(rbs).to include("def initialize: (String subject, *Integer bodies) ->")
+    expect(rbs).to include('def initialize: ("hi" subject, *(1 | 2) bodies) ->')
   end
 
   # The intra-class path (`IntraClassCallAnalyzer`) maps by index against its own
@@ -154,7 +154,7 @@ RSpec.describe "rest parameter inference" do
       RUBY
     )
 
-    expect(rbs).to include("def internal: (*(String | Integer) things) ->")
+    expect(rbs).to include('def internal: (*("a" | 1) things) ->')
   end
 
   it "stays untyped when no call site says anything" do
@@ -194,7 +194,7 @@ RSpec.describe "rest parameter inference" do
         "    rest = [User.new]\n    Notifier.new.notify(\"head\", *rest)"
       )
 
-      expect(rbs).to include("def notify: (String first, untyped second) ->")
+      expect(rbs).to include('def notify: ("head" first, untyped second) ->')
     end
 
     it "leaves an intra-class call alone the same way" do

--- a/spec/lib/rbs_infer/inference/type_merger_spec.rb
+++ b/spec/lib/rbs_infer/inference/type_merger_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
         method_param_types: { "set_current_session" => { "session" => "Session" } }
       )
 
-      expect(member.signature).to end_with("-> { value: String, httponly: bool, same_site: Symbol }")
+      expect(member.signature).to end_with('-> { value: String, httponly: true, same_site: :lax }')
     end
 
     # The "does not corrupt a block-bearing signature..." spec below only
@@ -276,7 +276,7 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
 
       # The BLOCK's `-> untyped` has to survive; only the final return changes.
       expect(member.signature)
-        .to eq("write: (untyped session) ?{ (*untyped) -> untyped } -> { value: String, httponly: bool }")
+        .to eq('write: (untyped session) ?{ (*untyped) -> untyped } -> { value: String, httponly: true }')
     end
 
     it "does not corrupt a block-bearing signature when resolving the return type" do
@@ -298,7 +298,7 @@ RSpec.describe RbsInfer::Inference::TypeMerger do
       member = collector.members.find { |m| m.name == "wrapper" }
       # Signature should have block: "wrapper: () ?{ (*untyped) -> untyped } -> String"
       # The block's -> untyped should NOT be replaced
-      expect(member.signature).to include("?{ (*untyped) -> untyped } -> String")
+      expect(member.signature).to include('?{ (*untyped) -> untyped } -> "hello"')
       expect(member.signature).not_to include("-> untyped } -> String } -> String")
     end
   end

--- a/spec/lib/rbs_infer/signatures/method_type_resolver_spec.rb
+++ b/spec/lib/rbs_infer/signatures/method_type_resolver_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
 
     with_temp_files("my_app/entity.rb" => entity_src, "my_app/service.rb" => service_src) do |dir, paths|
       resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
-      expect(resolve(resolver, "MyApp::Entity", "nome")).to eq("String")
+      expect(resolve(resolver, "MyApp::Entity", "nome")).to eq('"test"')
     end
   end
 
@@ -171,7 +171,7 @@ RSpec.describe RbsInfer::Signatures::MethodTypeResolver do
     with_temp_files("my_app/entity.rb" => entity_src, "my_app/caller.rb" => caller_src) do |dir, paths|
       resolver = build_resolver(paths, constant_resolver: fake_constant_resolver)
       expect(resolve(resolver, "MyApp::Entity", "email")).to eq("Wrapper")
-      expect(resolver.resolve_init_param_types("MyApp::Entity")["email"]).to eq("String")
+      expect(resolver.resolve_init_param_types("MyApp::Entity")["email"]).to eq('"test@email.com"')
     end
   end
 

--- a/spec/lib/rbs_infer/signatures/overloading_marker_spec.rb
+++ b/spec/lib/rbs_infer/signatures/overloading_marker_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "the `# @rbs_infer |...` overloading marker" do
       end
     RUBY
 
-    expect(rbs).to include("def self.pid: () -> Integer | ...")
+    expect(rbs).to include("def self.pid: () -> 0 | ...")
   end
 
   # Confirmed against the member's OWNER. A def in a nested module belongs to
@@ -121,7 +121,7 @@ RSpec.describe "the `# @rbs_infer |...` overloading marker" do
       end
     RUBY
 
-    expect(rbs).to include("def self.getuid: () -> Integer | ...")
+    expect(rbs).to include("def self.getuid: () -> 0 | ...")
   end
 
   it "leaves an unmarked method alone even when the environment declares it" do

--- a/spec/lib/rbs_infer/signatures/steep_bridge/block_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/signatures/steep_bridge/block_analyzer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::BlockAnalyzer, :dummy_app do
       RUBY
 
       expect(bridge.forwarded_block_requirements(code)["named"])
-        .to eq(required: true, params: ["String"])
+        .to eq(required: true, params: ['"token"'])
     end
 
     # felixefelip/rbs_infer#174. The anonymous forward is the same statement
@@ -35,7 +35,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::BlockAnalyzer, :dummy_app do
       RUBY
 
       expect(bridge.forwarded_block_requirements(code)["anonymous"])
-        .to eq(required: true, params: ["String"])
+        .to eq(required: true, params: ['"token"'])
     end
 
     # `&:symbol` builds a proc on the spot; it is not this method's block, so it

--- a/spec/lib/rbs_infer/signatures/steep_bridge/return_type_analyzer_spec.rb
+++ b/spec/lib/rbs_infer/signatures/steep_bridge/return_type_analyzer_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe RbsInfer::Signatures::SteepBridge::ReturnTypeAnalyzer, :dummy_app
 
       result = bridge.method_return_types(code)
       ret = result["verify_multiples_returns_with_void_and_rescue"]
-      expect(ret).to match(/String\??/)
+      expect(ret).to match(/"error"\??/)
       expect(ret).not_to include("void")
     end
 


### PR DESCRIPTION
S3 of #345. S4 (per-call-site specialization) and S5 (fixpoint + widening) are deliberately not here — those are a new pass in Steep's `TypeConstruction`, and bundling them with 100 regenerated expectations would make neither reviewable.

## What changes

A literal is emitted wherever the program fixes the value — **returns, ivars, setters, and parameters inferred from call sites alike**, per the decision recorded on #345. All four consumers of `infer_literal_node_type` opt in.

```rbs
def name:   () -> "name"        # was String
def action: () -> "delete"      # was String
def show: ((:name | :age) which) -> (String | Integer | nil)
def extension_allowlist: () -> Array[("jpg" | "jpeg" | "gif" | "png" | "webp")]
```

The last two are the point: an enum that was `Symbol` now says which symbols.

**A default widens; a call site does not.** The distinction is not new — `optional_param_type` already made it for `nil` (*"a `nil` default says the parameter is OPTIONAL, not that its type is `nil`"*), and this is the same reading for every other literal. Without it a default of `80` typed `def gravatar_url: (?80 size)` and rejected every other size: 14 signatures in the dummy, all gone. Two paths needed it — positional defaults in `ExtractParamsSignature`, keyword defaults in `InitializeBodyAnalyzer`.

## Where the review effort belongs

248 files, of which **7 are `lib/`** (127 insertions). Everything else is generated RBS and expectations. The seven:

| file | what |
|---|---|
| `ast/node_type_inferrer.rb` | emit the literal; `widen_literal_node` for defaults |
| `inference/class_member_collector/extract_params_signature.rb` | positional default widens |
| `inference/initialize_body_analyzer.rb` | keyword default widens |
| `inference/class_member_collector.rb` | collect early returns (#347) |
| `signatures/rbs_parser_util.rb` | parenthesize a symbol before `?`; `widen_literal_type` |
| `signatures/method_type_resolver.rb` | resolve a method on a literal receiver |
| `signatures/rbs_definition_resolver.rb` | a literal argument satisfies its class in overload selection |

## Four bugs this surfaced, three of them older than it

Literal types did not create these. They were there, and widening hid them — which is the argument for the decision in miniature.

1. **A symbol literal swallowed the nilable marker.** `?` is legal in a symbol, so `:edit` + `?` is the *symbol* `:edit?`, not `:edit` or nil. `parenthesize_before_optional` only wrapped unions/intersections/procs, gated on `[|&^]`. `users_avatars_controller`'s `render` declared `?:edit?`, could not pass its own `render :edit`, and took twelve view ivars down with it. Only the bare symbol is affected — `"edit"?`, `1?`, `true?`, `:edit!?` all parse as intended.
2. **An early `return X if cond` was dropped** (#347). `infer_return_type` read the tail and nothing else, so `return false if post.published?` above a `true` tail inferred `-> true` while the body returns `bool`. Half the `return` was already read — `has_nil_return?` took its nilability. Now its type is too. Boundaries checked: a `return` in a block counts, in a lambda does not, in a nested `def` belongs to that method.
3. **A literal receiver resolved nothing.** `new.run.upcase` over `def run: () -> "abc"` gave `untyped` — `resolve` splits nilable, intersection and union receivers, and a literal is none of those.
4. **A literal argument matched no overload.** Overload selection compares type *names*: `"Integer" == "10"` is false, so no overload of `Integer#+` matched, the unfiltered list stayed, and `31 + 10` came out `BigDecimal` off an overload the bigdecimal stdlib adds. Worth recording how close it came to being blessed — the dummy's own RBS said `-> Integer`, and only the in-process snapshot disagreed.

#346 (a parameter's default *replaces* its call sites instead of joining them) is also from this work and stays open; the default-widening above makes it imprecision rather than breakage.

## Testing

- Full suite green.
- `steep check` on the dummy green against a refreshed baseline. The four baseline lines that moved are the same errors with a more specific type (`(::String | nil)` → `("John Doe" | "x" | nil)`), not new ones.
- Taken to a fixed point: the regeneration loop needs steep→rbs_infer alternated until stable, because the view generator reads the *narrowed* type from the sidecar rather than the declaration. Nine view errors mid-way were that lag, diagnosed by instrumenting `apply_method_entry_facts` against a worktree at the pre-S3 commit.
- The 84 hand-written assertions were moved one at a time, not by script: the same string has different right answers in the same file (`"nome: String"` appears 4× in `analyzer_spec`, two of which must stay `String`; `def initialize: (name: String)` is `"To Do"` in one block and `"Jo"` in another).

Three assertions came out stronger than they went in — `value_return_only: () -> (2 | 1)` was `-> Integer`, which passed both with the fix and with the bug it repaired.

## Reading the commits

The three `wip(literals)` commits are the measurement trail and their messages describe intermediate states that later commits resolved — `3034ffe` in particular says the change cannot land as it stands, which was true when written and is not now. The `Revert "chore(dummy)"` at the tip removes two files that only a test run rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Myw5xJLtv8mqZoXLqTvjeW
