### PR TITLE
test(literals): Example69 closes — the literal survives the second hop (S5 of #345)

### DIFF
--- a/spec/dummy/sig/generated/.steep_specializations.yml
+++ b/spec/dummy/sig/generated/.steep_specializations.yml
@@ -20,6 +20,9 @@ methods:
   Example69::Foo#call:
     "(flag_name: false)": '"delete"'
     "(flag_name: true)": '"name_delete"'
+  Example69::Foo#name_action_dynamic:
+    "(flag_name: false)": '"delete"'
+    "(flag_name: true)": '"name_delete"'
   Example7::Dispatcher#show:
     "(:age)": "::Integer"
     "(:name)": "::String"

--- a/spec/dummy/sig/rbs_infer/app/models/example69.rbs
+++ b/spec/dummy/sig/rbs_infer/app/models/example69.rbs
@@ -4,8 +4,8 @@ module Example69
     def action: () -> "delete"
     def call_name_action: () -> "name_delete"
     def call_action: () -> "delete"
-    def call_dynamic: () -> ("name_delete" | "delete")
-    def call_dynamic_with_name: () -> ("name_delete" | "delete")
+    def call_dynamic: () -> "name_delete"
+    def call_dynamic_with_name: () -> "delete"
     def call_both: () -> Array[("name_delete" | "delete")]
     def name_action_dynamic: (flag_name: bool) -> ("name_delete" | "delete")
     def call_unknown: (flag_name: untyped) -> ("name_delete" | "delete")

--- a/spec/expectations/models/example69.rbs
+++ b/spec/expectations/models/example69.rbs
@@ -4,8 +4,8 @@ module Example69
     def action: () -> "delete"
     def call_name_action: () -> "name_delete"
     def call_action: () -> "delete"
-    def call_dynamic: () -> ("name_delete" | "delete")
-    def call_dynamic_with_name: () -> ("name_delete" | "delete")
+    def call_dynamic: () -> "name_delete"
+    def call_dynamic_with_name: () -> "delete"
     def call_both: () -> Array[("name_delete" | "delete")]
     def name_action_dynamic: (flag_name: bool) -> ("name_delete" | "delete")
     def call_unknown: (flag_name: untyped) -> ("name_delete" | "delete")


### PR DESCRIPTION
Needs felixefelip/steep#167 (stage S5: the specialization passes iterated to a fixpoint). No rbs_infer code changes — the slice added in #349 takes the literal as soon as Steep answers with it, so this is the dummy catching up plus the snapshot.

## What changed

The sidecar gains one method, which is the whole of S5 as seen from here:

```yaml
 Example69::Foo#call:
   "(flag_name: false)": '"delete"'
   "(flag_name: true)": '"name_delete"'
+Example69::Foo#name_action_dynamic:
+  "(flag_name: false)": '"delete"'
+  "(flag_name: true)": '"name_delete"'
```

`name_action_dynamic` forwards its parameter to `call`, so it could only be specialized once `call` already was — a second generation. With it recorded, its callers read a single literal:

```rbs
def call_dynamic: () -> "name_delete"          # was ("name_delete" | "delete")
def call_dynamic_with_name: () -> "delete"     # was ("name_delete" | "delete")
```

## Example69 closes

Every line now states the literal written beside it in `spec/dummy/app/models/example69.rb`, which is what the fixture was written to pin:

```rbs
module Example69
  class Foo
    def name: () -> "name"
    def action: () -> "delete"
    def call_name_action: () -> "name_delete"
    def call_action: () -> "delete"
    def call_dynamic: () -> "name_delete"
    def call_dynamic_with_name: () -> "delete"
    def call_both: () -> Array[("name_delete" | "delete")]
    def name_action_dynamic: (flag_name: bool) -> ("name_delete" | "delete")
    def call_unknown: (flag_name: untyped) -> ("name_delete" | "delete")

    private

    def call: (?flag_name: bool) -> ("name_delete" | "delete")
  end
end
```

The two union lines are the fixture's own controls, not gaps: `name_action_dynamic` has call sites that disagree, and `call_unknown` has no caller at all, so a union is the honest answer for both and they are what catch an implementation that over-specializes a declaration from one call site.

## Verification

- suite green: **1645 examples, 0 failures**
- dummy reaches a fixed point in **two** `rbs_infer` → `steep check` cycles
- `steep check` holds its **49-diagnostic baseline**, messages unchanged (the baseline file has no diff)
- nothing else in `spec/dummy/sig` moves — the only RBS diff is `example69.rbs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfeSTBcB41WMGTP9db8kNd